### PR TITLE
Fix Docker instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,4 @@ Goal: 9/10 or better.
 
 ```bash
 pipenv run pylint browse
+```

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ You can also run the browse app in Docker. The following commands will build
 and run browse using defaults for the configuration parameters and will use
 the test data from `tests/data`.
 
+Install [Docker](https://docs.docker.com/get-docker/) if you haven't already, then run the following:
+
 ```bash
 docker build . -t arxiv/browse:some_tag
 docker run -it 8000:8000 arxiv/browse:some_tag

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ the test data from `tests/data`.
 Install [Docker](https://docs.docker.com/get-docker/) if you haven't already, then run the following:
 
 ```bash
-docker build . -t arxiv/browse:some_tag
-docker run -it 8000:8000 arxiv/browse:some_tag
+docker build . -t arxiv/browse
+docker run -it --publish 8000:8000 arxiv/browse
 ```
+
 If all goes well, http://localhost:8000/ will render the home page.
 
 ### Configuration Parameters


### PR DESCRIPTION
This PR updates the Docker section of the README.

Before this change, running the second command fails:

```
$ docker run -it 8000:8000 arxiv/browse:some_tag          
Unable to find image '8000:8000' locally
docker: Error response from daemon: pull access denied for 8000, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
```

Summary of changes:

- Updates the second run command to include the missing `--publish` flag
- Removes the `:some_tag` suffix from the image name. It's not strictly needed and could cause confusion.
- Adds a link to the Docker download page
- Removes a code block syntax error at the bottom of the README