### PR TITLE
Pre-release merge for browse v0.2.8

### DIFF
--- a/browse/config.py
+++ b/browse/config.py
@@ -267,7 +267,8 @@ BROWSE_SITE_LABEL = os.environ.get('BROWSE_SITE_LABEL', 'arXiv.org')
 BROWSE_SITE_HOST = os.environ.get('BROWSE_SITE_HOST', None)
 """This is similar to, but decoupled from SERVER_NAME."""
 
-BROWSE_ANALYTICS_ENABLED = os.environ.get('BROWSE_ANALYTICS_ENABLED', False)
+BROWSE_ANALYTICS_ENABLED = bool(int(os.environ.get(
+    'BROWSE_ANALYTICS_ENABLED', '0')))
 """Enable/disable Matomo web analytics."""
 BROWSE_ANALYTICS_BASE_URL = os.environ.get('BROWSE_ANALYTICS_BASE_URL',
                                            'https://webstats.arxiv.org/')

--- a/browse/config.py
+++ b/browse/config.py
@@ -8,7 +8,7 @@ import warnings
 import dateutil.parser
 from datetime import datetime, timedelta
 
-APP_VERSION = '0.2.7'
+APP_VERSION = '0.2.8'
 """The application version """
 
 ON = 'yes'

--- a/browse/templates/abs/extra_services.html
+++ b/browse/templates/abs/extra_services.html
@@ -197,6 +197,9 @@
         </li>
         {% endif %}
         <li><a href="https://ui.adsabs.harvard.edu/abs/arXiv:{{ abs_meta.arxiv_id|replace('/','%2F') }}">NASA ADS</a></li>
+        {#- This was previously injected by Bibliographic Explorer -#}
+        <li><a href="https://scholar.google.com/scholar?q={{ abs_meta.title|urlencode }}.%20arXiv%20{{ abs_meta.get_datetime_of_version(version=0).year }}" target="_blank" rel="noopener">Google Scholar</a></li>
+        <li><a href="https://api.semanticscholar.org/arXiv:{{ abs_meta.arxiv_id }}" target="_blank" rel="noopener">Semantic Scholar</a></li>
       </ul>
     </div>
 

--- a/browse/templates/home/home.html
+++ b/browse/templates/home/home.html
@@ -9,9 +9,9 @@
 
 {%- block content %}
 {#- TODO: display order in taxonomy? -#}
-<p class="tagline">Open access to {% if document_count -%}{{ "{:,}".format(document_count) }}{%- endif %}
- e-prints in the fields of physics, mathematics, computer science, quantitative biology, quantitative finance, statistics, electrical engineering and systems science, and economics. Submissions to arXiv should conform to Cornell University academic standards. arXiv is owned and operated by Cornell University, a private not-for-profit educational institution. arXiv is funded by Cornell University, the Simons Foundation and by the member institutions.</p>
-<br/>
+<p class="tagline">arXiv is a free distribution service and an open-access archive for {% if document_count -%}{{ "{:,}".format(document_count) }}{%- endif %}
+ scholarly articles in the fields of physics, mathematics, computer science, quantitative biology, quantitative finance, statistics, electrical engineering and systems science, and economics.
+</p><br/>
 {#-  /multi sends to either search, catchup or form interface based on which button is hit. -#}
 <form name="home-adv-search" action="/multi" method="get" role="search">
   Subject search and browse:
@@ -60,7 +60,7 @@ Read <a href="/help/robots">robots beware</a> before attempting any automated do
   <li><a href="/about">General information</a></li>
   <li><a href="/help/submit">How to Submit to arXiv</a></li>
   <li><a href="/new">News</a></li>
-  <li><a href="/about/give">Membership & Giving</a></li>
+  <li><a href="/about/give">Membership &amp; Giving</a></li>
   <li><a href="/about/people">Who We Are</a></li>
 </ul>
 

--- a/browse/templates/tb/base.html
+++ b/browse/templates/tb/base.html
@@ -13,7 +13,7 @@
 {%- block content %}
   <div style="font-size: smaller; margin-top: 2em;">
   <h3>About trackbacks</h3>
-  <p>By sending a <a href="/help/trackback/">trackback</a>, you can notify
+  <p>By sending a <a href="/help/trackback">trackback</a>, you can notify
   arXiv.org that you have created a web page that references a paper. Popular
   blogging software supports trackback:  you can send us a trackback about this
   paper by giving your software the following <i>trackback URL:</i></p>
@@ -21,7 +21,7 @@
   <p>Some blogging software supports <i>trackback autodiscovery</i> -- in this
   case,  your software will automatically send a trackback as soon as your
   create a link to our abstract page.  See our
-  <a href="/help/trackback/">trackback help page</a> for more information.</p>
+  <a href="/help/trackback">trackback help page</a> for more information.</p>
   </div>
   <script type="text/javascript" language="javascript">mathjaxToggle();</script>
 {% endblock content %}


### PR DESCRIPTION
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://arxiv-org.atlassian.net/browse/ARXIVNG-2867'>ARXIVNG-2867</a>] -         all /tb/[id] pages incorrectly link to the trackback help, among other issues on that page
</li>
</ul>

<h2>        New Feature
</h2>
<ul>
<li>[<a href='https://arxiv-org.atlassian.net/browse/ARXIVNG-2902'>ARXIVNG-2902</a>] -         Add Semantic Scholar link to side panel
</li>
</ul>
    
<h2>        Task
</h2>
<ul>
<li>[<a href='https://arxiv-org.atlassian.net/browse/ARXIVNG-2862'>ARXIVNG-2862</a>] -         Update &quot;about arXiv&quot; at top of arXiv.org &amp; what shows for &quot;New&quot;
</li>
</ul>
                                                            