### PR TITLE
Arxivng 1612 hotfix

### DIFF
--- a/browse/factory.py
+++ b/browse/factory.py
@@ -62,7 +62,7 @@ def create_web_app() -> Flask:
 
     app.jinja_env.filters['line_feed_to_br'] = line_feed_to_br
     app.jinja_env.filters['tex_to_utf'] = partial( tex_to_utf, symbols=True )
-    app.jinja_env.filters['txt_to_utf_no_symb'] = partial( tex_to_utf, symbols=False)
+    app.jinja_env.filters['tex_to_utf_no_symb'] = partial( tex_to_utf, symbols=False)
     
     app.jinja_env.filters['entity_to_utf'] = entity_to_utf
 

--- a/browse/factory.py
+++ b/browse/factory.py
@@ -61,7 +61,9 @@ def create_web_app() -> Flask:
         app.jinja_env.filters = {}
 
     app.jinja_env.filters['line_feed_to_br'] = line_feed_to_br
-    app.jinja_env.filters['tex_to_utf'] = tex_to_utf
+    app.jinja_env.filters['tex_to_utf'] = partial( tex_to_utf, symbols=True )
+    app.jinja_env.filters['txt_to_utf_no_symb'] = partial( tex_to_utf, symbols=False)
+    
     app.jinja_env.filters['entity_to_utf'] = entity_to_utf
 
     app.jinja_env.filters['clickthrough_url_for'] = ct_url_for

--- a/browse/factory.py
+++ b/browse/factory.py
@@ -61,8 +61,8 @@ def create_web_app() -> Flask:
         app.jinja_env.filters = {}
 
     app.jinja_env.filters['line_feed_to_br'] = line_feed_to_br
-    app.jinja_env.filters['tex_to_utf'] = partial( tex_to_utf, symbols=True )
-    app.jinja_env.filters['tex_to_utf_no_symb'] = partial( tex_to_utf, symbols=False)
+    app.jinja_env.filters['tex_to_utf'] = partial( tex_to_utf, letters=True )
+    app.jinja_env.filters['tex_to_utf_no_symb'] = partial( tex_to_utf, letters=False)
     
     app.jinja_env.filters['entity_to_utf'] = entity_to_utf
 

--- a/browse/filters.py
+++ b/browse/filters.py
@@ -80,10 +80,20 @@ def entity_to_utf(text: str) -> str:
     return Markup(with_lt_gt)
 
 
-def tex_to_utf(text: JinjaFilterInput) -> Markup:
-    """Wrap tex2utf as a filter."""
+def tex_to_utf(text: JinjaFilterInput, symbols: bool=True) -> Markup:
+    """
+    Convert some TeX accents and symbols to UTF-8 characters. 
+
+    :param text: Text to filter.
+
+    :param symbols: If False, do not convert greek symbols.  Greek
+    symbols can cause problems. Ex \phi is not suppose to look like φ. 
+    φ looks like \varphi to someone use to TeX.
+
+    :returns: Jinja Markup of filtered text
+    """
     if hasattr(text, '__html__'):
         # Need to unescape so nothing that is tex is escaped
-        return Markup(escape(tex2utf(text.unescape())))  # type: ignore
+        return Markup(escape(tex2utf(text.unescape(), symbols=symbols)))  # type: ignore
     else:
-        return Markup(escape(tex2utf(text)))
+        return Markup(escape(tex2utf(text, symbols=symbols)))

--- a/browse/filters.py
+++ b/browse/filters.py
@@ -80,20 +80,21 @@ def entity_to_utf(text: str) -> str:
     return Markup(with_lt_gt)
 
 
-def tex_to_utf(text: JinjaFilterInput, symbols: bool=True) -> Markup:
+def tex_to_utf(text: JinjaFilterInput, letters: bool=True) -> Markup:
     """
     Convert some TeX accents and symbols to UTF-8 characters. 
 
     :param text: Text to filter.
 
-    :param symbols: If False, do not convert greek symbols.  Greek
+    :param letters: If False, do not convert greek symbols.  Greek
     symbols can cause problems. Ex \phi is not suppose to look like φ. 
     φ looks like \varphi to someone use to TeX.
+    See ARXIVNG-1612
 
     :returns: Jinja Markup of filtered text
     """
     if hasattr(text, '__html__'):
         # Need to unescape so nothing that is tex is escaped
-        return Markup(escape(tex2utf(text.unescape(), symbols=symbols)))  # type: ignore
+        return Markup(escape(tex2utf(text.unescape(), letters=letters)))  # type: ignore
     else:
-        return Markup(escape(tex2utf(text, symbols=symbols)))
+        return Markup(escape(tex2utf(text, letters=letters)))

