### PR TITLE
Fixes an author list display bug

### DIFF
--- a/browse/services/search/search_authors.py
+++ b/browse/services/search/search_authors.py
@@ -49,7 +49,7 @@ def split_long_author_list(
     count = 0
     back_count = 0
     for item in authors:
-        if count > size:
+        if count >= size:
             back.append(item)
             if isinstance(item, tuple):
                 back_count = back_count + 1
@@ -57,6 +57,14 @@ def split_long_author_list(
             front.append(item)
             if isinstance(item, tuple):
                 count = count + 1
+
+    # handle case where back doesn't have much ARXIVNG-2083
+    authors_in_back = len(list(filter(lambda x: isinstance(x, tuple), back)))
+    if authors_in_back < 2:
+        front = front + back
+        back = []
+        back_count = 0
+
     return front, back, back_count
 
 

--- a/tests/data/abs_files/ftp/arxiv/papers/1902/1902.05884.abs
+++ b/tests/data/abs_files/ftp/arxiv/papers/1902/1902.05884.abs
@@ -1,0 +1,46 @@
+------------------------------------------------------------------------------
+\\
+arXiv:1902.05884
+From: Alberto Correa dos Reis <user@example.org>
+Date: Fri, 15 Feb 2019 16:48:58 GMT   (980kb,D)
+
+Title: Dalitz plot analysis of the $D^+\to K^-K^+K^+$ decay
+Authors: LHCb Collaboration: R. Aaij, B. Adeva, M. Adinolfi, Z. Ajaltouni, S.
+  Akar, J. Albrecht, F. Alessio, M. Alexander, A. Alfonso Albero, S. Ali, G.
+  Alkhazov, P. Alvarez Cartelle, A.A. Alves Jr, S. Amato, S. Amerio, Y. Amhis,
+  L. An, L. Anderlini, G. Andreassi, M. Andreotti, J.E. Andrews, R.B. Appleby,
+  F. Archilli, J. Arnau Romeu, A. Artamonov, M. Artuso, E. Aslanides, M.
+  Atzeni, G. Auriemma, M. Baalouch, I. Babuschkin, S. Bachmann, J.J. Back, A.
+  Badalov, C. Baesso, S. Baker, V. Balagura, W. Baldini, A. Baranov, R.J.
+  Barlow, C. Barschel, S. Barsuk, W. Barter, F. Baryshnikov, V. Batozskaya, V.
+  Battista, A. Bay, L. Beaucourt, J. Beddow, F. Bedeschi, I. Bediaga, A.
+  Beiter, L.J. Bel, N. Beliy, V. Bellee, N. Belloli, K. Belous, I. Belyaev, G.
+  Bencivenni, E. Ben-Haim, S. Benson, S. Beranek, A. Berezhnoy, R. Bernet, D.
+  Berninghoff, E. Bertholet, A. Bertolin, C. Betancourt, F. Betti, M.O.
+  Bettler, Ia. Bezshyiko, S. Bifani, P. Billoir, A. Birnkraut, A. Bizzeti, M.
+  Bj{\o}rn, T. Blake, F. Blanc, S. Blusk, V. Bocci, T. Boettcher, A. Bondar, N.
+  Bondar, I. Bordyuzhin, S. Borghi, M. Borisyak, M. Borsato, F. Bossu, M.
+  Boubdir, T.J.V. Bowcock, E. Bowen, C. Bozzi, S. Braun, J. Brodzicka, D.
+  Brundu, E. Buchanan, C. Burr, A. Bursche, J. Buytaert, W. Byczynski, (750
+  additional authors not shown)
+Categories: hep-ex
+Comments: 37 pages, 14 figures. All figures and tables, along with any
+  supplementary material and additional information, are available at
+  https://cern.ch/lhcbproject/Publications/p/LHCb-PAPER-2018-039.html
+Report-no: LHCb-PAPER-2018-039, CERN-EP-2018-336
+Journal-ref: Journal of High Energy Physics 04 (2019) 063
+DOI: 10.1007/JHEP04(2019)063
+License: http://creativecommons.org/licenses/by/4.0/
+\\
+  The resonant structure of the doubly Cabibbo-suppressed decay $D^+ \to
+K^-K^+K^+$ is studied for the first time. The measurement is based on a sample
+of pp-collision data, collected at a centre-of-mass energy of 8 TeV with the
+LHCb detector and corresponding to an integrated luminosity of 2 fb$^-1$. The
+amplitude analysis of this decay is performed with the isobar model and a
+phenomenological model based on an effective chiral Lagrangian. In both models
+the S-wave component in the $K^-K^+$ system is dominant, with a small
+contribution of the $\phi(1020)$ meson and a negligible contribution from
+tensor resonances. The $K^-K^+$ scattering amplitudes for the considered
+combinations of spin (0,1) and isospin (0,1) of the two-body system are
+obtained from the Dalitz plot fit with the phenomenological decay amplitude.
+\\

--- a/tests/legacy_comparison/html_comparisons.py
+++ b/tests/legacy_comparison/html_comparisons.py
@@ -60,6 +60,7 @@ def _element_similarity(name: str,
                         min_sim: float,
                         required: bool,
                         check_counts: bool,
+                        text_trans: Callable[[str],str],
                         html_arg: html_arg_dict) -> BadResult:
     """ Uses get_element to select an element of the BS doc on both NG and Legacy do a similarity. 
 
@@ -98,8 +99,8 @@ def _element_similarity(name: str,
     legacy_ele_txt = ''
 
     if len(ng) > 0 and len(legacy) > 0:
-        ng_ele_txt = ng[0].prettify()
-        legacy_ele_txt = legacy[0].prettify()
+        ng_ele_txt = text_trans(ng[0].prettify())
+        legacy_ele_txt = text_trans(legacy[0].prettify())
         sim = lev_similarity(ng_ele_txt, legacy_ele_txt)
 
         if sim < min_sim:
@@ -140,33 +141,46 @@ def _strip_script_and_noscript( eles: List[BeautifulSoup]):
     return eles
 
 
+def ident(x):
+    return x
+
 author_similarity = partial(
     _element_similarity, 'authors div',
     lambda bs: _strip_href(_strip_script_and_noscript(bs.select('.authors'))),
-    0.9, True, True)
+    0.9, True, True, ident)
 
 
 dateline_similarity = partial(
-    _element_similarity, 'dateline div', lambda bs: _strip_href(bs.select('.dateline')), 0.8, True, True)
+    _element_similarity, 'dateline div', lambda bs: _strip_href(bs.select('.dateline')), 0.8, True, True, ident)
+
+
+
+def normalize_history(sin):
+    return sin\
+        .replace('GMT', '[normalized_gmt_utc]').replace('UTC', '[normalized_gmt_utc]')\
+        .replace(' KB)', ' [normalized_kb])').replace('kb)', ' [normalized_kb])')
 
 
 history_similarity = partial(
-    _element_similarity, 'submission-history div', lambda bs: _strip_href(bs.select('.submission-history')), 0.9, True, True)
+    _element_similarity, 'submission-history div',
+    lambda bs: _strip_href(bs.select('.submission-history')),
+    0.9, True, True,
+    normalize_history)
 
 
 title_similarity = partial(
-    _element_similarity, 'title div', lambda bs: bs.select('.title'), 0.9, True, True)
+    _element_similarity, 'title div', lambda bs: bs.select('.title'), 0.9, True, True, ident)
 
 
 subject_similarity = partial(
-    _element_similarity, 'subjects td', lambda bs: bs.select('.subjects'), 0.98, True, True)
+    _element_similarity, 'subjects td', lambda bs: bs.select('.subjects'), 0.98, True, True, ident)
 
 
 comments_similarity = partial(
-    _element_similarity, 'comments td', lambda bs: bs.select('.comments'), 0.9, False, True)
+    _element_similarity, 'comments td', lambda bs: bs.select('.comments'), 0.9, False, True, ident)
 
 head_similarity = partial(
-    _element_similarity, 'head element', lambda bs: _strip_href(bs.select('head')), 0.80, True, True)
+    _element_similarity, 'head element', lambda bs: _strip_href(bs.select('head')), 0.80, True, True, ident)
 
 ############ div.extra-services Checks #################
 
@@ -176,57 +190,57 @@ def ex_strip(eles: List[BeautifulSoup]):
 
 extra_full_text_similarity = partial(_element_similarity, 'extra full-text div',
                                      lambda bs: ex_strip(bs.select('div.full-text')),
-                                     0.9,True,True)
+                                     0.9,True,True, ident)
 
 ancillary_similarity = partial(_element_similarity, 'extra ancillary div',
                                lambda bs: ex_strip(bs.select('div.ancillary')),
-                               0.9, False, True)
+                               0.9, False, True, ident)
 
 extra_ref_cite_similarity = partial(_element_similarity, 'extra ref_cite div',
                                     lambda bs: ex_strip(bs.select('div.extra-ref-cite')),
-                                    0.9, False, True)
+                                    0.9, False, True, ident)
 
 extra_general_similarity = partial(_element_similarity, 'extra extra-general div',
                                    lambda bs: ex_strip(bs.select('div.extra-general')),
-                                   0.9, False, True)
+                                   0.9, False, True, ident)
 
 extra_browse_similarity = partial(_element_similarity, 'extra browse div',
                                   lambda bs: ex_strip(bs.select('div.browse')),
-                                  0.9, True, True)
+                                  0.9, True, True, ident)
 
 dblp_similarity = partial(_element_similarity, 'extra DBLP div',
                           lambda bs: ex_strip(bs.select('.dblp')),
-                          0.9, False, True)
+                          0.9, False, True, ident)
 
 bookmarks_similarity = partial(_element_similarity, 'extra bookmarks div',
                                lambda bs: ex_strip(bs.select('.bookmarks')),
-                               0.9, False, True)
+                               0.9, False, True, ident)
 
 ################# /archive checks ################################
 
 archive_h1_similarity = partial(_element_similarity, 'top heading',
                                lambda bs: ex_strip(bs.select('#content > h1')),
-                               0.99, True, True)
+                                0.99, True, True, ident)
 
 archive_browse = partial(_element_similarity, 'browse',
                                lambda bs: ex_strip(bs.select('#content > ul > li:nth-child(1)')),
-                               0.99, True, True)
+                               0.99, True, True, ident)
 
 archive_catchup = partial(_element_similarity, 'archive catchup',
                                lambda bs: ex_strip(bs.select('#content > ul > li:nth-child(2)')),
-                               0.99, True, True)
+                               0.99, True, True, ident)
 
 archive_search= partial(_element_similarity, 'archive_search',
                                lambda bs: ex_strip(bs.select('#content > ul > li:nth-child(3)')),
-                               0.99, True, True)
+                               0.99, True, True, ident)
 
 archive_by_year= partial(_element_similarity, 'archive_by_year',
                                lambda bs: ex_strip(bs.select('#content > ul > li:nth-child(4)')),
-                               0.99, True, True)
+                               0.99, True, True, ident)
 
 
 archive_bogus= partial(_element_similarity, 'bogus_should_fail',
                                lambda bs: ex_strip(bs.select('.bogusClass')),
-                               0.99, True, True)
+                               0.99, True, True, ident)
 
 

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -92,7 +92,8 @@ class BrowseTest(unittest.TestCase):
         self.assertEqual(rv.status_code, 200)
         html = BeautifulSoup(rv.data.decode('utf-8'), 'html.parser')
 
-        csv_dl_elmt = html.find('a', {'href': '/stats/get_hourly?date=20190102'})
+        csv_dl_elmt = html.find(
+            'a', {'href': '/stats/get_hourly?date=20190102'})
         self.assertIsNotNone(csv_dl_elmt,
                              'csv download link exists')
 
@@ -112,10 +113,10 @@ class BrowseTest(unittest.TestCase):
         self.assertEqual(rv.status_code, 200)
         html = BeautifulSoup(rv.data.decode('utf-8'), 'html.parser')
 
-        csv_dl_elmt = html.find('a', {'href': '/stats/get_monthly_submissions'})
+        csv_dl_elmt = html.find(
+            'a', {'href': '/stats/get_monthly_submissions'})
         self.assertIsNotNone(csv_dl_elmt,
                              'csv download link exists')
-
 
     def test_abs_without_license_field(self):
         f1 = ABS_FILES + '/ftp/arxiv/papers/0704/0704.0001.abs'
@@ -421,28 +422,34 @@ class BrowseTest(unittest.TestCase):
         self.assertEqual(rv.status_code, 200)
 
         rv = self.app.get('/year/astro-ph/')
-        self.assertEqual( rv.status_code, 200)
+        self.assertEqual(rv.status_code, 200)
 
         rv = self.app.get('/year/astro-ph')
-        self.assertEqual( rv.status_code, 200)
+        self.assertEqual(rv.status_code, 200)
 
         rv = self.app.get('/year/astro-ph/09/')
         self.assertEqual(rv.status_code, 200)
 
         rv = self.app.get('/year')
-        self.assertEqual( rv.status_code, 404)
+        self.assertEqual(rv.status_code, 404)
 
         rv = self.app.get('/year/astro-ph/9999')
-        self.assertEqual(rv.status_code, 307, 'Future year should cause temporary redirect')
+        self.assertEqual(rv.status_code, 307,
+                         'Future year should cause temporary redirect')
 
         rv = self.app.get('/year/fakearchive/01')
         self.assertNotEqual(rv.status_code, 200)
-        self.assertLess( rv.status_code, 500, 'should not cause a 5XX')
+        self.assertLess(rv.status_code, 500, 'should not cause a 5XX')
 
         rv = self.app.get('/year/002/0000')
-        self.assertLess( rv.status_code, 500, 'should not cause a 5XX')
+        self.assertLess(rv.status_code, 500, 'should not cause a 5XX')
 
         rv = self.app.get('/year/astro-py/9223372036854775808')
-        self.assertLess( rv.status_code, 500, 'should not cause a 5XX')
+        self.assertLess(rv.status_code, 500, 'should not cause a 5XX')
 
-        
+    def test_secondary_order(self):
+        rv = self.app.get('/abs/0906.3421')
+        self.assertIn(
+            'Statistical Mechanics (cond-mat.stat-mech); Mathematical Physics (math-ph)',
+            rv.data.decode('utf-8'),
+            'Secondary categories should be orderd by category id ARXIVNG-2066')

--- a/tests/test_search_authors.py
+++ b/tests/test_search_authors.py
@@ -47,9 +47,11 @@ class TestAuthorLinkCreation(TestCase):
             out, [('C. de la Fuente Marcos', 'de la Fuente Marcos, C')])
 
     def test_split_long_author_list(self):
-        f1 = path_of_for_test('data/abs_files/ftp/arxiv/papers/1411/1411.4413.abs')
+        f1 = path_of_for_test(
+            'data/abs_files/ftp/arxiv/papers/1411/1411.4413.abs')
         meta: metadata = AbsMetaSession.parse_abs_file(filename=f1)
-        alst = split_long_author_list(queries_for_authors(str(meta.authors)), 20)
+        alst = split_long_author_list(
+            queries_for_authors(str(meta.authors)), 20)
         self.assertIs(type(alst), tuple)
         self.assertIs(len(alst), 3)
         self.assertIs(type(alst[0]), list)
@@ -58,12 +60,38 @@ class TestAuthorLinkCreation(TestCase):
         self.assertIs(type(alst[2]), int)
 
     def test_split_with_collaboration(self):
-        f1 = path_of_for_test('data/abs_files/ftp/arxiv/papers/0808/0808.4142.abs')
+        f1 = path_of_for_test(
+            'data/abs_files/ftp/arxiv/papers/0808/0808.4142.abs')
         meta: metadata = AbsMetaSession.parse_abs_file(filename=f1)
 
         split = split_authors(str(meta.authors))
-        self.assertListEqual(split, ['D0 Collaboration', ':', 'V. Abazov', ',', 'et al'])
+        self.assertListEqual(
+            split, ['D0 Collaboration', ':', 'V. Abazov', ',', 'et al'])
 
         alst = queries_for_authors(str(meta.authors))
         self.assertListEqual(alst, [('D0 Collaboration', 'D0 Collaboration'),
                                     ': ', ('V. Abazov', 'Abazov, V'), ', ', 'et al'])
+
+    def test_split_strange_author_list(self):
+        """Test odd author list that shows '0 additional authors' ARXIVNG-2083"""
+        f1 = path_of_for_test(
+            'data/abs_files/ftp/arxiv/papers/1902/1902.05884.abs')
+        meta: metadata = AbsMetaSession.parse_abs_file(filename=f1)
+        alst = split_long_author_list(
+            queries_for_authors(str(meta.authors)), 100)
+
+        self.assertIs(type(alst), tuple)
+        self.assertIs(len(alst), 3)
+
+        self.assertIs(type(alst[0]), list)
+        self.assertIs(type(alst[1]), list)
+        self.assertIs(type(alst[2]), int)
+
+        self.assertEqual(
+            len(list(filter(lambda x: isinstance(x, tuple), alst[0]))),
+            101)
+
+        self.assertEqual(
+            len(alst[1]), 0, "Back list on 1902.05884 should be empty")
+        self.assertEqual(
+            alst[2], 0, "Back list size on 1902.05884 should be empty")


### PR DESCRIPTION
/abs/1902.05884  should not have odd '0 additional authors' text.
This PR fixes that. 
Also fixes off by one bug in split_long_author_list()
Adds some changes to legacy comparison tests.

ARXIVNG-2085