### PR TITLE
This fixes etag quotes and a couple other things

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -308,7 +308,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=116
 
 # Maximum number of lines in a module
 max-module-lines=1000

--- a/browse/services/util/response_headers.py
+++ b/browse/services/util/response_headers.py
@@ -1,6 +1,6 @@
 """Response header utility functions."""
 from datetime import datetime, timedelta, timezone
-from typing import Tuple
+from typing import Tuple, Optional
 from dateutil.tz import tzutc, gettz
 
 
@@ -12,11 +12,16 @@ PUBLISH_ISO_WEEKDAYS = [1, 2, 3, 4, 7]
 """Days of the week publish happens: Sunday-Thursday."""
 
 
-def guess_next_update_utc(dt: datetime = datetime.now(timezone.utc)) \
-        -> Tuple[datetime, bool]:
+def guess_next_update_utc(dt: Optional[datetime] = None) -> Tuple[datetime, bool]:
     """Make a sensible guess at earliest possible datetime of next update.
 
     Guess is based on provided datetime.
+
+    This is function will be needed by several services that are
+    outside of arxiv-browse. In the legacy system having this logic
+    redundently implemented lead to difficult to debug problems. Move
+    this to a common library like arxiv-base or make it a service
+    offered by arxiv-publish.
 
     Parameters
     ----------
@@ -31,7 +36,10 @@ def guess_next_update_utc(dt: datetime = datetime.now(timezone.utc)) \
         whether the provided dt is likely to coincide with a publish process,
         which is the APPROX_PUBLISH_DURATION window starting 20:00 on the
         normal publish days specified by PUBLISH_ISO_WEEKDAYS.
+
     """
+    if dt is None:
+        dt = datetime.now(timezone.utc)
     config = get_application_config()
     tz = gettz(config.get('ARXIV_BUSINESS_TZ', 'US/Eastern'))
     dt = dt.astimezone(tz=tz)

--- a/tests/test_304.py
+++ b/tests/test_304.py
@@ -1,12 +1,18 @@
+"""Test"""
+
 import unittest
-from dateutil import parser
 from datetime import timedelta
+from dateutil import parser
+
 
 from browse.services.util.response_headers import mime_header_date
 
 from app import app
 
-class ListPageTest(unittest.TestCase):
+
+class ModifiedTest(unittest.TestCase):
+    """Test when page is modified and not modified for 200 and 304"""
+
     def setUp(self):
         app.testing = True
         app.config['APPLICATION_ROOT'] = ''
@@ -14,13 +20,14 @@ class ListPageTest(unittest.TestCase):
         self.client = app.test_client()
 
     def test_modified(self):
+        """Test"""
         with self.app.app_context():
             rv = self.client.get('/abs/0704.0600')
             self.assertEqual(rv.status_code, 200)
 
             last_mod = rv.headers['Last-Modified']
             etag = rv.headers['ETag']
-            
+
             rv = self.client.get('/abs/0704.0600',
                                  headers={'If-Modified-Since': last_mod})
             self.assertEqual(rv.status_code, 304)
@@ -54,6 +61,7 @@ class ListPageTest(unittest.TestCase):
             self.assertEqual(rv.status_code, 304)
 
     def test_not_modified(self):
+        """Test when pages is not modified"""
         with self.app.app_context():
             rv = self.client.get('/abs/0704.0600')
             self.assertEqual(rv.status_code, 200)
@@ -61,13 +69,12 @@ class ListPageTest(unittest.TestCase):
             mod_dt = parser.parse(rv.headers['Last-Modified'])
 
             rv = self.client.get('/abs/0704.0600',
-                                 headers={'If-Modified-Since': mime_header_date(mod_dt )})
+                                 headers={'If-Modified-Since': mime_header_date(mod_dt)})
             self.assertEqual(rv.status_code, 304)
 
             rv = self.client.get('/abs/0704.0600',
                                  headers={'If-Modified-Since': mime_header_date(mod_dt + timedelta(seconds=-1))})
             self.assertEqual(rv.status_code, 200)
-
 
             rv = self.client.get('/abs/0704.0600',
                                  headers={'If-None-Match': '"should-never-match"'})

--- a/tests/test_304.py
+++ b/tests/test_304.py
@@ -1,4 +1,8 @@
 import unittest
