### PR TITLE
ARXIVNG-2758 various accessible edits

### DIFF
--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -15,7 +15,7 @@ body {
 
 a:link, a:visited, a:active {
   text-decoration: none;
-  font-weight: bold;
+  /*font-weight: bold;*/
 }
 
 a:hover {
@@ -191,7 +191,7 @@ em.boxed {
 }
 
 #header .header-breadcrumbs a {
-  font-weight: bold;
+  /*font-weight: bold;*/
 }
 
 body#front #header h1 {
@@ -546,7 +546,7 @@ div#long-author-list {
 }
 
 #abs .arxivid a {
-  font-weight: bold;
+  /*font-weight: bold;*/
 }
 
 #abs .arxividv {}
@@ -686,7 +686,7 @@ div#long-dc-list {
 
 .browse .prevnext {
   padding: 0.2em 0 0 0;
-  font-weight: bold;
+  /*font-weight: bold;*/
 }
 
 .browse .prevnext .nolink {

--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -182,6 +182,18 @@ em.boxed {
   float: left;
 }
 
+#header .header-breadcrumbs {
+  margin: 0;
+  font-size: 1em;
+  padding: 10px 0 .2em 10px;
+  font-style: normal;
+  float: left;
+}
+
+#header .header-breadcrumbs a {
+  font-weight: bold;
+}
+
 body#front #header h1 {
   font-size: 2.5em;
   font-weight: normal;
@@ -397,7 +409,7 @@ footer ul {
 /****************************************
  * Content styles
  *****************************************/
-#content {
+#content, #content-inner {
   margin: .7em;
   font-size: 90%;
 }
@@ -438,25 +450,25 @@ p.tagline {
 /****************************************
  * Abstract styles (/abs)
  ****************************************/
-#abs {
+#abs-outer, #abs {
   margin: -0.7em;
 }
 
-#abs .leftcolumn {
+#abs-outer .leftcolumn {
   /* the 16 + 0.35 corresponds with the .extra-services width and border */
   margin: 0 16.35em 0 0;
   padding: 0px;
 }
 
 /* arXiv.org archive/subjclass info for abs pages... */
-#abs .subheader {
+#abs-outer .subheader {
   background-color: #eee;
   color: #000;
   padding: .25em 0;
   border-bottom: 1px solid #ccc;
 }
 
-#abs .subheader h1 {
+#abs-outer .subheader h1 {
   margin: 0;
   font-size: 1.1em;
   padding: 0 0 .2em 20px;
@@ -541,26 +553,26 @@ div#long-author-list {
 
 #abs .jref {}
 
-#abs .submission-history {
+#abs-outer .submission-history {
   margin: 1.5em 0 1.5em 20px;
   font-size: 90%;
   line-height: 1.5em;
 }
 
-#abs .submission-history h2 {
+#abs-outer .submission-history h2 {
   font-size: 120%;
   margin: 0 0 .25em 0;
   font-weight: bold;
 }
 
-#abs .submission-history pre {
+#abs-outer .submission-history pre {
   font-family: 'Lucida Grande', helvetica, arial, verdana, sans-serif;
   margin: 0;
   line-height: 1.4em;
   padding: 0;
 }
 
-#abs .endorsers {
+#abs-outer .endorsers {
   margin: 1em 0 1.5em 20px;
   font-size: small;
   font-style: italic;

--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -19,12 +19,12 @@
 
 {% block header_class %}{% endblock %}
 {% block header_h1 %}
-  <h1><a href="/">{{ config['BROWSE_SITE_LABEL'] }}</a> &gt; <a href="{{ url_for('.list_articles',context=abs_meta.primary_archive.id, subcontext='recent') }}">{{ abs_meta.primary_archive.id }}</a> &gt; arXiv:{{ requested_id }}</h1>
+  <div class="header-breadcrumbs"><a href="/">{{ config['BROWSE_SITE_LABEL'] }}</a> &gt; <a href="{{ url_for('.list_articles',context=abs_meta.primary_archive.id, subcontext='recent') }}">{{ abs_meta.primary_archive.id }}</a> &gt; arXiv:{{ requested_id }}</div>
 {% endblock header_h1 %}
 
 {%- block content %}
 {%- include "abs/trackback_rdf.html" %}
