### PR TITLE
ARXIVNG-1797 adjust margins to fix misalignment of feedback sentence

### DIFF
--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -87,16 +87,17 @@
       {{ generate_version_entry(version_entry, abs_meta.version) }}
       {%- endfor -%}
     </div>
+  </div>
+  <!--end leftcolumn-->
     <div class="endorsers"><a href="{{ url_for('.show_endorsers',arxiv_id=abs_meta.arxiv_id) }}">Which authors of this paper are endorsers?</a> | <a id="mathjax_toggle" href="javascript:setMathjaxCookie()">Disable MathJax</a> (<a href="{{ url_for('help_mathjax') }}">What is MathJax?</a>)
-      <span class="help" style="display: inline-block; font-style: normal; float: right"><a href="https://confluence.cornell.edu/x/MjmLFQ">Browse v0.1 released 2018-10-22</a>&nbsp;&nbsp;<button class="button is-small" id="feedback-button">Feedback?</button></span>
+      <span class="help" style="display: inline-block; font-style: normal; float: right; margin-top: 0; margin-right: 1em;"><a href="https://confluence.cornell.edu/x/MjmLFQ">Browse v0.1 released 2018-10-22</a>&nbsp;&nbsp;<button class="button is-small" id="feedback-button">Feedback?</button></span>
     </div>
     <script type="text/javascript" language="javascript">mathjaxToggle();</script>
     {#- The following supports the arXiv Labs Bibliographic Explorer project: https://labs.arxiv.org/projects/bibexplorer -#}
     {% if config['LABS_BIBEXPLORER_ENABLED'] %}
     <script src="/bibex/bibex.js?20181010" type="text/javascript" defer></script>
     {% endif %}
-  </div>
-  <!--end leftcolumn-->
+
 </div>
 {% endblock content %}
 {%- block footer_text -%}

--- a/browse/templates/short_trailer.html
+++ b/browse/templates/short_trailer.html
@@ -2,5 +2,5 @@
   Link back to: <a href="{{ url_for('home') }}">arXiv</a>,
   <a href="{{ url_for('browse.form') }}">form interface</a>,
   <a href="{{ url_for('contact') }}">contact</a>.&nbsp;&nbsp;
-  <span class="help" style="display: inline-block; float: right"><a href="https://confluence.cornell.edu/x/MjmLFQ">Browse v0.1 released 2018-10-22</a>&nbsp;&nbsp;<button class="button is-small" id="feedback-button">Feedback?</button></span>
+  <span class="help" style="display: inline-block; float: right; margin-top: 0;"><a href="https://confluence.cornell.edu/x/MjmLFQ">Browse v0.1 released 2018-10-22</a>&nbsp;&nbsp;<button class="button is-small" id="feedback-button">Feedback?</button></span>
 </p>


### PR DESCRIPTION
This fix does two things:
1) moves the lowest line out of the "left column" div so that it expands to full width
![screen shot 2019-02-21 at 9 45 20 am](https://user-images.githubusercontent.com/17456668/53177180-8f40f200-35bd-11e9-9de7-fdc6448a4d1e.png)

2) adjusts margin so that the two lines are aligned vertically.
![screen shot 2019-02-21 at 9 45 33 am](https://user-images.githubusercontent.com/17456668/53177218-9cf67780-35bd-11e9-9fec-2342a911dac5.png)

Note that at very small widths the two lines are pinned to either side of the screen, this is expected behavior (see screenshot).
![screen shot 2019-02-21 at 9 45 41 am](https://user-images.githubusercontent.com/17456668/53177266-b5ff2880-35bd-11e9-84ce-efd24c85c8e6.png)