--- a/browse/services/util/tex2utf.py
+++ b/browse/services/util/tex2utf.py
@@ -85,8 +85,9 @@ textlet = {
     'nu': 0x03bd, 'xi': 0x03be, 'omicron': 0x03bf,
     'pi': 0x03c0, 'rho': 0x03c1, 'varsigma': 0x03c2,
     'sigma': 0x03c3, 'tau': 0x03c4, 'upsion': 0x03c5,
-    'phi': 0x03c6, 'chi': 0x03c7, 'psi': 0x03c8,
-    'omega': 0x03c9,
+    'varphi': 0x03C6, # φ
+    'phi':  0x03D5, # ϕ
+    'chi': 0x03c7, 'psi': 0x03c8, 'omega': 0x03c9,
 }
 
 
@@ -141,8 +142,18 @@ def texch2UTF(acc: str) -> str:
 # }
 #
 
-def tex2utf(tex: str) -> str:
-    """Converts some accents and greek TeX to utf8."""
+def tex2utf(tex: str, symbols: bool=True) -> str:
+    """
+    Convert some TeX accents and greek symbols to UTF-8 characters. 
+
+    :param tex: Text to filter.
+
+    :param symbols: If False, do not convert greek symbols.  Greek
+    symbols can cause problems. Ex \phi is not suppose to look like φ. 
+    φ looks like \varphi to someone use to TeX.
+
+    :returns: string possibly with some TeX replaced with UTF8
+    """
     # This is Legacy stuff and might not be needed if we move toward all utf8
 
     # Do dotless i,j -> plain i,j where they are part of an accented i or j
@@ -151,7 +162,8 @@ def tex2utf(tex: str) -> str:
 
     # Now work on the Tex sequences, first those with letters only match
     utf = textlet_pattern.sub(_textlet_sub, utf)
-    utf = textsym_pattern.sub(_textsym_sub, utf)
+    if symbols:
+        utf = textsym_pattern.sub(_textsym_sub, utf)
 
     utf = re.sub(r'\{\\j\}|\\j\s', 'j', utf)  # not in Unicode?
 

--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -64,7 +64,8 @@
 
     <div class="dateline">{{ generate_dateline() }}</div>
 
