### PR TITLE
minor: emphasize category key over category name

### DIFF
--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -2077,10 +2077,10 @@ body#front.with-cu-identity #header #search {
 }
 .large-data-list h4 {
   margin:1em 1em 1em 0;
-  font-size: .9em;
+  font-size: 1.1em;
 }
 .large-data-list h4 span {
-  font-size: .8em;
+  font-size: .7em;
   font-weight: normal;
 }
 .large-data-list .physics {

--- a/browse/templates/category_taxonomy.html
+++ b/browse/templates/category_taxonomy.html
@@ -46,10 +46,10 @@
       </div>
       {%- endif -%}
       <div class="column">
-        {% for category_key, category_details in categories.items()|sort(attribute='1.name') if categories[category_key].in_archive == archive_key %}
+        {% for category_key, category_details in categories.items()|sort(attribute='0') if categories[category_key].in_archive == archive_key %}
         <div class="columns divided">
           <div class="column is-one-fifth">
-            <h4>{{ categories[category_key].name }} <span>({{ category_key }})</span></h4>
+            <h4>{{ category_key }} <span>({{ categories[category_key].name }})</span></h4>
           </div>
           <div class="column">
           {%- if 'description' in categories[category_key] -%}


### PR DESCRIPTION
These small changes order the category taxonomy page by category key instead of category name, and visually emphasize the key. 

Per Steinn's feedback, he often doesnt know the category name and is scanning by category key in order to figure out what it is. 

Here is a screenshot for reviewing:
![Screen Shot 2020-04-28 at 8 39 21 AM](https://user-images.githubusercontent.com/56078140/80488288-1a3d1b00-892c-11ea-9b77-f97def3e47a5.png)
