### PR TITLE
Bump toggle-labs.js version

### DIFF
--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -14,7 +14,7 @@
   {#  <link rel="stylesheet" type="text/css" media="screen" href="{{ url_for('static', filename='css/paperwithcode.css') }}" /> #}
   <script src="//code.jquery.com/jquery-latest.min.js" type="text/javascript"></script>
   <script src="//cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js" type="text/javascript"></script>
-  <script src="{{ url_for('static', filename='js/toggle-labs.js') }}?20210513" type="text/javascript"></script>
+  <script src="{{ url_for('static', filename='js/toggle-labs.js') }}?20210728" type="text/javascript"></script>
   <script src="{{ url_for('static', filename='js/cite.js') }}" type="text/javascript"></script>
   {%- endif %}
   {%- include "feedback_collector_js.html" -%}


### PR DESCRIPTION
A small update related to #234 that I forgot to do yesterday. Bumps up toggle-labs version to force reloading of the cached script.