### PR TITLE
News item about TeX updates on homepage

### DIFF
--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -2488,12 +2488,12 @@ body#front.with-cu-identity #header #search {
 
 
 /**** Pendo Guide Badge Styles - when you only want a badge/text note and no corresponding guide ****/
-.intro-and-news .bb-text {
+/* .intro-and-news .bb-text {
     text-align: left !important;
 }
 .intro-and-news .\_pendo-badge\_ {
   cursor: text !important;
-}
+} */
 
 
 /*icon styles*/

--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -2488,12 +2488,12 @@ body#front.with-cu-identity #header #search {
 
 
 /**** Pendo Guide Badge Styles - when you only want a badge/text note and no corresponding guide ****/
-/* .intro-and-news .bb-text {
+.intro-and-news .bb-text {
     text-align: left !important;
 }
 .intro-and-news .\_pendo-badge\_ {
   cursor: text !important;
-} */
+}
 
 
 /*icon styles*/

--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -2486,6 +2486,16 @@ body#front.with-cu-identity #header #search {
   }
 }
 
+
+/**** Pendo Guide Badge Styles - when you only want a badge/text note and no corresponding guide ****/
+.intro-and-news .bb-text {
+    text-align: left !important;
+}
+.intro-and-news .\_pendo-badge\_ {
+  cursor: text !important;
+}
+
+
 /*icon styles*/
 svg.icon {
   height: 1em !important;

--- a/browse/templates/home/home.html
+++ b/browse/templates/home/home.html
@@ -51,12 +51,14 @@
      },false);
     </script>
     <h4 class="homepage-news-title">News</h4>
+    <!-- special news section -->
+    {%- include "home/news.html" -%}
     See cumulative <a href="/new/">"What's New"</a> pages.
     Read <a href="/help/robots">robots beware</a> before attempting any automated download
   </div>
