### PR TITLE
adds unique classes to abs for Pendo targeting

### DIFF
--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -79,7 +79,7 @@
   {% include "abs/extra_services.html" %}
 
   <div class="endorsers">
-    <a href="{{ url_for('.show_endorsers',arxiv_id=abs_meta.arxiv_id) }}">Which authors of this paper are endorsers?</a> |
+    <a href="{{ url_for('.show_endorsers',arxiv_id=abs_meta.arxiv_id) }}" class="endorser-who">Which authors of this paper are endorsers?</a> |
     <a id="mathjax_toggle" href="javascript:setMathjaxCookie()">Disable MathJax</a> (<a href="{{ url_for('help_mathjax') }}">What is MathJax?</a>)
     <span class="help" style="font-style: normal; float: right; margin-top: 0; margin-right: 1em;">{% include "feedback_collector.html" %}</span>
   </div>

--- a/browse/templates/abs/extra_services.html
+++ b/browse/templates/abs/extra_services.html
@@ -4,11 +4,11 @@
     {% if loop.index == cutoff and anc_file_list|length > cutoff %}
 </ul><div id="long-anc-list"><ul>
     {% endif %}
-  <li><a href="{{url_for('.src',arxiv_id=abs_meta.arxiv_id_v,file_name=anc_file['name'])}}">{{ anc_file['name'] }}</a></li>
+  <li><a href="{{url_for('.src',arxiv_id=abs_meta.arxiv_id_v,file_name=anc_file['name'])}}" class="anc-file-name">{{ anc_file['name'] }}</a></li>
   {%- endfor -%}
   {% if anc_file_list|length > cutoff %}
     {%- set num_files_not_shown = anc_file_list|length - cutoff + 1 -%}
-  </ul></div><ul class="no-bullet"><li><a href="javascript:toggleList('long-anc-list','{{ num_files_not_shown }} additional file{% if num_files_not_shown > 1 %}s{% endif %} not shown');" title="Show entire file list." id="toggle">({{ num_files_not_shown }} additional file{% if num_files_not_shown > 1 %}s{% endif %} not shown)</a><noscript>&nbsp;You must enabled JavaScript to view entire file list.</noscript></li></ul>
+  </ul></div><ul class="no-bullet"><li><a href="javascript:toggleList('long-anc-list','{{ num_files_not_shown }} additional file{% if num_files_not_shown > 1 %}s{% endif %} not shown');" title="Show entire file list." id="toggle" class="anc-additional-file">({{ num_files_not_shown }} additional file{% if num_files_not_shown > 1 %}s{% endif %} not shown)</a><noscript>&nbsp;You must enabled JavaScript to view entire file list.</noscript></li></ul>
   {% else %}
 </ul>
   {% endif %}
@@ -25,24 +25,24 @@
     {%- for format in format_list if not (format == 'src' and not current) %}
   <li>
     {%- if format == 'src' -%}
-    <a href="{{url_for('.eprint', arxiv_id=requested_id)}}" class="abs-button">Source</a>
+    <a href="{{url_for('.eprint', arxiv_id=requested_id)}}" class="abs-button download-eprint">Source</a>
     {%- elif format.startswith('ps') -%}
-    <a href="{{url_for('.ps', arxiv_id=requested_id)}}" class="abs-button">PostScript{% if format.endswith('(400)') %} (400 dpi){% elif format.endswith('(600)') %} (600 dpi){% elif format.endswith('(cm)') %} (Type I cm){% elif format.endswith('(CM)') %} (Type I CM){% endif %}</a>
+    <a href="{{url_for('.ps', arxiv_id=requested_id)}}" class="abs-button download-ps">PostScript{% if format.endswith('(400)') %} (400 dpi){% elif format.endswith('(600)') %} (600 dpi){% elif format.endswith('(cm)') %} (Type I cm){% elif format.endswith('(CM)') %} (Type I CM){% endif %}</a>
     {%- elif format.startswith('pdf') -%}
-    <a href="{{url_for('.pdf', arxiv_id=requested_id)}}" accesskey="f" class="abs-button">PDF{% if format.endswith('only') %} only{% endif %}</a>
+    <a href="{{url_for('.pdf', arxiv_id=requested_id)}}" accesskey="f" class="abs-button download-pdf">PDF{% if format.endswith('only') %} only{% endif %}</a>
     {%- elif format == 'dvi' -%}
