### PR TITLE
Add a meta tag exposing an article's DOI

### DIFF
--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -18,6 +18,9 @@
   <script src="{{ url_for('static', filename='js/toggle-labs.js') }}?20210728" type="text/javascript"></script>
   <script src="{{ url_for('static', filename='js/cite.js') }}" type="text/javascript"></script>
   {%- endif %}
+  {%- if datacite_doi %}
+    <meta name="citation_doi" content="{{ datacite_doi }}"/>
+  {%- endif %}
   {%- include "feedback_collector_js.html" -%}
   {{- generate_scholar_tags() }}
   {{- generate_social_media_tags() }}


### PR DESCRIPTION
This will make it discoverable by Google Scholar and other
indexers. See e.g.
https://scholar.google.com/intl/it/scholar/inclusion.html#indexing