### PR TITLE
Fixes /bibtex citation for old style ids ARXIVNG-4751

### DIFF
--- a/browse/routes/ui.py
+++ b/browse/routes/ui.py
@@ -439,7 +439,7 @@ def cookies(set):  # type: ignore
     return render_template('cookies.html', **response), code, headers
 
 
-@blueprint.route('bibtex/<arxiv_id>', methods=['GET'])
+@blueprint.route('bibtex/<path:arxiv_id>', methods=['GET'])
 def bibtex(arxiv_id: str):  # type: ignore
     """Bibtex for a paper."""
     return bibtex_citation(arxiv_id)

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -477,3 +477,13 @@ class BrowseTest(unittest.TestCase):
         jref_elmt = html.find('td', 'jref')
         self.assertTrue(jref_elmt, 'Should have jref td element')
         self.assertIn('RIMS Kôkyûroku Bessatsu', jref_elmt.text, 'Expecting converted TeX in journal reference field')
+
+    def test_bibtex(self):
+        for dir_name, _, file_list in os.walk(ABS_FILES):
+            for fname in file_list:
+                fname_path = os.path.join(dir_name, fname)
+                if os.stat(fname_path).st_size == 0 or not fname_path.endswith('.abs'):
+                    continue
+                dm = AbsMetaSession.parse_abs_file(filename=fname_path)
+                rv = self.app.get(f'/bibtex/{dm.arxiv_id}')
+                self.assertEqual(rv.status_code, 200, f'checking /bibtex for {dm.arxiv_id}')


### PR DESCRIPTION
This fixes the problem with the bibex citation for old IDs. 