### PR TITLE
Clean-up CORE Recommender script

### DIFF
--- a/browse/static/js/core-recommender.js
+++ b/browse/static/js/core-recommender.js
@@ -6,39 +6,8 @@
 
   var document = window.document;
   var baseUrl = 'https://core.ac.uk';
-  var cookieName = options.cookieName || "arxiv_core_recommender";
   var scriptId = options.scriptId || "recommender-embed";
   var apiKey = options.apiKey || "24c597";
-
-
-  // Generic cookie manipulations
-
-  function setCookie(name, value, days) {
-    if (!name && !value) return false;
-  
-    if (days) {
-      var date = new Date();
-      date.setTime(date.getTime()+(days * 24 * 60 * 60 * 1000));
-      var expires = "; expires=" + date.toGMTString();
-    } else {
-      var expires = "";
-    }
-
-    document.cookie = name + "=" + value + expires +"; path=/";
-    return true;
-  }
-
-  function getCookie(name) {
-    var nameEq = name + "=";
-    var begin = document.cookie.indexOf(nameEq);
-    if (begin < 0) return null;
-
-    var end = document.cookie.indexOf(";", begin);
-    if (end < 0) end = document.cookie.length;
-
-    var value = decodeURIComponent(document.cookie.substring(begin + nameEq.length, end));
-    return value;
-  }
 
 
   // Generic DOM manipulations
@@ -67,16 +36,6 @@
 
   // CORE Recommender
 
-  function getRecommenderStatus() {
-    const cookieValue = getCookie(cookieName) || "enabled";
-    return cookieValue === "enabled";
-  }
-
-  function setRecommenderStatus(enabled) {
-    const value = enabled ? "enabled" : "disabled";
-    setCookie(cookieName, value, 365);
-  }
-
   function loadRecommender(baseUrl, userInput, options) {
     if (options == null) options = {};
     if (userInput == null) userInput = {};
@@ -95,29 +54,22 @@
     document.getElementById("coreRecommenderOutput").innerHTML = "";
   }
 
-  function renderToggleButtonText(status) {
-    var buttonElement = document.getElementById("core-recommender-toggle");
-    const caption = (status ? "Disable" : "Enable") + " CORE Recommendations";
-    buttonElement.innerHTML = caption;
-  }
-
-  function toggleRecommender(forceStatus) {
-    var nextStatus = forceStatus != null ? forceStatus : !getRecommenderStatus();
-    
-    setRecommenderStatus(nextStatus);
-
-    renderToggleButtonText(nextStatus);
-    if (nextStatus)
+  function toggleRecommender(isEnabled) {
+    if (isEnabled)
       loadRecommender(baseUrl);
     else
       unloadRecommender();
   }
 
   function initRecommender() {
-    var isEnabled = getRecommenderStatus();
-    toggleRecommender(isEnabled);
+    toggleRecommender(true);
   }
 
-  window.toggleCORERecommender = toggleRecommender;
-  window.addEventListener('load', initRecommender);
+
+  // Initialization
+
+  if (window.document.readyState == 'loading')
+    window.addEventListener('load', initRecommender);
+  else
+    initRecommender();
 }(window));


### PR DESCRIPTION
1. Removes cookie management from the `core-recommender.js`
2. Adds a conditional check for the script loading:
   - if the `document` was loaded already, the `init()` function
     is executed
   - if the `document` was not loaded, a new 'load' listener is added

---

I checked how the arXiv Labs' switchers work and found that the cookie management is done separately. I removed this from the CORE Recommender's stript accordingly.

Also, I fixed the problem with immediate loading of the recommendations. There was a little unexpected case.

However, I see the differences between the deployed script on the `beta` and the latest version in the `develop` branch. I hope there will be no conflicts.

---

I will properly test it and turn off the draft later.
