### PR TITLE
Cleans up google scholar search URI construction 

### DIFF
--- a/browse/templates/abs/extra_services.html
+++ b/browse/templates/abs/extra_services.html
@@ -9,7 +9,7 @@
     {%- endif -%}
   {%- endfor -%}
   {%- set first_dt = abs_meta.get_datetime_of_version(version=0) -%}
-  <a  class="abs-button abs-button-small cite-google-scholar" href="https://scholar.google.com/scholar_lookup?title={{ abs_meta.title|urlencode }}{{ author_params.value }}&publication_date={{ first_dt.strftime('%Y/%m/%d') }}&arxiv_id={{ abs_meta.arxiv_id }}" target="_blank" rel="noopener">Google Scholar</a>
+  <a  class="abs-button abs-button-small cite-google-scholar" href="https://scholar.google.com/scholar_lookup?arxiv_id={{ abs_meta.arxiv_id }}" target="_blank" rel="noopener">Google Scholar</a>
 {%- endmacro -%}
 
 {%- macro generate_ancillary_file_list(anc_file_list=[], cutoff=6) -%}


### PR DESCRIPTION
Presently, the linking to Google Scholar provides too much date into the url, and seems to have inconsistent linking results. For example, 

[https://arxiv.org/abs/2201.12543](arXiv:2201.12543)

links to the wrong arXiv id under the current linking structure, but if the search terms are simplified, then the search resolves to the correct arXiv, such as: 

[https://scholar.google.com/scholar_lookup?arxiv_id=2201.12543](https://scholar.google.com/scholar_lookup?arxiv_id=2201.12543)