-    <a href="{{url_for('.dvi', arxiv_id=requested_id)}}" class="abs-button">{{ format.upper() }}</a>
+    <a href="{{url_for('.dvi', arxiv_id=requested_id)}}" class="abs-button download-dvi">{{ format.upper() }}</a>
     {%- elif format == 'html' -%}
-    <a href="{{url_for('.html', arxiv_id=requested_id)}}" accesskey="f" class="abs-button">{{ format.upper() }}</a>
+    <a href="{{url_for('.html', arxiv_id=requested_id)}}" accesskey="f" class="abs-button download-html">{{ format.upper() }}</a>
     {%- elif format == 'other' -%}
-    <a href="{{url_for('.format', arxiv_id=requested_id)}}" class="abs-button">Other formats</a>
+    <a href="{{url_for('.format', arxiv_id=requested_id)}}" class="abs-button download-format">Other formats</a>
     {%- elif format == 'nops' -%}
     <a href="{{url_for('.ps', arxiv_id=requested_id)}}" class="abs-button-grey">(PostScript unavailable)</a>
     {%- elif format == 'sciencewise_pdf' -%}
     {#- TODO: consider this format for deprecation -#}
     {#- TODO: create clickthrough link from sciencewise link -#}
-    <a href="http://sciencewise.info/media/pdf/{{ abs_meta.arxiv_id_v }}.pdf" title="Tagged PDF on ScienceWISE.info" class="abs-button">Tagged PDF</a>
-    <a href="http://sciencewise.info/media/pdf/{{ abs_meta.arxiv_id_v }}.pdf" title="Tagged PDF on ScienceWISE.info" class="abs-button">
+    <a href="http://sciencewise.info/media/pdf/{{ abs_meta.arxiv_id_v }}.pdf" title="Tagged PDF on ScienceWISE.info" class="abs-button tag-sciencewise">Tagged PDF</a>
+    <a href="http://sciencewise.info/media/pdf/{{ abs_meta.arxiv_id_v }}.pdf" title="Tagged PDF on ScienceWISE.info" class="abs-button tag-sciencewise">
       <img src="https://arxiv.org/icons/sciencewise75x32.png" height="16" width="38" alt="ScienceWISE" />
     </a>
     {%- endif -%}
@@ -58,22 +58,22 @@
   <div class="prevnext">
     {% if browse_context_previous_url -%}
     <span class="arrow">
-      <a class="abs-button" href="{{browse_context_previous_url }}"
+      <a class="abs-button prev-url" href="{{browse_context_previous_url }}"
          accesskey="p" title="previous in {{ browse_context }} (accesskey p)">&lt;&nbsp;prev</a>
     </span>
     <span class="is-hidden-mobile">&nbsp; | &nbsp;</span>
     {%- else -%}
-    <span class="nolink" class="abs-button">&lt;&nbsp;previous article</span>
+    <span class="nolink" class="abs-button prev-url">&lt;&nbsp;previous article</span>
     <span class="is-hidden-mobile">&nbsp; | &nbsp;</span>
     {% endif -%}
 
     {% if browse_context_next_url %}
     <span class="arrow">
-      <a class="abs-button" href="{{browse_context_next_url}}" accesskey="n"
+      <a class="abs-button next-url" href="{{browse_context_next_url}}" accesskey="n"
          title="next in {{ browse_context }} (accesskey n)">next&nbsp;&gt;</a>
     </span>
     {%- else -%}
-    <span class="abs-button" class="nolink">next article&nbsp;&gt;</span>
+    <span class="abs-button next-url" class="nolink">next article&nbsp;&gt;</span>
     {%- endif -%}
     <br/>
   </div>{#end div.prevnext#}
@@ -81,11 +81,11 @@
   {%- if browse_context != 'arxiv' -%}
   {#- This fixes a bug in the classic UI logic -#}
   <div class="list">
-    <a class="abs-button abs-button-grey abs-button-small" href="{{url_for('.list_articles',context=browse_context, subcontext='new')}}">new</a>
+    <a class="abs-button abs-button-grey abs-button-small context-new" href="{{url_for('.list_articles',context=browse_context, subcontext='new')}}">new</a>
     <span class="is-hidden-mobile"> | </span>
-    <a class="abs-button abs-button-grey abs-button-small" href="{{url_for('.list_articles',context=browse_context, subcontext='recent')}}">recent</a>
+    <a class="abs-button abs-button-grey abs-button-small context-recent" href="{{url_for('.list_articles',context=browse_context, subcontext='recent')}}">recent</a>
     <span class="is-hidden-mobile"> | </span>
-    <a class="abs-button abs-button-grey abs-button-small" href="{{url_for('.list_articles',context=browse_context, subcontext=abs_meta.arxiv_identifier.yymm)}}">
+    <a class="abs-button abs-button-grey abs-button-small context-id" href="{{url_for('.list_articles',context=browse_context, subcontext=abs_meta.arxiv_identifier.yymm)}}">
       {{- abs_meta.arxiv_identifier.yymm -}}</a>
   </div>
   {%- endif -%}
@@ -93,7 +93,7 @@
   {%- if not abs_meta.arxiv_identifier.is_old_id and (abs_meta.get_browse_context_list()|length > 1) -%}
   <div class="abs-switch-cat">
     Change to browse by:
-    <div class="switch">
+    <div class="switch context-change">
       {% for category in abs_meta.get_browse_context_list() if not (browse_context==category) %}
         {%- set switch_url = url_for('browse.abstract', arxiv_id=abs_meta.arxiv_identifier.id, context=category) -%}
         {% if '.' in category %}
@@ -192,14 +192,14 @@
       <ul>
         {% if include_inspire_link %}
         <li>
-          <a class="abs-button abs-button-small" href="https://inspirehep.net/literature?q=find%20eprint%20{{ abs_meta.arxiv_id }}">INSPIRE HEP</a><br/>
+          <a class="abs-button abs-button-small cite-inspire" href="https://inspirehep.net/literature?q=find%20eprint%20{{ abs_meta.arxiv_id }}">INSPIRE HEP</a><br/>
           <span class="inspire-links">(<a href="/refs/{{ abs_meta.arxiv_id }}">refers to</a> | <a href="/cits/{{ abs_meta.arxiv_id }}">cited by</a>)</span>
         </li>
         {% endif %}
-        <li><a  class="abs-button abs-button-small" href="https://ui.adsabs.harvard.edu/abs/arXiv:{{ abs_meta.arxiv_id|replace('/','%2F') }}">NASA ADS</a></li>
+        <li><a  class="abs-button abs-button-small cite-ads" href="https://ui.adsabs.harvard.edu/abs/arXiv:{{ abs_meta.arxiv_id|replace('/','%2F') }}">NASA ADS</a></li>
         {#- This was previously injected by Bibliographic Explorer -#}
-        <li><a  class="abs-button abs-button-small" href="https://scholar.google.com/scholar?q={{ abs_meta.title|urlencode }}.%20arXiv%20{{ abs_meta.get_datetime_of_version(version=0).year }}" target="_blank" rel="noopener">Google Scholar</a></li>
-        <li><a  class="abs-button abs-button-small" href="https://api.semanticscholar.org/arXiv:{{ abs_meta.arxiv_id }}" target="_blank" rel="noopener">Semantic Scholar</a></li>
+        <li><a  class="abs-button abs-button-small cite-google-scholar" href="https://scholar.google.com/scholar?q={{ abs_meta.title|urlencode }}.%20arXiv%20{{ abs_meta.get_datetime_of_version(version=0).year }}" target="_blank" rel="noopener">Google Scholar</a></li>
+        <li><a  class="abs-button abs-button-small cite-semantic-scholar" href="https://api.semanticscholar.org/arXiv:{{ abs_meta.arxiv_id }}" target="_blank" rel="noopener">Semantic Scholar</a></li>
       </ul>
       <div style="clear:both;"></div>
     </div>
@@ -207,7 +207,7 @@
     {% if trackback_ping_count and trackback_ping_count > 0 %}
     <div class="extra-general">
         <div class="what-is-this">
-            <h3><a  class="abs-button abs-button-grey abs-button-small" href="/tb/{{ abs_meta.arxiv_id }}"> {{ trackback_ping_count }} blog link{% if trackback_ping_count > 1 %}s{% endif %}</a></h3> (<a href="{{url_for('help_trackback')}}">what is this?</a>)
+            <h3><a  class="abs-button abs-button-grey abs-button-small trackback-link" href="/tb/{{ abs_meta.arxiv_id }}"> {{ trackback_ping_count }} blog link{% if trackback_ping_count > 1 %}s{% endif %}</a></h3> (<a href="{{url_for('help_trackback')}}" class="trackback-help">what is this?</a>)
         </div>
     </div>
     {% endif %}


### PR DESCRIPTION
No visual changes are included in this branch. It adds new unique classes to elements in the abs sidebar, and to the endorsers link in the main abs content area, so that the pendo tag manager can more precisely tag and track usage. 