+from dateutil import parser
+from datetime import timedelta
+
+from browse.services.util.response_headers import mime_header_date
 
 from app import app
 
@@ -9,13 +13,14 @@ class ListPageTest(unittest.TestCase):
         self.app = app
         self.client = app.test_client()
 
-    def test_not_modified(self):
+    def test_modified(self):
         with self.app.app_context():
             rv = self.client.get('/abs/0704.0600')
             self.assertEqual(rv.status_code, 200)
 
             last_mod = rv.headers['Last-Modified']
             etag = rv.headers['ETag']
+            
             rv = self.client.get('/abs/0704.0600',
                                  headers={'If-Modified-Since': last_mod})
             self.assertEqual(rv.status_code, 304)
@@ -47,4 +52,23 @@ class ListPageTest(unittest.TestCase):
             rv = self.client.get('/abs/0704.0600',
                                  headers={'iF-NoNE-MaTCH': etag})
             self.assertEqual(rv.status_code, 304)
-            
+
+    def test_not_modified(self):
+        with self.app.app_context():
+            rv = self.client.get('/abs/0704.0600')
+            self.assertEqual(rv.status_code, 200)
+
+            mod_dt = parser.parse(rv.headers['Last-Modified'])
+
+            rv = self.client.get('/abs/0704.0600',
+                                 headers={'If-Modified-Since': mime_header_date(mod_dt )})
+            self.assertEqual(rv.status_code, 304)
+
+            rv = self.client.get('/abs/0704.0600',
+                                 headers={'If-Modified-Since': mime_header_date(mod_dt + timedelta(seconds=-1))})
+            self.assertEqual(rv.status_code, 200)
+
+
+            rv = self.client.get('/abs/0704.0600',
+                                 headers={'If-None-Match': '"should-never-match"'})
+            self.assertEqual(rv.status_code, 200)

--- a/tests/test_304.py
+++ b/tests/test_304.py
@@ -1,0 +1,50 @@
+import unittest
+
+from app import app
+
+class ListPageTest(unittest.TestCase):
+    def setUp(self):
+        app.testing = True
+        app.config['APPLICATION_ROOT'] = ''
+        self.app = app
+        self.client = app.test_client()
+
+    def test_not_modified(self):
+        with self.app.app_context():
+            rv = self.client.get('/abs/0704.0600')
+            self.assertEqual(rv.status_code, 200)
+
+            last_mod = rv.headers['Last-Modified']
+            etag = rv.headers['ETag']
+            rv = self.client.get('/abs/0704.0600',
+                                 headers={'If-Modified-Since': last_mod})
+            self.assertEqual(rv.status_code, 304)
+
+            rv = self.client.get('/abs/0704.0600',
+                                 headers={'if-modified-since': last_mod})
+            self.assertEqual(rv.status_code, 304)
+
+            rv = self.client.get('/abs/0704.0600',
+                                 headers={'IF-MODIFIED-SINCE': last_mod})
+            self.assertEqual(rv.status_code, 304)
+
+            rv = self.client.get('/abs/0704.0600',
+                                 headers={'If-ModiFIED-SiNCE': last_mod})
+            self.assertEqual(rv.status_code, 304)
+
+            rv = self.client.get('/abs/0704.0600',
+                                 headers={'If-None-Match': etag})
+            self.assertEqual(rv.status_code, 304)
+
+            rv = self.client.get('/abs/0704.0600',
+                                 headers={'if-none-match': etag})
+            self.assertEqual(rv.status_code, 304)
+
+            rv = self.client.get('/abs/0704.0600',
+                                 headers={'IF-NONE-MATCH': etag})
+            self.assertEqual(rv.status_code, 304)
+
+            rv = self.client.get('/abs/0704.0600',
+                                 headers={'iF-NoNE-MaTCH': etag})
+            self.assertEqual(rv.status_code, 304)
+            


### PR DESCRIPTION
This fixes etag handling and last-modified time handling.

It also gets the request headers for these in a case insensitive way.

Jim and I were hoping that this would fix people needing to refresh to get updated papers. The refresh would be intended to get around the sever returning a 304 Not-Modified. But this bug was causing the server to always 200 (Ok) and never 304 (Not modified).  