### PR TITLE
hotfix to display of browse in sidebar

### DIFF
--- a/browse/templates/abs/extra_services.html
+++ b/browse/templates/abs/extra_services.html
@@ -59,16 +59,18 @@
     {% if browse_context_previous_url -%}
     <span class="arrow">
       <a class="abs-button" href="{{browse_context_previous_url }}"
-         accesskey="p" title="previous in {{ browse_context }} (accesskey p)">&lt;&nbsp;prev article</a>
+         accesskey="p" title="previous in {{ browse_context }} (accesskey p)">&lt;&nbsp;prev</a>
     </span>
+    <span class="is-hidden-mobile">&nbsp; | &nbsp;</span>
     {%- else -%}
     <span class="nolink" class="abs-button">&lt;&nbsp;previous article</span>
+    <span class="is-hidden-mobile">&nbsp; | &nbsp;</span>
     {% endif -%}
 
     {% if browse_context_next_url %}
     <span class="arrow">
       <a class="abs-button" href="{{browse_context_next_url}}" accesskey="n"
-         title="next in {{ browse_context }} (accesskey n)">next article&nbsp;&gt;</a>
+         title="next in {{ browse_context }} (accesskey n)">next&nbsp;&gt;</a>
     </span>
     {%- else -%}
     <span class="abs-button" class="nolink">next article&nbsp;&gt;</span>
@@ -80,7 +82,9 @@
   {#- This fixes a bug in the classic UI logic -#}
   <div class="list">
     <a class="abs-button abs-button-grey abs-button-small" href="{{url_for('.list_articles',context=browse_context, subcontext='new')}}">new</a>
+    <span class="is-hidden-mobile"> | </span>
     <a class="abs-button abs-button-grey abs-button-small" href="{{url_for('.list_articles',context=browse_context, subcontext='recent')}}">recent</a>
+    <span class="is-hidden-mobile"> | </span>
     <a class="abs-button abs-button-grey abs-button-small" href="{{url_for('.list_articles',context=browse_context, subcontext=abs_meta.arxiv_identifier.yymm)}}">
       {{- abs_meta.arxiv_identifier.yymm -}}</a>
   </div>
@@ -93,9 +97,9 @@
       {% for category in abs_meta.get_browse_context_list() if not (browse_context==category) %}
         {%- set switch_url = url_for('browse.abstract', arxiv_id=abs_meta.arxiv_identifier.id, context=category) -%}
         {% if '.' in category %}
-        <a class="subclass" href="{{ switch_url}}">{{ category }}</a>
+        <a class="subclass" href="{{ switch_url}}">{{ category }}</a><br class="is-hidden-mobile">
         {% else %}
-        <a href="{{ switch_url}}">{{ category }}</a>
+        <a href="{{ switch_url}}">{{ category }}</a><br class="is-hidden-mobile">
         {% endif %}
       {% endfor %}
     </div>

--- a/tests/test_browse_links.py
+++ b/tests/test_browse_links.py
@@ -32,11 +32,11 @@ class BrowseLinksTest(unittest.TestCase):
 
         pn_div = html.find('div', 'prevnext')
         self.assertIsNotNone(pn_div, 'Should have div.prevnext')
-        self.assertEqual(pn_div.find_all('span')[0].a['title'],
+        self.assertEqual(pn_div.find_all('span', 'arrow')[0].a['title'],
                          'previous in cs.MM (accesskey p)',
                          'Should have previous span.arrow subtags with correct category')
 
-        self.assertEqual(pn_div.find_all('span')[1].a['title'],
+        self.assertEqual(pn_div.find_all('span', 'arrow')[1].a['title'],
                          'next in cs.MM (accesskey n)',
                          'Should have next span.arrow subtags with correct category')
 
@@ -86,7 +86,7 @@ class BrowseLinksTest(unittest.TestCase):
 
         atags = pn_div.find_all('a')
         self.assertTrue(len(atags) >= 1, 'Shold be at least one <a> tags for prev/next')
-        
+
         self.assertEqual(pn_div.find_all('a')[0]['title'],
                          'previous in math-ph (accesskey p)',
                          'Should have previous span.arrow subtags with correct category')


### PR DESCRIPTION
fixes desktop display of the "current browse context" and "change to browse by" sections in the right sidebar of the abstract page.