### PR TITLE
ARXIVNG-1985: proxy field in Submission history should (mostly) show full text

### DIFF
--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -53,7 +53,7 @@
       <h2>Submission history</h2> From: {{ abs_meta.submitter.name|tex2utf if abs_meta.submitter.name != None }} [<a href="/show-email/{{ abs_meta.arxiv_id|show_email_hash }}/{{ abs_meta.arxiv_id }}">view email</a>]
       {#- Extra message for proxy sites (i.e. Proxy line has username and id) -#}
       {#- TODO: revisit this. Logic for display follows classic but is strange; sometimes a proxy is just a person's name. -#}
-      {% if abs_meta.proxy != None %}&nbsp;[via {% if abs_meta.proxy|wordcount == 1 or abs_meta.proxy.startswith('ccsd') %}{{ abs_meta.proxy.split()[0]|tex2utf|upper }} proxy{% else %}{{ abs_meta.proxy|tex2utf }} as proxy{% endif %}]{% endif %}
+      {% if abs_meta.proxy != None %}&nbsp;[via {% if abs_meta.proxy|wordcount == 1 or abs_meta.proxy.startswith('ccsd') %}{{ abs_meta.proxy.split()[0]|upper }} proxy{% else %}{{ abs_meta.proxy|tex2utf }} as proxy{% endif %}]{% endif %}
       <br/>
       {%- for version_entry in abs_meta.version_history -%}
       {{ generate_version_entry(version_entry, abs_meta.version) }}

--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -53,7 +53,7 @@
       <h2>Submission history</h2> From: {{ abs_meta.submitter.name|tex2utf if abs_meta.submitter.name != None }} [<a href="/show-email/{{ abs_meta.arxiv_id|show_email_hash }}/{{ abs_meta.arxiv_id }}">view email</a>]
       {#- Extra message for proxy sites (i.e. Proxy line has username and id) -#}
       {#- TODO: revisit this. Logic for display follows classic but is strange; sometimes a proxy is just a person's name. -#}
-      {% if abs_meta.proxy != None and abs_meta.proxy|wordcount > 1 %}&nbsp;[via {{ abs_meta.proxy.split()[0]|tex2utf|upper }} proxy]{% endif %}
+      {% if abs_meta.proxy != None %}&nbsp;[via {% if abs_meta.proxy|wordcount == 1 or abs_meta.proxy.startswith('ccsd') %}{{ abs_meta.proxy.split()[0]|tex2utf|upper }} proxy{% else %}{{ abs_meta.proxy|tex2utf }} as proxy{% endif %}]{% endif %}
       <br/>
       {%- for version_entry in abs_meta.version_history -%}
       {{ generate_version_entry(version_entry, abs_meta.version) }}

--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -1,5 +1,5 @@
 {#- News blurbs appear at the top of the home page. Generally there should be no more than four items. -#}
-14 Jun 2019: <strong>Attention Users</strong>: there will be intermittent service disruptions on Sunday, June 16 due to <a href="https://it.cornell.edu/news/cit-data-center-router-upgrade-impacting-service-june-16-2019/20190607">network maintenance</a><br/>
-12 Jun 2019: <a href="http://bit.ly/arXivExecutiveDirector3">We are hiring: Executive Director of arXiv</a><br/>
-11 Jun 2019: <a href="https://arxiv.org/new/#june11_2019">Announcing a new category and category mergers</a><br/>
-20 May 2019: <a href="http://bit.ly/arXivEngineer4">We are hiring: arXiv Service Reliability Engineer</a><br/>
+18 Jun 2019: <strong>Attention Users</strong>: at 8AM ET / 12PM UTC on Friday, June 21, the submission system will be unavailable for approximately 30 minutes for routine maintenance.<br/>
+12 Jun 2019: <a href="http://bit.ly/arXivExecutiveDirector3">We are hiring: Executive Director of arXiv.</a><br/>
+11 Jun 2019: <a href="https://arxiv.org/new/#june11_2019">Announcing a new category and category mergers.</a><br/>
+20 May 2019: <a href="http://bit.ly/arXivEngineer4">We are hiring: arXiv Service Reliability Engineer.</a><br/>

--- a/browse/templates/user_banner.html
+++ b/browse/templates/user_banner.html
@@ -1,3 +1,5 @@
+{# donation banner #}
+{%- if 0 -%}
 <div class="slider-wrapper" style="display:none">
   <a class="close-slider" href="#"><img src="{{ url_for('static', filename='images/icons/close-slider.png') }}"></a>
   <div class="copy-donation">
@@ -16,4 +18,10 @@
       </div>
     </div>
   </div>
+</div>
+{%- endif -%}
+{# downtime #}
+<div class="slider-wrapper" style="display:none">
+  <a class="close-slider" href="#"><img src="{{ url_for('static', filename='images/icons/close-slider.png') }}"></a>
+  <p><strong>Attention Users</strong>: at 8AM ET / 12PM UTC on Friday, June 21, the submission system will be unavailable for approximately 30 minutes for routine maintenance.</p>
 </div>


### PR DESCRIPTION
Some background first: 

- as of today, there are 11,270 distinct proxy names in the system
- if you remove the proxy names that start with "ccsd", you are left with 130 distinct names
- of the 11,140 proxy names that start with "ccsd", the names generally look like this (where `N` is an integer):
  `ccsd ujm-NNNNNNNN`
  `ccsd hal-NNNNNNNN`
  `ccsd inria-NNNNNNNN`

The classic display logic simply took the first word in the proxy name and capitalized it; I think this makes sense for the CCSD case but not necessarily others. So, in this PR I'm proposing the following changes to the display logic:
- if the proxy name is only one word long OR starts with "ccsd", then upper case it
- if the proxy name is more than one word long, display it as is, with tex2utf filtering; trail with "as proxy" instead of just "proxy"

Examples "proxy name" -> display:
- "ccsd hal-00460810" -> [via CCSD proxy]
- "ccsd inria-00460912" -> [via CCSD proxy]
- "vtex" -> [via VTEX proxy]
- "Martin Wolf" -> [via Martin Wolf as proxy]
- "Hajnal Andr\'eka" -> [via Hajnal Andréka as proxy]