### PR TITLE
Use anchors for calls on contribution on Code & Data tab

### DIFF
--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -855,7 +855,7 @@ p.tagline {
 }
 
 #pwc-output h3.pwc-community-nocode {
-  margin-bottom: 8px;
+  margin-bottom: 15px;
 }
 
 #pwc-output h3.pwc-community-code {

--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -855,7 +855,7 @@ p.tagline {
 }
 
 #pwc-output h3.pwc-community-nocode {
-  margin-bottom: 15px;
+  margin-bottom: 8px;
 }
 
 #pwc-output h3.pwc-community-code {

--- a/browse/static/js/paperswithcode.js
+++ b/browse/static/js/paperswithcode.js
@@ -67,7 +67,7 @@
     if (data.unofficial_count === 0) {
       $output.append('<h3 class="pwc-community-nocode">Community Code</h3>');
       let link = $(`<a target="_blank">${icons.pwc}Papers With Code</a>`);
-      link.attr('href', data.paper_url);
+      link.attr('href', data.paper_url + "#code");
       $output
         .append('Submit your implementations of this paper on ')
         .append(link);
@@ -204,7 +204,7 @@
     // If there is nothing just put a simple message
     if (data.introduced.length === 0 && data.mentioned.length === 0) {
       let link = $('<a target="_blank">link datasets here</a>');
-      link.attr('href', data.paper_url);
+      link.attr('href', data.paper_url + "#datasets");
       let p = $('<span>');
       p.append('No dataset metadata found, you can ')
        .append(link)


### PR DESCRIPTION
Small fix to use anchors because we can now how two separate calls for contribution (for code and data)