### PR TITLE
add support for status page web plugin

### DIFF
--- a/browse/config.py
+++ b/browse/config.py
@@ -301,6 +301,18 @@ except Exception:
         warnings.warn("Bad value for BROWSE_USER_BANNER_END_DATE")
     BROWSE_USER_BANNER_END_DATE = datetime.now() + timedelta(days=1)
 
+BROWSE_STATUS_BANNER_ENABLED = bool(int(os.environ.get(
+    'BROWSE_STATUS_BANNER_ENABLED', '0')))
+"""Enable/disable status service banner."""
+
+BROWSE_STATUS_BANNER_SCRIPT_URL = os.environ.get(
+    'BROWSE_STATUS_BANNER_SCRIPT_URL',
+    'https://code.sorryapp.com/status-bar/4.latest/status-bar.min.js')
+
+BROWSE_STATUS_BANNER_SITE_ID = os.environ.get(
+    'BROWSE_STATUS_BANNER_SITE_ID', 'foo')
+"""Enable/disable status service banner."""
+
 DOCUMENT_LATEST_VERSIONS_PATH = os.environ.get(
     'DOCUMENT_LATEST_VERSIONS_PATH', 'tests/data/abs_files/ftp')
 """Paths to .abs and source files."""

--- a/browse/templates/base.html
+++ b/browse/templates/base.html
@@ -145,7 +145,9 @@
       </div>
     </div>
   </footer>
-
+  {% if config['BROWSE_STATUS_BANNER_ENABLED'] -%}
+  <script async src="{{ config['BROWSE_STATUS_BANNER_SCRIPT_URL'] }}" data-for="{{ config['BROWSE_STATUS_BANNER_SITE_ID'] }}"></script>
+  {%- endif %}
 </body>
 
 </html>


### PR DESCRIPTION
I've added this so that we have maximum visibility for status alerts. Once a user clicks on the close button, they won't be bugged by it again. Example screenshot below:


<img width="1146" alt="Screenshot 2020-04-02 21 15 38" src="https://user-images.githubusercontent.com/746253/78357480-8de34680-757f-11ea-99fb-b1a34630eeda.png">