-<div id="abs">
+<div id="abs-outer">
   {% include "abs/extra_services.html" %}
   <div class="leftcolumn">
     <div class="subheader">

--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -75,9 +75,9 @@
 
 {%- macro generate_version_entry(version_entry, this_version) %}
   {%- if version_entry.version == this_version -%}
-  <b>[v{{ version_entry.version }}]</b>
+  <strong>[v{{ version_entry.version }}]</strong>
 {% else %}
-  <b><a href="{{ url_for('.abstract', arxiv_id='{}v{}'.format(abs_meta.arxiv_id, version_entry.version)) }}">[v{{ version_entry.version }}]</a></b>
+  <strong><a href="{{ url_for('.abstract', arxiv_id='{}v{}'.format(abs_meta.arxiv_id, version_entry.version)) }}">[v{{ version_entry.version }}]</a></strong>
   {% endif %}{{ version_entry.submitted_date.strftime('%a, %-d %b %Y %H:%M:%S %Z') }} ({{ "{:,}".format(version_entry.size_kilobytes) }} KB){#- ({{(version_entry.size_kilobytes*1000)|filesizeformat}}) -#}<br/>
 {%- endmacro -%}
 

--- a/browse/templates/home/home.html
+++ b/browse/templates/home/home.html
@@ -13,9 +13,9 @@
  e-prints in the fields of physics, mathematics, computer science, quantitative biology, quantitative finance, statistics, electrical engineering and systems science, and economics. Submissions to arXiv should conform to Cornell University academic standards. arXiv is owned and operated by Cornell University, a private not-for-profit educational institution. arXiv is funded by Cornell University, the Simons Foundation and by the member institutions.</p>
 <br/>
 {#-  /multi sends to either search, catchup or form interface based on which button is hit. -#}
-<form name="home-adv-search" action="/multi" method="get">
+<form name="home-adv-search" action="/multi" method="get" role="search">
   Subject search and browse:
-  <select name="group">
+  <select name="group" title="Search in">
   {%- for group_key, group_details in groups.items() if not group_details.is_test %}
     <option
         value ="{{group_key}}"
@@ -77,14 +77,15 @@ Read <a href="/help/robots">robots beware</a> before attempting any automated do
 
     {#- TODO: url_for /list, /catchup -#}
     <li>
-      <a href="{{ archive_url }}">{{ archive_name }}</a> (<b>{{ archive_key if archive_key != 'cs' else 'CoRR' }}</b> <a href="/list/{{ archive_key }}/new">new</a>, <a href="/list/{{ archive_key }}/recent">recent</a>, <a href="{{ archive_search_url }}">search</a>{% if 0 %}, <a href="/catchup?archive={{ archive_key }}&amp;sdaysback=30&amp;num=2000&amp;order=reverse&amp;method=without">last month</a>{% endif %})
+      <a href="{{ archive_url }}" id="main-{{ archive_key }}" aria-labelledby="main-{{ archive_key }}">{{ archive_name }}</a>
+      (<strong id="{{ archive_key }}">{{ archive_key if archive_key != 'cs' else 'CoRR' }}</strong> <a id="new-{{ archive_key }}" aria-labelledby="new-{{ archive_key }} {{ archive_key }}" href="/list/{{ archive_key }}/new">new</a>, <a id="recent-{{ archive_key }}" aria-labelledby="recent-{{ archive_key }} {{ archive_key }}" href="/list/{{ archive_key }}/recent">recent</a>, <a id="search-{{ archive_key }}" aria-labelledby="search-{{ archive_key }} {{ archive_key }}" href="{{ archive_search_url }}">search</a>{% if 0 %}, <a href="/catchup?archive={{ archive_key }}&amp;sdaysback=30&amp;num=2000&amp;order=reverse&amp;method=without">last month</a>{% endif %})
       {%- if group_key == 'grp_physics' and archive_key not in categories  -%}<br/>includes:
-      {%- elif archive_key == 'cs' -%}<br/>includes (see <a href="https://arxiv.org/corr/subjectclasses">detailed description</a>):
-      {%- elif archive_key in ('eess', 'econ') -%}<br/>includes (see <a href="/help/{{ archive_key }}">detailed description</a>):
-      {%- elif group_key != 'grp_physics' -%}<br/>includes (see <a href="/new/{{ archive_key }}.html">detailed description</a>):
+      {%- elif archive_key == 'cs' -%}<br/>includes (see <a href="https://arxiv.org/corr/subjectclasses" id="details-{{ archive_key }}" aria-labelledby="details-{{ archive_key }} main-{{ archive_key }}">detailed description</a>):
+      {%- elif archive_key in ('eess', 'econ') -%}<br/>includes (see <a href="/help/{{ archive_key }}" id="details-{{ archive_key }}" aria-labelledby="details-{{ archive_key }} main-{{ archive_key }}">detailed description</a>):
+      {%- elif group_key != 'grp_physics' -%}<br/>includes (see <a href="/new/{{ archive_key }}.html" id="details-{{ archive_key }}" aria-labelledby="details-{{ archive_key }} main-{{ archive_key }}">detailed description</a>):
       {%- endif -%}
       {% for category_key, category_details in categories.items()|sort(attribute='1.name') if categories[category_key].in_archive == archive_key %}
-      {% if not (loop.first and loop.last and group_key == 'grp_physics') %}<a href="/list/{{ category_key }}/recent">{{ categories[category_key].name }}</a>{% if not loop.last %}; {% endif %}{% endif %}
+      {% if not (loop.first and loop.last and group_key == 'grp_physics') %}<a href="/list/{{ category_key }}/recent" id="{{ category_key }}" aria-labelledby="main-{{ archive_key }} {{ category_key }}">{{ categories[category_key].name }}</a>{% if not loop.last %}; {% endif %}{% endif %}
       {% endfor %}
     </li>
     {% endfor %}

--- a/browse/templates/list/base.html
+++ b/browse/templates/list/base.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {%- block content %}
-<div id='content'>
+<div id='content-inner'>
 <div id='dlpage'>
   <h1>{{list_ctx_name}}</h1>
 
@@ -55,7 +55,7 @@
   {% set listing_index = item['list_index'] %}
     <dt>
       <a name='item{{listing_index}}'>[{{listing_index}}]</a>
-      <a href ="{{url_for('.abstract', arxiv_id=ids)}}" title="Abstract">
+      <a href ="{{url_for('.abstract', arxiv_id=ids)}}" title="Abstract" id="{{ids}}">
         arXiv:{{ article.arxiv_identifier.ids }}
       </a>
       {{ type_info( item ) }}
@@ -128,19 +128,19 @@
     <a href={{url_for('.list_articles',context=context, subcontext=subcontext, skip=skipn, show=to_show)}}>
       {{txt}}</a>
   {% else %}
-    <span style="color: #999">{{txt}}</span>
+    <span style="color: #454545">{{txt}}</span>
   {% endif %}
 {%- endmacro -%}
 
 {%- macro dl_links( article ) -%}
-  {% set id=article.arxiv_id %}
+  {% set id = article.arxiv_id %}
   {% set downloads = downloads[ article.arxiv_id_v ] %}
-  [<a href="{{url_for('.pdf', arxiv_id=id)}}" title="Download PDF">pdf</a>
+  [<a href="{{url_for('.pdf', arxiv_id=id)}}" title="Download PDF" id="pdf-{{id}}" aria-labelledby="pdf-{{id}}">pdf</a>
   {%- if 'ps' in downloads -%}
-    , <a href="{{url_for('.ps', arxiv_id=id)}}" title="Download PostScript">ps</a>
+    , <a href="{{url_for('.ps', arxiv_id=id)}}" title="Download PostScript" id="ps-{{id}}" aria-labelledby="ps-{{id}}">ps</a>
   {%- endif -%}
   {%- if 'other' in downloads -%}
-    , <a href="{{url_for('.format', arxiv_id=id)}}" title="Other formats">other</a>
+    , <a href="{{url_for('.format', arxiv_id=id)}}" title="Other formats" id="oth-{{id}}" aria-labelledby="oth-{{id}}">other</a>
   {%- endif -%}
   ]
 {%- endmacro -%}

--- a/browse/templates/list/base.html
+++ b/browse/templates/list/base.html
@@ -3,10 +3,10 @@
 {% block title %}{{list_ctx_name}} {{list_month_name}} {{list_year}}{% endblock %}
 
 {% block header_h1 %}
-<h1>
+<div class="header-breadcrumbs">
   <a href="{{ url_for('.home') }}">{{ config['BROWSE_SITE_LABEL'] }}</a> &gt;
   <a href="{{url_for('.list_articles', context=list_ctx_id, subcontext='recent')}}">{{list_ctx_id}}</a>
-  </h1>
+  </div>
 {% endblock %}
 
 {%- block content %}

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -235,10 +235,10 @@ class BrowseTest(unittest.TestCase):
         rv = self.app.get('/abs/physics/9707012')
         self.assertEqual(rv.status_code, 200)
         html = BeautifulSoup(rv.data.decode('utf-8'), 'html.parser')
-        h1_elmt = html.find('h1')
-        h1_txt = h1_elmt.get_text()
-        self.assertRegex(h1_txt, r'arXiv:physics\/9707012')
-        self.assertNotRegex(h1_txt, r'arXiv:physics\/9707012v')
+        div_elmt = html.find('div', class_= 'header-breadcrumbs')
+        div_txt = div_elmt.get_text()
+        self.assertRegex(div_txt, r'arXiv:physics\/9707012')
+        self.assertNotRegex(div_txt, r'arXiv:physics\/9707012v')
 
         title_elmt = html.find('title')
         title_txt = title_elmt.get_text()
@@ -254,9 +254,9 @@ class BrowseTest(unittest.TestCase):
         rv = self.app.get('/abs/physics/9707012v4')
         self.assertEqual(rv.status_code, 200)
         html = BeautifulSoup(rv.data.decode('utf-8'), 'html.parser')
-        h1_elmt = html.find('h1')
-        h1_txt = h1_elmt.get_text()
-        self.assertRegex(h1_txt, r'arXiv:physics\/9707012v4')
+        div_elmt = html.find('div', class_='header-breadcrumbs')
+        div_txt = div_elmt.get_text()
+        self.assertRegex(div_txt, r'arXiv:physics\/9707012v4')
 
         title_elmt = html.find('title')
         title_txt = title_elmt.get_text()
@@ -303,8 +303,8 @@ class BrowseTest(unittest.TestCase):
 
         self.assertTrue(
             'MPES &amp;amp; Oxford' not in rv.data.decode('utf-8'),
-            "Ampersand in author affiliation should not be double escaped")       
-        
+            "Ampersand in author affiliation should not be double escaped")
+
     def test_160408245(self):
         """Test linking in 1604.08245."""
         id = '1604.08245'


### PR DESCRIPTION
Addresses the following accessibility related edits on browse:
- fixed homepage links by adding unique aria labels.
- addressed duplicate IDs on abs.
- added secondary search form aria labelling to homepage.

Please note the changes to the abs page are dependent on a very small PR for base (single line edit made to templates/base/macros.html)