### PR TITLE
covid-19 quick search links in arXiv and bioRxiv/medRxiv

### DIFF
--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -469,6 +469,41 @@ footer .sorry-app-links .help {
 #content-inner {
 
 }
+
+/****************************************
+ * Home styles
+ *****************************************/
+.message-covid {
+  border: 2px solid #b31a1a;
+  border-radius: 10px;
+  background-color: #fef6f6;
+  padding: .5em 1em;
+  margin: 2em 0em 1em 0em;
+}
+.message-covid span.label {
+  display: block;
+  background-color: #b31a1a;
+  width: 160px;
+  text-align: center;
+  margin-top: -1.5em;
+  color: #ffffff;
+  padding: .25em 0;
+  font-size: 12px;
+}
+.message-covid ul {
+  margin-bottom: 2em;
+  margin-top: 0;
+}
+.message-covid p {
+  margin-bottom: .5em;
+}
+@media screen and (min-width: 501px) {
+  .message-covid {
+    padding: .5em 1em;
+    margin: 2em 4em 1em .25em;
+  }
+}
+
 /****************************************
  * Stats pages (/stats)
  ****************************************/

--- a/browse/templates/home/home.html
+++ b/browse/templates/home/home.html
@@ -46,8 +46,8 @@
      document.getElementById('adv-search-btn').onclick=doAdvSearchBtn;
  },false);
 </script>
-{%- include "home/news.html" -%}
 <p>
+{%- include "home/news.html" -%}
 See cumulative <a href="/new/">"What's New"</a> pages.
 Read <a href="/help/robots">robots beware</a> before attempting any automated download
 </p>

--- a/browse/templates/home/home.html
+++ b/browse/templates/home/home.html
@@ -46,8 +46,8 @@
      document.getElementById('adv-search-btn').onclick=doAdvSearchBtn;
  },false);
 </script>
-<p>
 {%- include "home/news.html" -%}
+<p>
 See cumulative <a href="/new/">"What's New"</a> pages.
 Read <a href="/help/robots">robots beware</a> before attempting any automated download
 </p>

--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -8,7 +8,7 @@
     <li><a href="https://arxiv.org/covid19search" title="COVID-19 SARS-CoV-2 preprints from arXiv">arXiv</a></li>
     <li><a target="_blank" href="https://connect.biorxiv.org/relate/content/181" title="COVID-19 SARS-CoV-2 preprints from medRxiv and bioRxiv">medRxiv and bioRxiv</a></li>
   </ul>
-  <p>26 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/30/new-covid-19-quick-search/">arXiv announces new COVID-19 quick search</a><br/>
+  <p>27 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/30/new-covid-19-quick-search/">arXiv announces new COVID-19 quick search</a><br/>
   12 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/12/arxiv-responds-to-covid-19-uncertainties/">arXiv responds to COVID-19 uncertainties</a></p>
 </div>
 

