### PR TITLE
minimizes COVID message block on homepage

### DIFF
--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -557,7 +557,7 @@ footer .sorry-app-links .a11y-main-link {
   background-color: #b31a1a;
   width: 160px;
   text-align: center;
-  margin-top: -1.5em;
+  margin-top: -1.9em;
   color: #ffffff;
   padding: .25em 0;
   font-size: 12px;

--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -549,7 +549,7 @@ footer .sorry-app-links .a11y-main-link {
   border-radius: 10px;
   background-color: #fef6f6;
   padding: .5em 1em;
-  margin: 2em 1% 1em 1%;
+  margin: 1em 1% 1em 1%;
   width: 92%;
 }
 .message-special span.label {
@@ -563,7 +563,7 @@ footer .sorry-app-links .a11y-main-link {
   font-size: 12px;
 }
 .message-special ul {
-  margin-bottom: 2em;
+  margin-bottom: 1em;
   margin-top: 0;
 }
 .message-special p {
@@ -748,6 +748,12 @@ p.tagline {
 }
 .home-search {
   clear:both;
+  border: 1px solid #dddddd;
+  padding: .5em;
+  margin-top: 1em;
+}
+.home-search label {
+  font-weight: bold;
 }
 @media screen and (max-width: 768px) {
   .tagline-cta, .tagline-wrapper {

--- a/browse/templates/home/home.html
+++ b/browse/templates/home/home.html
@@ -9,51 +9,55 @@
 
 {%- block content %}
 {#- TODO: display order in taxonomy? -#}
-<p class="tagline">arXiv is a free distribution service and an open-access archive for {% if document_count -%}{{ "{:,}".format(document_count) }}{%- endif %}
- scholarly articles in the fields of physics, mathematics, computer science, quantitative biology, quantitative finance, statistics, electrical engineering and systems science, and economics.
- Materials on this site are not peer-reviewed by arXiv.
-</p>
 
-<br>
-{#-  /multi sends to either search, catchup or form interface based on which button is hit. -#}
-<form name="home-adv-search" class="home-search" action="/multi" method="get" role="search">
-  Subject search and browse:
-  <select name="group" title="Search in">
-  {%- for group_key, group_details in groups.items() if not group_details.is_test %}
-    <option
-        value ="{{group_key}}"
-        data-url="{{url_for('search_archive', archive=group_key[4:])}}"
-        {% if group_key == 'grp_physics' %}selected="selected"{% endif %}>
-      {{ group_details.name }}
-    </option>
-    {%- endfor %}
-  </select>
-  <input id="adv-search-btn" type="button" value="Search">
-  <input type="submit" name="/form" value="Form Interface">
-  <input type="submit" name="/catchup" value="Catchup">
-</form>
+<div class="columns">
+  <div class="column">
+    <p class="tagline">arXiv is a free distribution service and an open-access archive for {% if document_count -%}{{ "{:,}".format(document_count) }}{%- endif %}
+     scholarly articles in the fields of physics, mathematics, computer science, quantitative biology, quantitative finance, statistics, electrical engineering and systems science, and economics.
+     Materials on this site are not peer-reviewed by arXiv.
+    </p>
 
-<script type="text/javascript">
- function doAdvSearchBtn(event) {
-     sel = document.querySelector('select[name="group"]')
-     if(sel && sel.options && sel.options[sel.selectedIndex].dataset.url ){
-         data_url = sel.options[sel.selectedIndex].dataset.url
-         if( data_url ){
-             window.location = data_url;
-         }else{
-             console.error('home page search button: no data_url found for search');
+    {#-  /multi sends to either search, catchup or form interface based on which button is hit. -#}
+    <form name="home-adv-search" class="home-search" action="/multi" method="get" role="search">
+      <label for="search-category">Subject search and browse:</label><br>
+      <select name="group" title="Search in" id="search-category">
+      {%- for group_key, group_details in groups.items() if not group_details.is_test %}
+        <option
+            value ="{{group_key}}"
+            data-url="{{url_for('search_archive', archive=group_key[4:])}}"
+            {% if group_key == 'grp_physics' %}selected="selected"{% endif %}>
+          {{ group_details.name }}
+        </option>
+        {%- endfor %}
+      </select>
+      <input id="adv-search-btn" type="button" value="Search">
+      <input type="submit" name="/form" value="Form Interface">
+      <input type="submit" name="/catchup" value="Catchup">
+    </form>
+    <script type="text/javascript">
+     function doAdvSearchBtn(event) {
+         sel = document.querySelector('select[name="group"]')
+         if(sel && sel.options && sel.options[sel.selectedIndex].dataset.url ){
+             data_url = sel.options[sel.selectedIndex].dataset.url
+             if( data_url ){
+                 window.location = data_url;
+             }else{
+                 console.error('home page search button: no data_url found for search');
+             }
          }
      }
- }
- document.addEventListener('DOMContentLoaded',function() {
-     document.getElementById('adv-search-btn').onclick=doAdvSearchBtn;
- },false);
-</script>
-<p>
-{%- include "home/news.html" -%}
-See cumulative <a href="/new/">"What's New"</a> pages.
-Read <a href="/help/robots">robots beware</a> before attempting any automated download
-</p>
+     document.addEventListener('DOMContentLoaded',function() {
+         document.getElementById('adv-search-btn').onclick=doAdvSearchBtn;
+     },false);
+    </script>
+    <h4 class="homepage-news-title">News</h4>
+    See cumulative <a href="/new/">"What's New"</a> pages.
+    Read <a href="/help/robots">robots beware</a> before attempting any automated download
+  </div>
+  <!-- special news column -->
+  {%- include "home/news.html" -%}
+</div>
+
 {#- TODO: define display order in taxonomy? -#}
 {{- group_section(('grp_physics','grp_math','grp_cs','grp_q-bio','grp_q-fin','grp_stat','grp_eess','grp_econ')) }}
 

--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -1,28 +1,21 @@
 {#- News blurbs appear at the top of the home page. Generally there should be no more than four items. -#}
 {%- set rd_int = request_datetime.strftime("%Y%m%d%H%M")|int -%}
-
 {%- if rd_int >= 202003300900 -%}
-<div class="columns">
-  <div class="message-special column">
-    <span class="label">COVID-19 Quick Links</span>
-    <p>See COVID-19 SARS-CoV-2 preprints from</p>
-    <ul>
-      <li><a href="https://arxiv.org/covid19search" title="COVID-19 SARS-CoV-2 preprints from arXiv">arXiv</a></li>
-      <li><a target="_blank" href="https://connect.biorxiv.org/relate/content/181" title="COVID-19 SARS-CoV-2 preprints from medRxiv and bioRxiv">medRxiv and bioRxiv</a></li>
-    </ul>
-    <p>30 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/30/new-covid-19-quick-search/">arXiv announces new COVID-19 quick search</a><br/>
-    12 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/12/arxiv-responds-to-covid-19-uncertainties/">arXiv responds to COVID-19 uncertainties</a></p>
-    <p><em>Important:</em> e-prints posted on arXiv are not peer-reviewed by arXiv; they should not be relied upon without context to guide clinical practice or health-related behavior and should not be reported in news media as established information without consulting multiple experts in the field.</p>
-  </div>
+<div class="message-special column">
+  <span class="label">COVID-19 Quick Links</span>
+  <p>See COVID-19 SARS-CoV-2 preprints from</p>
+  <ul>
+    <li><a href="https://arxiv.org/covid19search" title="COVID-19 SARS-CoV-2 preprints from arXiv">arXiv</a></li>
+    <li><a target="_blank" href="https://connect.biorxiv.org/relate/content/181" title="COVID-19 SARS-CoV-2 preprints from medRxiv and bioRxiv">medRxiv and bioRxiv</a></li>
+  </ul>
+  <p><em>Important:</em> e-prints posted on arXiv are not peer-reviewed by arXiv; they should not be relied upon without context to guide clinical practice or health-related behavior and should not be reported in news media as established information without consulting multiple experts in the field.</p>
 </div>
 {% else %}
 16 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/16/arxiv-announces-its-first-executive-director/">arXiv announces its first executive director</a><br/>
 12 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/12/arxiv-responds-to-covid-19-uncertainties/">arXiv responds to COVID-19 uncertainties</a><br/>
 {%- endif -%}
 
-<br style="clear:both;">
-
-<h4 class="homepage-news-title">News</h4>
+<!-- annual giving message -->
 {%- if rd_int >= 2019092300 and rd_int <= 2019092700 -%}
 23 Sep 2019: Our giving campaign is this week. <a href="https://blogs.cornell.edu/arxiv/2019/09/19/donate-to-arxiv-4/">Support arXiv with a donation!</a><br/>
 {%- endif -%}


### PR DESCRIPTION
Steinn pointed out the COVID block on the homepage could use a rethink. The two somewhat dated news items are removed and it's taking up less space in a right hand column. Also added minimal styling around the search on the left to differentiate it from the surrounding text.

Screenshot attached for quick review:
<img width="1573" alt="Screen Shot 2020-07-27 at 8 13 41 AM" src="https://user-images.githubusercontent.com/56078140/88540541-2430f180-cfe1-11ea-96a1-85062db05d4f.png">
