### PR TITLE
adds homepage news: no announcement on june 9th

### DIFF
--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -496,6 +496,9 @@ footer .sorry-app-links .help {
 .message-covid p {
   margin-bottom: .5em;
 }
+.homepage-news-title {
+  margin-bottom: .25em;
+}
 @media screen and (min-width: 501px) {
   .message-covid {
     padding: .5em 1em;

--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -17,6 +17,9 @@
 16 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/16/arxiv-announces-its-first-executive-director/">arXiv announces its first executive director</a><br/>
 12 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/12/arxiv-responds-to-covid-19-uncertainties/">arXiv responds to COVID-19 uncertainties</a><br/>
 {%- endif -%}
+
+<h4 class="homepage-news-title">News</h4>
+Notice to authors and readers that there will be no regular announcement of papers on Tuesday 9 June 2020. Please see the <a href="https://arxiv.org/new/#5June2020">news post for details</a>.<br>
 {%- if rd_int >= 2019092300 and rd_int <= 2019092700 -%}
 23 Sep 2019: Our giving campaign is this week. <a href="https://blogs.cornell.edu/arxiv/2019/09/19/donate-to-arxiv-4/">Support arXiv with a donation!</a><br/>
 {%- endif -%}


### PR DESCRIPTION
quick screenshot:
![Screen Shot 2020-06-05 at 4 12 28 PM](https://user-images.githubusercontent.com/56078140/83918767-62c7cf80-a747-11ea-86e1-6594055903d1.png)
