### PR TITLE
Small style fixes for the "Code & Data" tab

### DIFF
--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -836,27 +836,39 @@ p.tagline {
 #pwc-output > h3 {
     margin-top: 25px;
 }
-.pwc-icon {
+#pwc-output .pwc-icon {
     width: 23px;
     height: 23px;
     position: relative;
     top: 5px;
-    margin-right: 5px;
+    margin-left: 3px;
+    margin-right: 6px;
 }
 
-.pwc-icon-primary {
+#pwc-output .pwc-icon-primary {
     top: 6px;
+    margin-left: 3px;
 }
 
-.pwc-avatar-box {
+#pwc-output .pwc-avatar-box {
     display: inline-block;
 }
+
+#pwc-output h3.pwc-community-nocode {
+  margin-bottom: 8px;
+}
+
+#pwc-output h3.pwc-community-code {
+  margin-bottom: 15px;
+}
+
 
 /* Papers with Code **Datasets** specific section */
 
 #pwc-data-output {
     padding: 7px;
     margin-bottom: 10px;
+    margin-top: 20px;
 }
 
 #labstabs #pwc-data-output > p.pwc-provided {

--- a/browse/static/js/paperswithcode.js
+++ b/browse/static/js/paperswithcode.js
@@ -64,20 +64,19 @@
         .append(link);
     }
 
-    $output.append('<h3>Community Code</h3>');
-
     if (data.unofficial_count === 0) {
+      $output.append('<h3 class="pwc-community-nocode">Community Code</h3>');
       let link = $(`<a target="_blank">${icons.pwc}Papers With Code</a>`);
       link.attr('href', data.paper_url);
       $output
         .append('Submit your implementations of this paper on ')
         .append(link);
     } else {
+      $output.append('<h3 class="pwc-community-code">Community Code</h3>');
       let link = $('<a class="pwc-code-link" target="_blank"></a>');
       link.attr('href', data.paper_url + '#code');
       link
         .append(icons.pwc)
-        .append(' ')
         .append(document.createTextNode(data.unofficial_count))
         .append(` code implementation${data.unofficial_count > 1 ? 's': ''}`);
 
@@ -200,7 +199,7 @@
       return;
     }
 
-    $output.append('<h3>Datasets</h3>');
+    $output.append('<h3>Datasets Used</h3>');
 
     // If there is nothing just put a simple message
     if (data.introduced.length === 0 && data.mentioned.length === 0) {


### PR DESCRIPTION
A couple of small fixes for spacing consistency for the Code and Data sections. 