### PR TITLE
ensure scite badge uses right aligned tooltip placement

### DIFF
--- a/browse/static/js/scite.js
+++ b/browse/static/js/scite.js
@@ -23,6 +23,7 @@
                 data-small="false"
                 data-show-labels="true"
                 data-campaign="arxiv"
+                data-tooltip-placement="right"
             >
             </div>
             <script async type="application/javascript" src="https://cdn.scite.ai/badge/scite-badge-latest.min.js"></script>


### PR DESCRIPTION
# Change

Use the tooltip placement attribute to ensure the scite badge is right-aligned. In this way the stacking and overlap issues are mitigated.

<img width="608" alt="Screen Shot 2021-08-25 at 1 10 28 PM" src="https://user-images.githubusercontent.com/15069938/130826385-7b826be6-5c44-4bdd-be8a-98694168a30f.png">

cc 👁️  @mhl10 