### PR TITLE
add scite.ai Smart Citations badge to  bibliographic tools in arxiv labs

### DIFF
--- a/browse/static/js/scite.css
+++ b/browse/static/js/scite.css
@@ -1,0 +1,19 @@
+.scite-no-doi {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: flex-start;
+    max-width: 300px;
+}
+.scite-tally-logo {
+    width: 100px;
+}
+.scite-no-doi-header {
+    margin-bottom: 0;
+}
+.scite-no-doi-explainer {
+    font-family: sans-serif;
+    color: #1D1E20;
+    font-weight: 500;
+    font-size: 12px;
+}

--- a/browse/static/js/scite.js
+++ b/browse/static/js/scite.js
@@ -1,0 +1,43 @@
+(function () {
+    const metadoi = document.head.querySelector(`[name="citation_doi"]`);
+    const doi = metadoi ? metadoi.content : '';
+
+    const scriptPath = document.getElementById('scite-toggle').attributes["data-script-url"].value;
+    const scriptDir = scriptPath.substr(0, scriptPath.lastIndexOf('/'));
+    const cssTag = `<link rel="stylesheet" type="text/css" href="${scriptDir}/scite.css"/>`;
+
+    const $output = $('#scite-open-in');
+    if ($output.html() != '') {
+        // Toggled off
+        $output.html('');
+        return;
+    }
+
+    if (doi) {
+        $output.html(cssTag + `
+            <div
+                class="scite-badge"
+                data-doi="${doi}"
+                data-layout="vertical"
+                data-show-zero="false"
+                data-small="false"
+                data-show-labels="true"
+                data-campaign="arxiv"
+            >
+            </div>
+            <script async type="application/javascript" src="https://cdn.scite.ai/badge/scite-badge-latest.min.js"></script>
+        `);
+        return;
+    }
+
+    $output.html(cssTag + `
+        <div class="scite-no-doi">
+            <img class="scite-tally-logo" width="100px" src="https://cdn.scite.ai/assets/images/logo.svg">
+            <h3 class="scite-no-doi-header">No DOI found</h3>
+            <p class="scite-no-doi-explainer">
+                scite only processes publications with a DOI and there is no DOI available for this paper. Please check back when a DOI is available.
+                In the meantime, here is an example of what scite Smart Citations look like: <a href="https://scite.ai/reports/association-between-amygdala-hyperactivity-to-gVamGz?utm_campaign=arxiv" rel="noopener" target="_blank">Example Report</a></p></div>
+            </p>
+        <div>
+    `);
+})();

--- a/browse/static/js/toggle-labs.js
+++ b/browse/static/js/toggle-labs.js
@@ -14,6 +14,7 @@ $(document).ready(function() {
   var scripts = {
     "paperwithcode": $('#paperwithcode-toggle').data('script-url') + "?20210727",
     "litmaps": $('#litmaps-toggle').data('script-url'),
+    "scite": $('#scite-toggle').data('script-url'),
     "connectedpapers": $('#connectedpapers-toggle').data('script-url'),
     "bibex": {
       "url": "https://static.arxiv.org/js/bibex/bibex.js?20210223",
@@ -43,6 +44,10 @@ $(document).ready(function() {
           });
         } else if (key == "litmaps-toggle") {
           $.cachedScript(scripts["litmaps"]).done(function(script, textStatus) {
+            console.log(textStatus);
+          });
+        } else if (key == "scite-toggle") {
+          $.cachedScript(scripts["scite"]).done(function(script, textStatus) {
             console.log(textStatus);
           });
         } else if (key == "core-recommender-toggle") {
@@ -106,6 +111,10 @@ $(document).ready(function() {
       }
     } else if ($(this).attr("id") == "litmaps-toggle") {
       $.cachedScript(scripts["litmaps"]).done(function(script, textStatus) {
+        console.log(textStatus);
+      });
+    } else if ($(this).attr("id") == "scite-toggle") {
+      $.cachedScript(scripts["scite"]).done(function(script, textStatus) {
         console.log(textStatus);
       });
     } else if ($(this).attr("id") == "core-recommender-toggle" && $(this).hasClass("enabled")) {

--- a/browse/templates/abs/labs_tabs.html
+++ b/browse/templates/abs/labs_tabs.html
@@ -51,9 +51,27 @@
           </div>
         </div>
         {% endif %}
+        <div class="columns is-mobile lab-row">
+          <div class="column lab-switch">
+            <label class="switch">
+              <input
+                id="scite-toggle"
+                type="checkbox"
+                class="lab-toggle"
+                data-script-url="{{ url_for('static', filename='js/scite.js') }}?20210617"
+                aria-labelledby="label-for-scite">
+              <span class="slider"></span>
+              <span class="is-sr-only">scite.ai Toggle</span>
+            </label>
+          </div>
+          <div class="column lab-name">
+            <span id="label-for-scite">scite Smart Citations</span> <em>(<a href="https://www.scite.ai/" target="_blank">What are Smart Citations?</a>)</em>
+          </div>
+        </div>
       </div>
         <div class="labs-content-placeholder labs-display" style="display: none;"></div>
         <div style="min-height: 15px" id="litmaps-open-in"></div>
+        <div style="min-height: 15px" id="scite-open-in"></div>
     </div>
 
 


### PR DESCRIPTION
# Change

Add scite.ai Smart Citations badge to bibliographic tools in arXiv labs based on the approved proposal for arXiv labs.

Please note: scite.ai currently only supports publications with DOIs. Here we leverage, like the cite.js plugin the meta tag containing a DOI where it exists.

cc @mhl10

## Demo

**With DOI**

![scite-arxiv](https://user-images.githubusercontent.com/15069938/129602168-ca48d0c8-ba94-4a5a-98d3-ada1d7ff7c57.gif)

**Without DOI**

<img width="361" alt="Screen Shot 2021-08-16 at 2 07 17 PM" src="https://user-images.githubusercontent.com/15069938/129602226-9771150d-9e5a-4809-8210-3b73d6f1e289.png">



