### PR TITLE
ARXIVNG-2710: Update banner text for Fall 2019 giving campaign

### DIFF
--- a/browse/templates/user_banner.html
+++ b/browse/templates/user_banner.html
@@ -1,13 +1,12 @@
 {# donation banner #}
-{%- if 0 -%}
 <div class="slider-wrapper" style="display:none">
   <a class="close-slider" href="#"><img src="{{ url_for('static', filename='images/icons/close-slider.png') }}"></a>
   <div class="copy-donation">
     <h1>Donate to arXiv</h1>
     <p>
       Please join the <a href="https://simonsfoundation.org">Simons Foundation</a> and our
-      generous <a href="https://confluence.cornell.edu/x/ALlRF">member organizations</a>
-      in supporting arXiv during our giving campaign. 100% of your contribution will fund
+      generous <a href="https://arxiv.org/about/ourmembers">member organizations</a>
+      in supporting arXiv during our giving campaign September 23-27. 100% of your contribution will fund
       improvements and new initiatives to benefit arXiv's global scientific community.
     </p>
   </div>
@@ -19,9 +18,10 @@
     </div>
   </div>
 </div>
-{%- endif -%}
+{%- if 0 -%}
 {# downtime #}
 <div class="slider-wrapper" style="display:none">
   <a class="close-slider" href="#"><img src="{{ url_for('static', filename='images/icons/close-slider.png') }}"></a>
   <p><strong>Attention Users</strong>: at 8AM ET / 12PM UTC on Friday, June 21, the submission system will be unavailable for approximately 30 minutes for routine maintenance.</p>
 </div>
+{%- endif -%}


### PR DESCRIPTION
I updated the text and the link to the member organizations to /about/ourmembers.

<img width="1046" alt="Screenshot 2019-09-19 09 17 54" src="https://user-images.githubusercontent.com/746253/65247524-84e8c700-dabe-11e9-8c1d-7f8cd26f3fc9.png">