-    <blockquote class="abstract mathjax"><span class="descriptor">Abstract:</span>{{ abs_meta.abstract|tex_to_utf|arxiv_urlize|line_feed_to_br }}</blockquote>
+    {# Below must equlvelent to what is done in the submission preview so the abstract appears as the author saw it in the preview. #}
+    <blockquote class="abstract mathjax"><span class="descriptor">Abstract:</span>{{ abs_meta.abstract|tex_to_utf_no_symb|arxiv_urlize|line_feed_to_br }}</blockquote>
     <!--CONTEXT-->
     <div class="metatable">
       <table summary="Additional metadata">

--- a/tests/data/abs_files/ftp/arxiv/papers/1901/1901.05426.abs
+++ b/tests/data/abs_files/ftp/arxiv/papers/1901/1901.05426.abs
@@ -1,0 +1,29 @@
+------------------------------------------------------------------------------
+\\
+arXiv:1901.05426
+From: Yuri Barash <kslkjrlkx@lksjrkcka.ac.ru>
+Date: Wed, 16 Jan 2019 18:26:32 GMT   (274kb)
+
+Title: Phase relations in superconductor-normal metal-superconductor tunnel
+  junctions
+Authors: Yu. S. Barash
+Categories: cond-mat.supr-con cond-mat.mes-hall
+Comments: 11 pages, 4 figures
+License: http://arxiv.org/licenses/nonexclusive-distrib/1.0/
+\\
+  The phase difference $\phi$, between the superconducting terminals in
+superconductor-normal metal-superconductor tunnel junctions (SINIS),
+incorporates the phase differences~$\chi_{1,2}$~across~thin interfaces of
+constituent $SIN$ junctions and the phase incursion $\varphi$ between the side
+faces of the central electrode of length $L$. It is demonstrated here that
+$\chi_{1,2}$ pass through over their proximity-reduced domain twice, there and
+back, while $\phi$ changes over the single period. Two corresponding solutions,
+that describe the double-valued order-parameter dependence on $\chi_{1,2}$,
+jointly form the single-valued dependence on $\phi$, operating in two adjoining
+regions of $\phi$. The phase incursion $\varphi$ plays a crucial role in
+creating such a behavior.
+
+  The current-phase relation $j(\phi,L)$ is composed of
+the two solutions and, at a fixed small $L$, is characterized by the
+phase-dependent effective transmission coefficient.
+\\

--- a/tests/data/abs_files/ftp/arxiv/papers/1901/1901.05426.abs
+++ b/tests/data/abs_files/ftp/arxiv/papers/1901/1901.05426.abs
@@ -21,9 +21,7 @@ back, while $\phi$ changes over the single period. Two corresponding solutions,
 that describe the double-valued order-parameter dependence on $\chi_{1,2}$,
 jointly form the single-valued dependence on $\phi$, operating in two adjoining
 regions of $\phi$. The phase incursion $\varphi$ plays a crucial role in
-creating such a behavior.
-
-  The current-phase relation $j(\phi,L)$ is composed of
+creating such a behavior. The current-phase relation $j(\phi,L)$ is composed of
 the two solutions and, at a fixed small $L$, is characterized by the
 phase-dependent effective transmission coefficient.
 \\

--- a/tests/test_abs_parser.py
+++ b/tests/test_abs_parser.py
@@ -132,3 +132,11 @@ ferromagnet superconducting domains is discussed.
         self.assertTrue(m.primary_category)
         self.assertTrue(m.primary_category.canonical,
                         'subsumed category adap-org should have a canonical')
+
+    def test_psi_in_abs(self):
+        """Test text in abs ARXIVNG-1612"""
+        f1 = ABS_FILES + '/ftp/arxiv/papers/1901/1901.05426.abs'
+        m = AbsMetaSession.parse_abs_file(filename=f1)
+        self.assertIsInstance(m, DocMetadata)
+        self.assertNotIn('$φ$', m.abstract,
+                         'TeX psi in abstract should not get converted to UTF8')

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -296,3 +296,22 @@ class BrowseTest(unittest.TestCase):
         self.assertTrue(auths_elmt, 'Should authors div element')
         self.assertNotIn(' ,', auths_elmt.text,
                          'Should not add extra spaces before commas')
+
+    def test_psi_in_abs(self):
+        # see https://arxiv-org.atlassian.net/browse/ARXIVNG-1612
+        # "phi being displayed as varphi in abstract on /abs page"
+        # phi being displayed incorrectly in abstract on /abs page
+        rv = self.app.get('/abs/1901.05426')
+        self.assertEqual(rv.status_code, 200)
+        html = BeautifulSoup(rv.data.decode('utf-8'), 'html.parser')
+        abs_elmt = html.find('blockquote', 'abstract')
+        self.assertTrue(abs_elmt, 'Should have abstract div element')
+        self.assertNotIn('$ φ$', abs_elmt.text,
+                         'TeX psi in abstract should not get converted to UTF8')
+        self.assertNotIn('$j(φ,L)$', abs_elmt.text,
+                         'TeX psi in abstract should not get converted to UTF8')
+        self.assertIn('The phase difference $\phi$, between the superconducting',
+                      abs_elmt.text,
+                      "Expecting uncoverted $\phi$ in html abstract.")
+        
+

--- a/tests/test_tex2utf.py
+++ b/tests/test_tex2utf.py
@@ -11,6 +11,9 @@ class TextTex2Utf(TestCase):
         utf_out = tex2utf(test_str)
         self.assertEqual(utf_out, test_str)
 
+        utf_out = tex2utf(test_str, letters=False)
+        self.assertEqual(utf_out, test_str)
+        
         test_str = "\\'e"
         utf_out = tex2utf(test_str)
         self.assertEqual(utf_out, chr(0xe9))
@@ -20,6 +23,20 @@ class TextTex2Utf(TestCase):
         utf_out = tex2utf(test_str)
         self.assertEqual(utf_out, chr(
             0xc9))
+
+        test_str = "\\'E"
+        utf_out = tex2utf(test_str,letters=True)
+        self.assertEqual(utf_out, chr(
+            0xc9))
+
+        test_str = "\\'E"
+        utf_out = tex2utf(test_str,letters=False)
+        self.assertEqual(utf_out, chr(0xc9))
+                         
+
+        test_str = "\\'E"
+        utf_out = tex2utf(test_str,False)
+        self.assertEqual(utf_out, chr(0xc9))
 
         # single textsymbol
         test_str = '\\OE'
@@ -54,6 +71,15 @@ class TextTex2Utf(TestCase):
         self.assertEqual(utf_out, chr(
             0x03b1))
 
+        test_str = '\\alpha'
+        utf_out = tex2utf(test_str,True)
+        self.assertEqual(utf_out, chr(
+            0x03b1))
+
+        test_str = '\\alpha'
+        utf_out = tex2utf(test_str,False)
+        self.assertEqual(utf_out, r'\alpha')
+        
         # simple test_string of greek
         test_str = '\\alpha\\beta\gamma'
         utf_out = tex2utf(test_str)


### PR DESCRIPTION
The core of this problem is that in arxiv-browse, the abs template is using tex_2_utf on the abstract. This is converting TeX like /psi to the unicode φ. This is bad because φ doesn't look like a TeX /psi. 

This PR is step 1 and step 2 of plan B:
Step 1 In NG arxiv-browse have a new filter tex_2_utf_no_symbols
Step 2: In NG arxiv-browse, use that new filter on abstract only 

The changes to the legacy submission display are in the works.

The classic system does not do tex_2_utf, only normal HTML escaping: 
https://github.com/arXiv/arxiv-lib/blob/64ae85ad9168713198fc682ab3882cc5a3f02a21/lib/arXiv/HTML/Abstract.pm#L904 
