### PR TITLE
ARXIVNG-2098: allow trailing slash in /archive/<archive_id/

### DIFF
--- a/browse/routes/ui.py
+++ b/browse/routes/ui.py
@@ -310,7 +310,7 @@ def form(arxiv_id: str) -> Response:
 
 
 @blueprint.route('archive/', defaults={'archive': None})
-@blueprint.route('archive/<archive>')
+@blueprint.route('archive/<archive>', strict_slashes=False)
 def archive(archive: str):  # type: ignore
     """Landing page for an archive."""
     response, code, headers = archive_page.get_archive(archive)  # type: ignore

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -14,6 +14,10 @@ class BrowseTest(unittest.TestCase):
         self.assertEqual(rv.status_code, 200)
         self.assertIn('Expires', rv.headers, 'Should have expires header')
 
+        rv = self.app.get("/archive/astro-ph/")
+        self.assertEqual(rv.status_code, 200,
+                         'Trailing slash should be allowed')
+
         src = rv.data.decode("utf-8")
         self.assertIn("Astrophysics", src)
         self.assertIn("/year/astro-ph/92", src)
@@ -66,6 +70,3 @@ class BrowseTest(unittest.TestCase):
 
         self.assertIn("High Energy Physics", src)
         self.assertNotIn("Categories within", src)
-
-
-


### PR DESCRIPTION
e.g. `/archive/astro-ph/`.