### PR TITLE
Add Plaudit endorsements for articles with a DOI

### DIFF
--- a/browse/static/js/plaudit.js
+++ b/browse/static/js/plaudit.js
@@ -1,0 +1,7 @@
+(function () {
+  $output = $('#plauditContainer');
+  const embedTag = document.createElement('script');
+  embedTag.dataset.embedderId = "arxiv";
+  embedTag.src = 'https://plaudit.pub/embed/endorsements.js';
+  $output.append(embedTag);
+})();

--- a/browse/static/js/toggle-labs.js
+++ b/browse/static/js/toggle-labs.js
@@ -12,7 +12,8 @@ $(document).ready(function() {
   };
 
   var scripts = {
-    "paperwithcode": $('#paperwithcode-toggle').data('script-url'),
+      "paperwithcode": $('#paperwithcode-toggle').data('script-url'),
+      "plaudit": $('#plaudit-toggle').data('script-url'),
       "bibex": {
           "url": "/bibex/bibex.js?20200709",
           "container": "#bib-main"
@@ -56,6 +57,10 @@ $(document).ready(function() {
           $.cachedScript(scripts["core-recommender"]["url"]).done(function(script, textStatus) {
             console.log(textStatus);
           });
+        } else if (key == "plaudit-toggle") {
+          $.cachedScript(scripts["plaudit"]).done(function(script, textStatus) {
+            console.log(textStatus);
+          });
         } else if (key === "paperwithcode-toggle") {
           $.cachedScript(scripts["paperwithcode"]).done(function(script, textStatus) {
             console.log(textStatus);
@@ -92,6 +97,8 @@ $(document).ready(function() {
       }
     } else if ($(this).attr("id") == "core-recommender-toggle" && $(this).hasClass("enabled") ) {
         $.cachedScript(scripts["core-recommender"]["url"]).done(function(script, textStatus) {});
+    } else if ($(this).attr("id") == "plaudit-toggle") {
+        $.cachedScript(scripts["plaudit"]).done(function(script, textStatus) {});
     } else if ($(this).attr("id") == "paperwithcode-toggle") {
       $.cachedScript(scripts["paperwithcode"]).done(function(script, textStatus) {
         console.log(textStatus);

--- a/browse/templates/abs/labs_tabs.html
+++ b/browse/templates/abs/labs_tabs.html
@@ -88,6 +88,31 @@
       </div>
       <div id="coreRecommenderOutput"></div>
     </div>
+    {%- if abs_meta.doi -%}
+    <input type="radio" name="tabs" id="tabfive">
+    <label for="tabfive">Endorsements</label>
+    <div class="tab">
+      <h1>Endorsements</h1>
+      <div class="toggle">
+        <div class="columns is-mobile lab-row">
+          <div class="column lab-switch">
+            <label class="switch">
+              <input
+                id="plaudit-toggle"
+                data-script-url="{{ url_for('static', filename='js/plaudit.js') }}"
+                type="checkbox" class="lab-toggle" aria-labelledby="label-for-plaudit">
+              <span class="slider"></span>
+              <span class="is-sr-only">Plaudit endorsements toggle</span>
+            </label>
+          </div>
+          <div class="column lab-name">
+            <span id="label-for-plaudit">Plaudit endorsements</span> <em>(<a href="https://labs.arxiv.org/">What is Plaudit?</a>)</em>
+          </div>
+        </div>
+      </div>
+      <div id="plauditContainer"></div>
+    </div>
+    {% endif %}
 
   </div>
 </div>


### PR DESCRIPTION
This PR accompanies my email proposing integrating Plaudit as an arXiv Labs project. I realise that I did not create an issue first, but I did not spend too much time on this and will not be insulted if this PR is closed or needs to be redone from scratch :)

[Plaudit](https://plaudit.pub) is an endorsement system already used by e.g. the Open Science Framework. It highlights endorsements of a work in the context of that work, and allows academics to add their own endorsements. It is [an open source project](https://gitlab.com/Flockademic/plaudit/), and all endorsement data is available as Open Data via CrossRef Event Data.

This PR adds a fifth tab to the arXiv Labs Panel that allows people to enable the Plaudit widget. It will only be shown for articles that have a DOI. To see what the Plaudit widget looks like in a production environment, see e.g. https://psyarxiv.com/5tcwd/

This is what it looks like on arXiv:

![image](https://user-images.githubusercontent.com/4251/97039847-5d8be580-156d-11eb-8a31-2afcc0852e7b.png)

To try this out with a Plaudit sandbox, replace

    https://plaudit.pub/embed/endorsements.js

with

    https://arxiv-review.plaudit.pub/embed/endorsements.js

in `browse/static/js/plaudit.js`. (Note that the review environment will shut down if it does not receive requests. To wake it up, visit https://arxiv-review.plaudit.pub/.)

The embed will only be allowed on `https://arxiv.org` and `https://beta.arxiv.org`.

Let me know what you think.