### PR TITLE
ARXIVNG-2230: add maintenance news item

### DIFF
--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -1,5 +1,5 @@
 {#- News blurbs appear at the top of the home page. Generally there should be no more than four items. -#}
-18 Jun 2019: <strong>Attention Users</strong>: at 8AM ET / 12PM UTC on Friday, June 21, the submission system will be unavailable for approximately 30 minutes for routine maintenance.<br/>
+21 Jun 2019: <strong>Attention Users</strong>: there may be a brief service disruption on Sunday, June 23 due to <a href="https://it.cornell.edu/news/managed-firewall-upgrade-impacting-service-june-23-2019/20190614">maintenance</a> by our network provider.<br/>
 12 Jun 2019: <a href="http://bit.ly/arXivExecutiveDirector3">We are hiring: Executive Director of arXiv.</a><br/>
 11 Jun 2019: <a href="https://arxiv.org/new/#june11_2019">Announcing a new category and category mergers.</a><br/>
 20 May 2019: <a href="http://bit.ly/arXivEngineer4">We are hiring: arXiv Service Reliability Engineer.</a><br/>


### PR DESCRIPTION
<img width="867" alt="Screenshot 2019-06-19 15 41 47" src="https://user-images.githubusercontent.com/746253/59795248-d22f7f80-92a8-11e9-9960-86a322253fb1.png">

The plan is to deploy this on Friday, June 21, after the database / submission system maintenance is completed.