### PR TITLE
post-giving week banner and news

### DIFF
--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -6,17 +6,15 @@
 Celebrating <a href="https://blog.arxiv.org/2021/08/13/celebrating-arxivs-30th-anniversary/" target="_blank">arXiv's 30th anniversary!</a> 1991-2021.
 <br><br>
 {%- endif -%}
+
+<!-- annual post-giving-week message -->
+{%- if rd_int >= 202111010100 and rd_int <= 202111072359 -%}
+A big thank you for donating to arXiv during International Open Access Week, October 25th-31st. It's not too late to show your support. <a href="https://bit.ly/arXivDONATEa" target="_blank">Donate to arXiv here</a>.
+<br><br>
+{%- endif -%}
+
+<!-- annual giving-week message -->
 {%- if rd_int >= 202110240100 and rd_int <= 202110312359 -%}
 Show your support for Open Science by <a href="https://bit.ly/arXivDONATEa" target="_blank">donating to arXiv</a> during International Open Access Week, October 25th-31st.
 <br><br>
-{%- endif -%}
-
-{%- if rd_int >= 202010010756 and rd_int <= 202011300100 -%}
-arXiv now processes new submissions and replacements with TeX Live 2020. <a href="https://blogs.cornell.edu/arxiv/2020/09/24/tex-live-2020-release-oct-1-2020/" target="_blank">Learn more</a>.
-<br><br>
-{%- endif -%}
-
-<!-- annual giving message -->
-{%- if rd_int >= 2019092300 and rd_int <= 2019092700 -%}
-23 Sep 2019: Our giving campaign is this week. <a href="https://blogs.cornell.edu/arxiv/2019/09/19/donate-to-arxiv-4/">Support arXiv with a donation!</a><br/>
 {%- endif -%}

--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -9,7 +9,7 @@ Celebrating <a href="https://blog.arxiv.org/2021/08/13/celebrating-arxivs-30th-a
 
 <!-- annual post-giving-week message -->
 {%- if rd_int >= 202111010100 and rd_int <= 202111072359 -%}
-A big thank you for donating to arXiv during International Open Access Week, October 25th-31st. It's not too late to show your support. <a href="https://bit.ly/arXivDONATEa" target="_blank">Donate to arXiv here</a>.
+A big thank you for donating to arXiv during International Open Access Week. It's not too late to show your support. <a href="https://bit.ly/arXivDONATEa" target="_blank">Donate to arXiv here</a>.
 <br><br>
 {%- endif -%}
 

--- a/browse/templates/user_banner.html
+++ b/browse/templates/user_banner.html
@@ -2,11 +2,10 @@
 <aside class="slider-wrapper" style="display:none">
   <a class="close-slider" href="#"><img src="{{ url_for('static', filename='images/icons/close-slider.png') }}" alt="close this message"></a>
   <div class="copy-donation">
-    <h1>Donate to arXiv</h1>
+    <h1>Thank you for supporting arXiv</h1>
     <p>
-      arXiv is a nonprofit that depends on donations to fund essential operations and new initiatives. 
-      If you are able, <b>please consider donating</b> during arXiv’s Giving Week, October 25 - 31.
-      Thank you!
+      Thank you to everyone who donated during arXiv's Giving Week, October 25 - 31. <b>It's not too late to give</b>.
+      arXiv is a nonprofit that depends on donations to fund essential operations and new initiatives. We appreciate your support of Open Science. Thank you!
     </p>
   </div>
   <div class="amount-donation">


### PR DESCRIPTION
Adds a news item and an updated banner with a post-giving week message and donate links. See screenshot below.

![Screen Shot 2021-11-01 at 2 34 34 PM](https://user-images.githubusercontent.com/56078140/139722986-83979f25-1181-4df9-9291-0ac6093c2839.png)

@mhl10 I could not find where to set the banner start and end dates, but it should run from today through Sunday night. 