### PR TITLE
ARXIVNG-2902: move Google and Semantic Scholar links into dedicated sidebar section

### DIFF
--- a/browse/templates/abs/extra_services.html
+++ b/browse/templates/abs/extra_services.html
@@ -213,6 +213,17 @@
       {{ generate_dblp_section() }}
     {%- endif -%}
 
+    <div id="additional-resources" class="extra-ref-cite">
+      <div><h3>Additional Resources</h3></div>
+        <ul>
+        <li>
+          {#- This was previously injected by Bibliographic Explorer -#}
+          <a href="https://scholar.google.com/scholar?q={{ abs_meta.title|urlencode }}.%20arXiv%20{{ abs_meta.get_datetime_of_version(version=0).year }}" target="_blank" rel="noopener">Google Scholar</a>
+        </li>
+        <li>
+          <a href="https://api.semanticscholar.org/arXiv:{{ abs_meta.arxiv_id }}" target="_blank" rel="noopener">Semantic Scholar</a>
+        </li>
+    </div>
     {% include "abs/bookmarking.html" %}
   </div>
   <!--end extra-services-->

--- a/browse/templates/abs/extra_services.html
+++ b/browse/templates/abs/extra_services.html
@@ -197,6 +197,9 @@
         </li>
         {% endif %}
         <li><a href="https://ui.adsabs.harvard.edu/abs/arXiv:{{ abs_meta.arxiv_id|replace('/','%2F') }}">NASA ADS</a></li>
+        {#- This was previously injected by Bibliographic Explorer -#}
+        <li><a href="https://scholar.google.com/scholar?q={{ abs_meta.title|urlencode }}.%20arXiv%20{{ abs_meta.get_datetime_of_version(version=0).year }}" target="_blank" rel="noopener">Google Scholar</a></li>
+        <li><a href="https://api.semanticscholar.org/arXiv:{{ abs_meta.arxiv_id }}" target="_blank" rel="noopener">Semantic Scholar</a></li>
       </ul>
     </div>
 
@@ -213,17 +216,6 @@
       {{ generate_dblp_section() }}
     {%- endif -%}
 
-    <div id="additional-resources" class="extra-ref-cite">
-      <div><h3>Additional Resources</h3></div>
-        <ul>
-        <li>
-          {#- This was previously injected by Bibliographic Explorer -#}
-          <a href="https://scholar.google.com/scholar?q={{ abs_meta.title|urlencode }}.%20arXiv%20{{ abs_meta.get_datetime_of_version(version=0).year }}" target="_blank" rel="noopener">Google Scholar</a>
-        </li>
-        <li>
-          <a href="https://api.semanticscholar.org/arXiv:{{ abs_meta.arxiv_id }}" target="_blank" rel="noopener">Semantic Scholar</a>
-        </li>
-    </div>
     {% include "abs/bookmarking.html" %}
   </div>
   <!--end extra-services-->


### PR DESCRIPTION
The screenshot below shows the sidebar with a new "Additional Resources" section that contains outbound search links for Google Scholar and Semantic Scholar. Previously, the Google Scholar link was being injected by the bibex javascript in the same section with the "Export citation" link. 

My questions:
- Is "Additional Resources" the best name for this new section?
- Perhaps not germane to this PR, but what if anything should we do about the "Export citation" link that is still being injected by bibex (regardless if bibex is enabled or not). It does seem valuable, but should probably be grouped with the other bibex elements if we want a clearer separation between core arXiv functionality and arXiv Labs functionality.

Changes are staged on beta, e.g. https://beta.arxiv.org/abs/1911.11778

<img width="532" alt="Screenshot 2020-02-03 14 53 30" src="https://user-images.githubusercontent.com/746253/73686862-cefdce00-4696-11ea-9dbb-6f17b20df94b.png">

Edit: moved links into "References & Citations" section:
<img width="239" alt="Screenshot 2020-02-03 15 55 34" src="https://user-images.githubusercontent.com/746253/73690139-b3e28c80-469d-11ea-9df8-eead7db762ea.png">
