### PR TITLE
ARXIVNG-4640: update banner for Fall 2021 giving week

### DIFF
--- a/browse/templates/user_banner.html
+++ b/browse/templates/user_banner.html
@@ -11,7 +11,7 @@
   </div>
   <div class="amount-donation">
     <div class="wrapper">
-      <div class="donate-cta"><a class="banner_link" href="https://bit.ly/arXivDONATE1"><b>DONATE</b></a>
+      <div class="donate-cta"><a class="banner_link" href="https://bit.ly/arXivDONATEa"><b>DONATE</b></a>
         <p>[secure site, no need to create account]</p>
       </div>
     </div>


### PR DESCRIPTION
Hi @afromme, @SBBCornell,

Please ignore this PR until tomorrow (Monday) :-) 

The Fall 2021 giving campaign kicks off tomorrow. Since we no longer have Pendo, we can use the banner template from arxiv-browse. Below screenshot shows the banner with the same wording that will be used in the emails:

<img width="1005" alt="Screen Shot 2021-10-24 at 1 02 25 PM" src="https://user-images.githubusercontent.com/746253/138604829-5acf1f0f-2195-4f9a-82d1-41af69341c14.png">