--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -1,6 +1,7 @@
 {#- News blurbs appear at the top of the home page. Generally there should be no more than four items. -#}
-{%- set rd_int = request_datetime.strftime("%Y%m%d")|int -%}
+{%- set rd_int = request_datetime.strftime("%Y%m%d%H%M")|int -%}
 
+{%- if rd_int >= 202003300900 -%}
 <div class="message-covid">
   <span class="label">COVID-19 Quick Links</span>
   <p>See COVID-19 SARS-CoV-2 preprints from</p>
@@ -8,10 +9,13 @@
     <li><a href="https://arxiv.org/covid19search" title="COVID-19 SARS-CoV-2 preprints from arXiv">arXiv</a></li>
     <li><a target="_blank" href="https://connect.biorxiv.org/relate/content/181" title="COVID-19 SARS-CoV-2 preprints from medRxiv and bioRxiv">medRxiv and bioRxiv</a></li>
   </ul>
-  <p>27 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/30/new-covid-19-quick-search/">arXiv announces new COVID-19 quick search</a><br/>
+  <p>30 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/30/new-covid-19-quick-search/">arXiv announces new COVID-19 quick search</a><br/>
   12 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/12/arxiv-responds-to-covid-19-uncertainties/">arXiv responds to COVID-19 uncertainties</a></p>
 </div>
-
-{%- if rd_int >= 20190923 and rd_int <= 20190927 -%}
+{% else %}
+16 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/16/arxiv-announces-its-first-executive-director/">arXiv announces its first executive director</a><br/>
+12 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/12/arxiv-responds-to-covid-19-uncertainties/">arXiv responds to COVID-19 uncertainties</a><br/>
+{%- endif -%}
+{%- if rd_int >= 2019092300 and rd_int <= 2019092700 -%}
 23 Sep 2019: Our giving campaign is this week. <a href="https://blogs.cornell.edu/arxiv/2019/09/19/donate-to-arxiv-4/">Support arXiv with a donation!</a><br/>
 {%- endif -%}

--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -1,8 +1,15 @@
 {#- News blurbs appear at the top of the home page. Generally there should be no more than four items. -#}
 {%- set rd_int = request_datetime.strftime("%Y%m%d")|int -%}
 
-See COVID-19 SARS-CoV-2 preprints from <a href="https://arxiv.org/search/advanced?advanced=&terms-0-operator=AND&terms-0-term=COVID-19&terms-0-field=title&terms-1-operator=OR&terms-1-term=SARS-CoV-2&terms-1-field=abstract&terms-3-operator=OR&terms-3-term=COVID-19&terms-3-field=abstract&terms-4-operator=OR&terms-4-term=SARS-CoV-2&terms-4-field=title&terms-5-operator=OR&terms-5-term=coronavirus&terms-5-field=title&terms-6-operator=OR&terms-6-term=coronavirus&terms-6-field=abstract&classification-physics_archives=all&classification-include_cross_list=include&date-filter_by=all_dates&date-year=&date-from_date=&date-to_date=&date-date_type=submitted_date&abstracts=show&size=200&order=-announced_date_first&source=home-covid-19" title="COVID-19 SARS-CoV-2 preprints from arXiv">arXiv</a>,
-<a target="_blank" href="https://connect.biorxiv.org/relate/content/181" title="COVID-19 SARS-CoV-2 preprints from medRxiv and bioRxiv">medRxiv and bioRxiv</a><br/><br/>
+<div class="message-covid">
+  <span class="label">COVID-19 Quick Links</span>
+  <p>See COVID-19 SARS-CoV-2 preprints from</p>
+  <ul>
+    <li><a href="https://arxiv.org/search/advanced?advanced=&amp;terms-0-operator=AND&amp;terms-0-term=COVID-19&amp;terms-0-field=title&amp;terms-1-operator=OR&amp;terms-1-term=SARS-CoV-2&amp;terms-1-field=abstract&amp;terms-3-operator=OR&amp;terms-3-term=COVID-19&amp;terms-3-field=abstract&amp;terms-4-operator=OR&amp;terms-4-term=SARS-CoV-2&amp;terms-4-field=title&amp;terms-5-operator=OR&amp;terms-5-term=coronavirus&amp;terms-5-field=title&amp;terms-6-operator=OR&amp;terms-6-term=coronavirus&amp;terms-6-field=abstract&amp;classification-physics_archives=all&amp;classification-include_cross_list=include&amp;date-filter_by=all_dates&amp;date-year=&amp;date-from_date=&amp;date-to_date=&amp;date-date_type=submitted_date&amp;abstracts=show&amp;size=200&amp;order=-announced_date_first&amp;source=home-covid-19" title="COVID-19 SARS-CoV-2 preprints from arXiv">arXiv</a></li>
+    <li><a target="_blank" href="https://connect.biorxiv.org/relate/content/181" title="COVID-19 SARS-CoV-2 preprints from medRxiv and bioRxiv">medRxiv and bioRxiv</a></li>
+  </ul>
+  <p>12 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/12/arxiv-responds-to-covid-19-uncertainties/">arXiv responds to COVID-19 uncertainties</a></p>
+</div>
 
 {%- if rd_int >= 20190923 and rd_int <= 20190927 -%}
 23 Sep 2019: Our giving campaign is this week. <a href="https://blogs.cornell.edu/arxiv/2019/09/19/donate-to-arxiv-4/">Support arXiv with a donation!</a><br/>

--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -5,7 +5,7 @@
   <span class="label">COVID-19 Quick Links</span>
   <p>See COVID-19 SARS-CoV-2 preprints from</p>
   <ul>
-    <li><a href="https://arxiv.org/search/advanced?advanced=&amp;terms-0-operator=AND&amp;terms-0-term=COVID-19&amp;terms-0-field=title&amp;terms-1-operator=OR&amp;terms-1-term=SARS-CoV-2&amp;terms-1-field=abstract&amp;terms-3-operator=OR&amp;terms-3-term=COVID-19&amp;terms-3-field=abstract&amp;terms-4-operator=OR&amp;terms-4-term=SARS-CoV-2&amp;terms-4-field=title&amp;terms-5-operator=OR&amp;terms-5-term=coronavirus&amp;terms-5-field=title&amp;terms-6-operator=OR&amp;terms-6-term=coronavirus&amp;terms-6-field=abstract&amp;classification-physics_archives=all&amp;classification-include_cross_list=include&amp;date-filter_by=all_dates&amp;date-year=&amp;date-from_date=&amp;date-to_date=&amp;date-date_type=submitted_date&amp;abstracts=show&amp;size=200&amp;order=-announced_date_first&amp;source=home-covid-19" title="COVID-19 SARS-CoV-2 preprints from arXiv">arXiv</a></li>
+    <li><a href="https://arxiv.org/covid19search" title="COVID-19 SARS-CoV-2 preprints from arXiv">arXiv</a></li>
     <li><a target="_blank" href="https://connect.biorxiv.org/relate/content/181" title="COVID-19 SARS-CoV-2 preprints from medRxiv and bioRxiv">medRxiv and bioRxiv</a></li>
   </ul>
   <p>12 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/12/arxiv-responds-to-covid-19-uncertainties/">arXiv responds to COVID-19 uncertainties</a></p>

--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -8,7 +8,8 @@
     <li><a href="https://arxiv.org/covid19search" title="COVID-19 SARS-CoV-2 preprints from arXiv">arXiv</a></li>
     <li><a target="_blank" href="https://connect.biorxiv.org/relate/content/181" title="COVID-19 SARS-CoV-2 preprints from medRxiv and bioRxiv">medRxiv and bioRxiv</a></li>
   </ul>
-  <p>12 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/12/arxiv-responds-to-covid-19-uncertainties/">arXiv responds to COVID-19 uncertainties</a></p>
+  <p>26 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/30/new-covid-19-quick-search/">arXiv announces new COVID-19 quick search</a><br/>
+  12 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/12/arxiv-responds-to-covid-19-uncertainties/">arXiv responds to COVID-19 uncertainties</a></p>
 </div>
 
 {%- if rd_int >= 20190923 and rd_int <= 20190927 -%}

--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -1,8 +1,10 @@
 {#- News blurbs appear at the top of the home page. Generally there should be no more than four items. -#}
 {%- set rd_int = request_datetime.strftime("%Y%m%d")|int -%}
 
+See COVID-19 SARS-CoV-2 preprints from <a href="https://arxiv.org/search/advanced?advanced=&terms-0-operator=AND&terms-0-term=COVID-19&terms-0-field=title&terms-1-operator=OR&terms-1-term=SARS-CoV-2&terms-1-field=abstract&terms-3-operator=OR&terms-3-term=COVID-19&terms-3-field=abstract&terms-4-operator=OR&terms-4-term=SARS-CoV-2&terms-4-field=title&terms-5-operator=OR&terms-5-term=coronavirus&terms-5-field=title&terms-6-operator=OR&terms-6-term=coronavirus&terms-6-field=abstract&classification-physics_archives=all&classification-include_cross_list=include&date-filter_by=all_dates&date-year=&date-from_date=&date-to_date=&date-date_type=submitted_date&abstracts=show&size=200&order=-announced_date_first&source=home-covid-19" title="COVID-19 SARS-CoV-2 preprints from arXiv">arXiv</a>,
+<a target="_blank" href="https://connect.biorxiv.org/relate/content/181" title="COVID-19 SARS-CoV-2 preprints from medRxiv and bioRxiv">medRxiv and bioRxiv</a><br/><br/>
+
 {%- if rd_int >= 20190923 and rd_int <= 20190927 -%}
 23 Sep 2019: Our giving campaign is this week. <a href="https://blogs.cornell.edu/arxiv/2019/09/19/donate-to-arxiv-4/">Support arXiv with a donation!</a><br/>
 {%- endif -%}
 12 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/12/arxiv-responds-to-covid-19-uncertainties/">arXiv responds to COVID-19 uncertainties</a><br/>
-

--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -14,4 +14,3 @@
 {%- if rd_int >= 20190923 and rd_int <= 20190927 -%}
 23 Sep 2019: Our giving campaign is this week. <a href="https://blogs.cornell.edu/arxiv/2019/09/19/donate-to-arxiv-4/">Support arXiv with a donation!</a><br/>
 {%- endif -%}
-12 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/12/arxiv-responds-to-covid-19-uncertainties/">arXiv responds to COVID-19 uncertainties</a><br/>


### PR DESCRIPTION
arXiv has decided that we will provide covid-19 quick search links on the home page, both to arXiv and to bioRxiv/medRxiv. 

This is a first pass (see screenshot below). @SBBCornell please reposition or restyle as needed.

<img width="771" alt="Screenshot 2020-03-25 21 25 28" src="https://user-images.githubusercontent.com/746253/77600760-338f1980-6edf-11ea-950b-b393ea4acdb6.png">
