### PR TITLE
Adds BPS banner and news links

### DIFF
--- a/browse/static/css/slider.css
+++ b/browse/static/css/slider.css
@@ -227,23 +227,24 @@ body {
   width: 50px;
 }
 .slider-wrapper.bps-banner {
-  background-color: #6b6459;
+  background-color: #ebdddc;
   color: #ffffff;
 }
 .slider-wrapper .copy-donation.bps-banner h1 {
-  color: #f9f7f7;
+  color: #000000;
 }
 .slider-wrapper .copy-donation.bps-banner p {
-  color: #ffffff;
+  color: #000000;
   text-shadow: none;
 }
 .slider-wrapper .copy-donation.bps-banner p a {
-  color: #a5d6fe;
+  color: #1f5e96;
   text-shadow: 1px 1px #000;
 }
 .slider-wrapper .amount-donation.bps-banner .donate-cta a {
-  background-color: #a5d6fe;
+  background-color: #b31b1b;
   margin: 10px 5px;
+  color: #f9f7f7;
 }
 .close-slider.bps-banner img {
   width: 25px;

--- a/browse/static/css/slider.css
+++ b/browse/static/css/slider.css
@@ -227,28 +227,58 @@ body {
   width: 50px;
 }
 .slider-wrapper.bps-banner {
-  background-color: #ebdddc;
+  background-color: #b31b1b;
   color: #ffffff;
 }
+.slider-wrapper .copy-donation.bps-banner {
+  width: 70%;
+}
 .slider-wrapper .copy-donation.bps-banner h1 {
-  color: #000000;
+  color: #f3edbe;
+  margin-bottom: 10px;
+  margin-top: 20px;
 }
 .slider-wrapper .copy-donation.bps-banner p {
-  color: #000000;
+  color: #f9f7f7;
   text-shadow: none;
+  margin-top:5px;
 }
 .slider-wrapper .copy-donation.bps-banner p a {
-  color: #1f5e96;
-  text-shadow: 1px 1px #000;
+  color: #f5e98e;
+  text-shadow: 1px 1px #831212;
+}
+.slider-wrapper .amount-donation.bps-banner {
+  width: 25%;
 }
 .slider-wrapper .amount-donation.bps-banner .donate-cta a {
   background-color: #b31b1b;
   margin: 10px 5px;
-  color: #f9f7f7;
+  color: #000000;
+}
+.slider-wrapper .amount-donation.bps-banner .donate-cta a:hover {
+  opacity: 1;
 }
 .close-slider.bps-banner img {
   width: 25px;
 }
 .slider-wrapper .copy-donation.bps-banner {
   border: 0;
+}
+.banner-btn-grad {background-image: linear-gradient(to right, #c19720 0%, #f5e98e  51%, #ffed6c  100%)}
+.banner-btn-grad {
+  margin: 10px;
+  padding: 15px 45px;
+  text-align: center;
+  text-transform: uppercase;
+  transition: 0.5s;
+  background-size: 200% auto;
+  color: black;
+  box-shadow: 0 0 20px #831212;
+  border-radius: 10px;
+  display: block;
+}
+.banner-btn-grad:hover {
+  background-position: right center; /* change the direction of the change here */
+  color: #fff;
+  text-decoration: none;
 }

--- a/browse/static/css/slider.css
+++ b/browse/static/css/slider.css
@@ -206,16 +206,48 @@ body {
 
 .survey-results p a {
     text-decoration: none;
-    color: #b31b1b;       
+    color: #b31b1b;
 }
 
 .survey-results p a:hover {
     opacity: .7;
-    
+
 }
 
 .survey-results .close-survey-banner {
     position: absolute;
     top: 12px;
     right: 10px;
+}
+
+/********** BPS styles **********/
+.slider-wrapper .copy-donation.bps-banner .banner-smileybones-icon {
+  float: left;
+  margin: 20px 15px;
+  width: 50px;
+}
+.slider-wrapper.bps-banner {
+  background-color: #6b6459;
+  color: #ffffff;
+}
+.slider-wrapper .copy-donation.bps-banner h1 {
+  color: #f9f7f7;
+}
+.slider-wrapper .copy-donation.bps-banner p {
+  color: #ffffff;
+  text-shadow: none;
+}
+.slider-wrapper .copy-donation.bps-banner p a {
+  color: #a5d6fe;
+  text-shadow: 1px 1px #000;
+}
+.slider-wrapper .amount-donation.bps-banner .donate-cta a {
+  background-color: #a5d6fe;
+  margin: 10px 5px;
+}
+.close-slider.bps-banner img {
+  width: 25px;
+}
+.slider-wrapper .copy-donation.bps-banner {
+  border: 0;
 }

--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -7,6 +7,13 @@ Celebrating <a href="https://blog.arxiv.org/2021/08/13/celebrating-arxivs-30th-a
 <br><br>
 {%- endif -%}
 
+<!-- brand perception survey -->
+{%- if rd_int >= 202111150100 and rd_int <= 202111160100 -%}
+<p><strong>Global survey:</strong> In just 3 minutes help us understand how you see arXiv, today.
+<a class="btn-slim" target="_blank" href="https://cornell.ca1.qualtrics.com/jfe/form/SV_a9o63a8zW62EwLk?continent={{ session['continent']['name'] if ('continent' in session and session['continent'] != None) else '' }}">Take survey</a>
+<br><br>
+{%- endif -%}
+
 <!-- annual post-giving-week message -->
 {%- if rd_int >= 202111010100 and rd_int <= 202111072359 -%}
 A big thank you for donating to arXiv during International Open Access Week. It's not too late to show your support. <a href="https://bit.ly/arXivDONATEa" target="_blank">Donate to arXiv here</a>.

--- a/browse/templates/user_banner.html
+++ b/browse/templates/user_banner.html
@@ -11,7 +11,7 @@
   </div>
   <div class="amount-donation bps-banner">
     <div class="wrapper">
-      <div class="donate-cta"><a class="banner_link" target="_blank" href="https://cornell.ca1.qualtrics.com/jfe/form/SV_a9o63a8zW62EwLk"><b>TAKE SURVEY</b></a>
+      <div class="donate-cta"><a class="banner_link banner-btn-grad" target="_blank" href="https://cornell.ca1.qualtrics.com/jfe/form/SV_a9o63a8zW62EwLk"><b>TAKE SURVEY</b></a>
       </div>
     </div>
   </div>

--- a/browse/templates/user_banner.html
+++ b/browse/templates/user_banner.html
@@ -5,7 +5,7 @@
     <img role="presentation" class="banner-smileybones-icon" width="50" src="{{ url_for('static', filename='images/icons/smileybones-pixel.png') }}" alt="arXiv smileybones icon" />
     <h1>Global Survey</h1>
     <p>
-      In just 3 minutes help us better understand how you see arXiv.
+      In just 3 minutes, help us better understand how you perceive arXiv.
       <a class="btn-slim" target="_blank" href="https://cornell.ca1.qualtrics.com/jfe/form/SV_a9o63a8zW62EwLk">Take the survey</a>
     </p>
   </div>

--- a/browse/templates/user_banner.html
+++ b/browse/templates/user_banner.html
@@ -1,21 +1,22 @@
 {# donation banner #}
-<aside class="slider-wrapper" style="display:none">
-  <a class="close-slider" href="#"><img src="{{ url_for('static', filename='images/icons/close-slider.png') }}" alt="close this message"></a>
-  <div class="copy-donation">
-    <h1>Thank you for supporting arXiv</h1>
+<aside class="slider-wrapper bps-banner" style="display:none">
+  <a class="close-slider bps-banner" href="#"><img src="{{ url_for('static', filename='images/icons/close-slider.png') }}" alt="close this message"></a>
+  <div class="copy-donation bps-banner">
+    <img role="presentation" class="banner-smileybones-icon" width="50" src="{{ url_for('static', filename='images/icons/smileybones-pixel.png') }}" alt="arXiv smileybones icon" />
+    <h1>Global Survey</h1>
     <p>
-      Thank you to everyone who donated during arXiv's Giving Week, October 25 - 31. <b>It's not too late to give</b>.
-      arXiv is a nonprofit that depends on donations to fund essential operations and new initiatives. We appreciate your support of Open Science. Thank you!
+      In just 3 minutes help us better understand how you see arXiv.
+      <a class="btn-slim" target="_blank" href="https://cornell.ca1.qualtrics.com/jfe/form/SV_a9o63a8zW62EwLk">Take the survey</a>
     </p>
   </div>
-  <div class="amount-donation">
+  <div class="amount-donation bps-banner">
     <div class="wrapper">
-      <div class="donate-cta"><a class="banner_link" href="https://bit.ly/arXivDONATEa"><b>DONATE</b></a>
-        <p>[secure site, no need to create account]</p>
+      <div class="donate-cta"><a class="banner_link" target="_blank" href="https://cornell.ca1.qualtrics.com/jfe/form/SV_a9o63a8zW62EwLk"><b>TAKE SURVEY</b></a>
       </div>
     </div>
   </div>
 </aside>
+
 {%- if 0 -%}
 {# downtime #}
 <aside class="slider-wrapper" style="display:none">


### PR DESCRIPTION
This PR adds a banner and homepage news link to the brand perception survey. It should run for 24 hours, from 1:00 AM on Monday the 15th to 1:00 AM on Tuesday the 16th. 

@mhl10 I used this timeblocking on the homepage news: {%- if rd_int >= 202111150100 and rd_int <= 202111160100 -%}

Screenshot of the homepage:
![Screen Shot 2021-11-10 at 11 21 07 AM](https://user-images.githubusercontent.com/56078140/141152645-29856c1f-ab66-4b55-81c8-17cfde8d23b7.png)

