### PR TITLE
covid-19 messaging updates on homepage and abs page

### DIFF
--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -24,7 +24,6 @@
 {%- block content %}
 {%- include "abs/trackback_rdf.html" %}
 <div id="abs-outer">
-
   {% set download_button %}
     {{ generate_download_button() }}
   {% endset %}
@@ -36,6 +35,11 @@
 
     <div class="header-breadcrumbs-mobile">
       <strong>arXiv:{{ requested_id }}</strong> ({{ abs_meta.primary_archive.id }})
+    </div>
+
+    <div class="message-covid" style="margin:2em 1em;">
+      <span class="label">COVID-19 e-print</span>
+      <p><em>Important:</em> e-prints posted on arXiv are not peer-reviewed by arXiv; they should not be relied upon without context to guide clinical practice or health-related behavior and should not be reported in news media as established information without readers checking their publication status.</p>
     </div>
 
     {{

--- a/browse/templates/home/home.html
+++ b/browse/templates/home/home.html
@@ -11,6 +11,7 @@
 {#- TODO: display order in taxonomy? -#}
 <p class="tagline">arXiv is a free distribution service and an open-access archive for {% if document_count -%}{{ "{:,}".format(document_count) }}{%- endif %}
  scholarly articles in the fields of physics, mathematics, computer science, quantitative biology, quantitative finance, statistics, electrical engineering and systems science, and economics.
+ Materials on this site are not peer-reviewed by arXiv.
 </p><br/>
 {#-  /multi sends to either search, catchup or form interface based on which button is hit. -#}
 <form name="home-adv-search" action="/multi" method="get" role="search">

--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -11,6 +11,7 @@
   </ul>
   <p>30 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/30/new-covid-19-quick-search/">arXiv announces new COVID-19 quick search</a><br/>
   12 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/12/arxiv-responds-to-covid-19-uncertainties/">arXiv responds to COVID-19 uncertainties</a></p>
+  <p><em>Important:</em> e-prints posted on arXiv are not peer-reviewed by arXiv; they should not be relied upon without context to guide clinical practice or health-related behavior and should not be reported in news media as established information without readers checking their publication status.</p>
 </div>
 {% else %}
 16 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/16/arxiv-announces-its-first-executive-director/">arXiv announces its first executive director</a><br/>


### PR DESCRIPTION
A PR with the covid messaging discussed in this confluence page: 
https://confluence.cornell.edu/display/arXiv/Homepage+preprint+messaging?focusedCommentId=381962327#comment-381962327

@mhl10 i wanted to jumpstart this with the basic content, but the abs page still needs the conditional code to only display that block for covid related articles. I will create a ticket.