-  <!-- special news column -->
-  {%- include "home/news.html" -%}
-</div>
+  <!-- special message column -->
+  {%- include "home/special-message.html" -%}
+</div><!-- /end columns -->
 
 {#- TODO: define display order in taxonomy? -#}
 {{- group_section(('grp_physics','grp_math','grp_cs','grp_q-bio','grp_q-fin','grp_stat','grp_eess','grp_econ')) }}

--- a/browse/templates/home/home.html
+++ b/browse/templates/home/home.html
@@ -11,7 +11,7 @@
 {#- TODO: display order in taxonomy? -#}
 
 <div class="columns">
-  <div class="column">
+  <div class="column intro-and-news">
     <p class="tagline">arXiv is a free distribution service and an open-access archive for {% if document_count -%}{{ "{:,}".format(document_count) }}{%- endif %}
      scholarly articles in the fields of physics, mathematics, computer science, quantitative biology, quantitative finance, statistics, electrical engineering and systems science, and economics.
      Materials on this site are not peer-reviewed by arXiv.

--- a/browse/templates/home/home.html
+++ b/browse/templates/home/home.html
@@ -53,7 +53,7 @@
     <h4 class="homepage-news-title">News</h4>
     <!-- special news section -->
     {%- include "home/news.html" -%}
-    Read about recent news and updates on <a href="https://blog.arxiv.org/" target="_blank">arXiv's blog</a>. (The former "what's new" page is being phase out).
+    Read about recent news and updates on <a href="https://blog.arxiv.org/" target="_blank">arXiv's blog</a>. (View the former <a href="https://arxiv.org/new/">"what's new" pages</a> here).
     <br>
     Read <a href="/help/robots">robots beware</a> before attempting any automated download
   </div>

--- a/browse/templates/home/home.html
+++ b/browse/templates/home/home.html
@@ -53,7 +53,8 @@
     <h4 class="homepage-news-title">News</h4>
     <!-- special news section -->
     {%- include "home/news.html" -%}
-    See cumulative <a href="/new/">"What's New"</a> pages.
+    Read about recent news and updates on <a href="https://blog.arxiv.org/" target="_blank">arXiv's blog</a>. (The former "what's new" page is being phase out).
+    <br>
     Read <a href="/help/robots">robots beware</a> before attempting any automated download
   </div>
   <!-- special message column -->

--- a/browse/templates/home/home.html
+++ b/browse/templates/home/home.html
@@ -53,9 +53,9 @@
     <h4 class="homepage-news-title">News</h4>
     <!-- special news section -->
     {%- include "home/news.html" -%}
-    Read about recent news and updates on <a href="https://blog.arxiv.org/" target="_blank">arXiv's blog</a>. (View the former <a href="https://arxiv.org/new/">"what's new" pages</a> here).
-    <br>
-    Read <a href="/help/robots">robots beware</a> before attempting any automated download
+    Read about recent news and updates on <a href="https://blog.arxiv.org/" target="_blank">arXiv's blog</a>.
+    (View the former <a href="https://arxiv.org/new/">"what's new" pages</a> here).
+    Read <a href="/help/robots">robots beware</a> before attempting any automated download.
   </div>
   <!-- special message column -->
   {%- include "home/special-message.html" -%}

--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -2,8 +2,8 @@
 {%- set rd_int = request_datetime.strftime("%Y%m%d%H%M")|int -%}
 
 {%- if rd_int >= 202009010100 and rd_int <= 202010141159 -%}
-Starting at 8am EDT on October 1, 2020, arXiv will process new submissions and replacements with TeX Live 2020.
-<br>
+Starting at 8am EDT on October 1, 2020, arXiv will process new submissions and replacements with TeX Live 2020. <a href="https://blogs.cornell.edu/arxiv/2020/09/24/tex-live-2020-release-oct-1-2020/" target="_blank">Learn more</a>.
+<br><br>
 {%- endif -%}
 
 <!-- annual giving message -->

--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -1,8 +1,12 @@
 {#- News items appear below the subject search. Generally there should be no more than four items. -#}
 {%- set rd_int = request_datetime.strftime("%Y%m%d%H%M")|int -%}
 
-{%- if rd_int >= 202009010100 and rd_int <= 202010141159 -%}
+{%- if rd_int >= 202009010100 and rd_int <= 202010010755 -%}
 Starting at 8am EDT on October 1, 2020, arXiv will process new submissions and replacements with TeX Live 2020. <a href="https://blogs.cornell.edu/arxiv/2020/09/24/tex-live-2020-release-oct-1-2020/" target="_blank">Learn more</a>.
+<br><br>
+{%- endif -%}
+{%- if rd_int >= 202010010756 and rd_int <= 202011300100 -%}
+arXiv now processes new submissions and replacements with TeX Live 2020. <a href="https://blogs.cornell.edu/arxiv/2020/09/24/tex-live-2020-release-oct-1-2020/" target="_blank">Learn more</a>.
 <br><br>
 {%- endif -%}
 

--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -1,18 +1,9 @@
-{#- News blurbs appear at the top of the home page. Generally there should be no more than four items. -#}
+{#- News items appear below the subject search. Generally there should be no more than four items. -#}
 {%- set rd_int = request_datetime.strftime("%Y%m%d%H%M")|int -%}
-{%- if rd_int >= 202003300900 -%}
-<div class="message-special column">
-  <span class="label">COVID-19 Quick Links</span>
-  <p>See COVID-19 SARS-CoV-2 preprints from</p>
-  <ul>
-    <li><a href="https://arxiv.org/covid19search" title="COVID-19 SARS-CoV-2 preprints from arXiv">arXiv</a></li>
-    <li><a target="_blank" href="https://connect.biorxiv.org/relate/content/181" title="COVID-19 SARS-CoV-2 preprints from medRxiv and bioRxiv">medRxiv and bioRxiv</a></li>
-  </ul>
-  <p><em>Important:</em> e-prints posted on arXiv are not peer-reviewed by arXiv; they should not be relied upon without context to guide clinical practice or health-related behavior and should not be reported in news media as established information without consulting multiple experts in the field.</p>
-</div>
-{% else %}
-16 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/16/arxiv-announces-its-first-executive-director/">arXiv announces its first executive director</a><br/>
-12 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/12/arxiv-responds-to-covid-19-uncertainties/">arXiv responds to COVID-19 uncertainties</a><br/>
+
+{%- if rd_int >= 2019092300 and rd_int <= 20201014700 -%}
+Starting at 8am EDT on October 1, 2020, arXiv will process new submissions and replacements with TeX Live 2020.
+<br>
 {%- endif -%}
 
 <!-- annual giving message -->

--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -1,7 +1,7 @@
 {#- News items appear below the subject search. Generally there should be no more than four items. -#}
 {%- set rd_int = request_datetime.strftime("%Y%m%d%H%M")|int -%}
 
-{%- if rd_int >= 2019092300 and rd_int <= 20201014700 -%}
+{%- if rd_int >= 202009010100 and rd_int <= 202010141159 -%}
 Starting at 8am EDT on October 1, 2020, arXiv will process new submissions and replacements with TeX Live 2020.
 <br>
 {%- endif -%}

--- a/browse/templates/home/special-message.html
+++ b/browse/templates/home/special-message.html
@@ -1,0 +1,22 @@
+{#- Special messages appear in a column to the side of the website intro/news section, each in their own column. Always apply the style "message-special" to the column. You can also apply the style "dark" to override the red styles and add a message with a black background instead. There should never preferably be just one, and never more than two. -#}
+{%- set rd_int = request_datetime.strftime("%Y%m%d%H%M")|int -%}
+
+{%- if rd_int >= 202003300900 -%}
+<div class="message-special column">
+  <span class="label">COVID-19 Quick Links</span>
+  <p>See COVID-19 SARS-CoV-2 preprints from</p>
+  <ul>
+    <li><a href="https://arxiv.org/covid19search" title="COVID-19 SARS-CoV-2 preprints from arXiv">arXiv</a></li>
+    <li><a target="_blank" href="https://connect.biorxiv.org/relate/content/181" title="COVID-19 SARS-CoV-2 preprints from medRxiv and bioRxiv">medRxiv and bioRxiv</a></li>
+  </ul>
+  <p><em>Important:</em> e-prints posted on arXiv are not peer-reviewed by arXiv; they should not be relied upon without context to guide clinical practice or health-related behavior and should not be reported in news media as established information without consulting multiple experts in the field.</p>
+</div>
+{% else %}
+16 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/16/arxiv-announces-its-first-executive-director/">arXiv announces its first executive director</a><br/>
+12 Mar 2020: <a href="https://blogs.cornell.edu/arxiv/2020/03/12/arxiv-responds-to-covid-19-uncertainties/">arXiv responds to COVID-19 uncertainties</a><br/>
+{%- endif -%}
+
+<!-- annual giving message -->
+{%- if rd_int >= 2019092300 and rd_int <= 2019092700 -%}
+23 Sep 2019: Our giving campaign is this week. <a href="https://blogs.cornell.edu/arxiv/2019/09/19/donate-to-arxiv-4/">Support arXiv with a donation!</a><br/>
+{%- endif -%}


### PR DESCRIPTION
This branch adds a news item to the homepage about the TeX live update.

This is the message that will display up until 7:55am on Oct. 1:
![Screen Shot 2020-09-24 at 4 31 54 PM](https://user-images.githubusercontent.com/56078140/94197327-a293fd80-fe83-11ea-8270-756c3d9e94c6.png)

After that date/time passes and up until the end of Nov. the news section will display this message:
![Screen Shot 2020-09-24 at 4 43 55 PM](https://user-images.githubusercontent.com/56078140/94198361-2ac6d280-fe85-11ea-8964-248bfef8678e.png)

(informational aside: the original plan was to add this blurb with Pendo only but I learned that they have very limited options for inline text injection. Their guides are intended to float on top of existing content as a new layer, or be a full width badge at the top or bottom of the page. I can inject a 'badge' but it requires special css tweaks that target the unique pendo badge ID, which means pushing an edit to our servers anyway. It also launches a guide when clicked, though I can make that guide invisible, but it still feels hacky. I will experiment with that further but for now we can add this news via this branch instead.)