### PR TITLE
Add timestamp to clear cache for Papers with Code widget

### DIFF
--- a/browse/static/js/toggle-labs.js
+++ b/browse/static/js/toggle-labs.js
@@ -12,7 +12,7 @@ $(document).ready(function() {
   };
 
   var scripts = {
-    "paperwithcode": $('#paperwithcode-toggle').data('script-url'),
+    "paperwithcode": $('#paperwithcode-toggle').data('script-url') + "?20210513",
     "connectedpapers": $('#connectedpapers-toggle').data('script-url'),
     "bibex": {
       "url": "https://static.arxiv.org/js/bibex/bibex.js?20210223",


### PR DESCRIPTION
I couldn't add it to the `script-url` element because it escapes `?` and didn't want to disable that. 