### PR TITLE
Add start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ the test data from `tests/data`.
 Install [Docker](https://docs.docker.com/get-docker/) if you haven't already, then run the following:
 
 ```bash
-docker build . -t arxiv/browse
-docker run -it --publish 8000:8000 arxiv/browse
+script/start
 ```
+
+This command will build the docker image and run it.
 
 If all goes well, http://localhost:8000/ will render the home page.
 

--- a/script/start
+++ b/script/start
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e # stop execution if a command or pipeline has an error
+set -x # print statements as they're being executed
+
+docker build . -t arxiv/browse
+docker run -it --publish 8000:8000 arxiv/browse


### PR DESCRIPTION
In my recent work on #257, I noticed that I had to stop the server and run these Docker commands every time I made changes. This PR adds a start script that bundles the commands into one, which makes it a bit easier to start and stop the server.

The script is following the [Scripts to Rule Them All](https://github.com/github/scripts-to-rule-them-all) methodology popularized by GitHub.

cc @mhl10 @SBBCornell 