### PR TITLE
Add rudimentary support for social media meta tags

### DIFF
--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -178,7 +178,7 @@
     <meta property="twitter:description" content="{{ abs_meta.abstract|trim|truncate(200, False, '...')|tex_to_utf }}"/>
     <meta property="og:site_name" content="arXiv.org"/>
     <meta property="og:title" content="{{ abs_meta.title|tex_to_utf }}"/>
-    <meta property="og:url" content="https://arxiv.org/{{ requested_id }}"/>
+    <meta property="og:url" content="{{ canonical_url(abs_meta.arxiv_id, abs_meta.version) }}"/>
     <meta property="og:description" content="{{ abs_meta.abstract|trim|tex_to_utf }}"/>
 {%- endmacro -%}
 

--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -173,10 +173,13 @@
 {%- endmacro -%}
 
 {%- macro generate_social_media_tags() -%}
-    <meta name="twitter:site" content="@arxiv">
-    <meta property="og:site_name" content="arXiv.org">
-    <meta property="og:title" content="{{ abs_meta.title|truncate(70, False, '...') }}">
-    <meta property="og:description" content="{{ abs_meta.abstract|trim|truncate(200, False, '...')|tex_to_utf }}">
+    <meta name="twitter:site" content="@arxiv"/>
+    <meta property="twitter:title" content="{{ abs_meta.title|tex_to_utf|truncate(70, False, '...') }}"/>
+    <meta property="twitter:description" content="{{ abs_meta.abstract|trim|truncate(200, False, '...')|tex_to_utf }}"/>
+    <meta property="og:site_name" content="arXiv.org"/>
+    <meta property="og:title" content="{{ abs_meta.title|tex_to_utf }}"/>
+    <meta property="og:url" content="https://arxiv.org/{{ requested_id }}"/>
+    <meta property="og:description" content="{{ abs_meta.abstract|trim|tex_to_utf }}"/>
 {%- endmacro -%}
 
 {%- macro category_line() -%}

--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -9,6 +9,7 @@
   {%- endif %}
   <script src="//static.arxiv.org/js/mathjaxToggle.min.js" type="text/javascript"></script>
   {{- generate_scholar_tags() }}
+  {{- generate_social_media_tags() }}
 {% endblock head %}
 
 {% block body_id %}{% endblock %}
@@ -169,6 +170,13 @@
   <meta name="{{tag.name}}" content="{{tag.content}}"/>
     {%- endfor -%}
 {%- endif -%}
+{%- endmacro -%}
+
+{%- macro generate_social_media_tags() -%}
+    <meta name="twitter:site" content="@arxiv">
+    <meta property="og:site_name" content="arXiv.org">
+    <meta property="og:title" content="{{ abs_meta.title|truncate(70, True, '...') }}">
+    <meta property="og:description" content="{{ abs_meta.abstract|trim|truncate(200, True, '...')|tex_to_utf }}">
 {%- endmacro -%}
 
 {%- macro category_line() -%}

--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -175,8 +175,8 @@
 {%- macro generate_social_media_tags() -%}
     <meta name="twitter:site" content="@arxiv">
     <meta property="og:site_name" content="arXiv.org">
-    <meta property="og:title" content="{{ abs_meta.title|truncate(70, True, '...') }}">
-    <meta property="og:description" content="{{ abs_meta.abstract|trim|truncate(200, True, '...')|tex_to_utf }}">
+    <meta property="og:title" content="{{ abs_meta.title|truncate(70, False, '...') }}">
+    <meta property="og:description" content="{{ abs_meta.abstract|trim|truncate(200, False, '...')|tex_to_utf }}">
 {%- endmacro -%}
 
 {%- macro category_line() -%}


### PR DESCRIPTION
We've learned from Steinn that ever since we modified the footer to include a11y information, the link previews (particularly those generated by FB) are sub-optimal. This PR is a first stab at including some of the social media meta tags per these [guidelines](https://css-tricks.com/essential-meta-tags-social-media/), which might help fix that display problem. Absent from this are the image tags that are technically required (but maybe, not really). 

I'm mainly putting this out there to continue the conversation, not necessarily to deploy something expediently (but that could be an option too).