### PR TITLE
Workaround for ARXIVNG-2063

### DIFF
--- a/browse/config.py
+++ b/browse/config.py
@@ -321,3 +321,9 @@ SESSION_DURATION = os.environ.get(
     'SESSION_DURATION',
     '36000'
 )
+
+URLS = [
+    ('ui.login', '/login', BROWSE_SITE_HOST or 'arxiv.org')
+    # This is a temporary workaround for ARXIVNG-2063
+]
+"""External URLs."""

--- a/browse/config.py
+++ b/browse/config.py
@@ -323,7 +323,7 @@ SESSION_DURATION = os.environ.get(
 )
 
 URLS = [
-    ('ui.login', '/login', BROWSE_SITE_HOST or 'arxiv.org')
+    ('ui.login', '/login', os.environ.get('SERVER_NAME', 'arxiv.org'))
     # This is a temporary workaround for ARXIVNG-2063
 ]
 """External URLs."""


### PR DESCRIPTION
This is just a temporary workaround for ARXIVNG-2063 and the case where a missing route in the URL map would cause an exception to get raised in the duplicate tapir_session cookie scenario.