### PR TITLE
Introduce Spaces Demos

### DIFF
--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -5,7 +5,7 @@
 /****************************************
  *   General rules
  *****************************************/
-body {
+ body {
   margin: 0;
   padding: 0;
   background-color: #fff;
@@ -1108,6 +1108,64 @@ p.tagline {
 }
 
 /*END Replicate CSS*/
+
+/*BEGIN Spaces CSS*/
+
+.spaces-summary {
+  margin-bottom: 0.5em;
+}
+
+.spaces-model {
+  padding: 15px 0;
+  display: flex;
+}
+
+.spaces-thumbnail {
+  height: 5.5rem;
+  border-radius: 0.5rem;
+}
+
+.spaces-model-details {
+  padding: 0px 15px;
+  vertical-align: top;
+}
+
+.spaces-model-details-heading {
+  margin: 0;
+  padding: 0;
+}
+
+.spaces-model-subheader {
+  color: gray;
+}
+
+.spaces-load-all-checkbox {
+  display: none;
+}
+
+.spaces-load-all-label {
+  display: inline-block;
+  padding: 0.75em;
+  background-color: #eef5f9;
+  cursor: pointer;
+  border-radius: 0.5rem;
+}
+
+.spaces-load-all-checkbox:checked + .spaces-load-all-label {
+  display: none;
+}
+
+.spaces-all-demos {
+  display: none;
+}
+
+.spaces-load-all-checkbox:checked + .spaces-load-all-label + .spaces-all-demos {
+  display: block;
+}
+
+
+/*END Spaces CSS*/
+
 
 /*LABS in TABS on ABS*/
 /*CSS-only, responsive tabbed display */

--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -5,7 +5,7 @@
 /****************************************
  *   General rules
  *****************************************/
- body {
+body {
   margin: 0;
   padding: 0;
   background-color: #fff;

--- a/browse/static/js/replicate.js
+++ b/browse/static/js/replicate.js
@@ -61,7 +61,7 @@
   function noModelsFound(models) {
     if (models.length === 0) {
       return `<p>
-        No demos found for this article. You can <a href="https://replicate.com/docs/arxiv?utm_source=arxiv&arxiv_paper_id=${arxivPaperId}">add one here</a>.
+        No Replicate demos found for this article. You can <a href="https://replicate.com/docs/arxiv?utm_source=arxiv&arxiv_paper_id=${arxivPaperId}">add one here</a>.
       </p>`
     } else {
       return ``

--- a/browse/static/js/spaces.js
+++ b/browse/static/js/spaces.js
@@ -1,7 +1,6 @@
 // Labs integration for displaying machine learning demos from huggingface.co/spaces
 
 (function () {
-    console.log("hello spaces");
     const container = document.getElementById("spaces-output")
     const containerAlreadyHasContent = container.innerHTML.trim().length > 0
   
@@ -92,11 +91,11 @@
       const huggingfaceSpaceThumbnail = `https://thumbnails.huggingface.co/social-thumbnails/spaces/${model.id}.png`;
       return `
         <div class="spaces-model">
-          <a href="${huggingfaceSpacesHost}/${model.id}">
+          <a target="_blank" href="${huggingfaceSpacesHost}/${model.id}">
             <img class="spaces-thumbnail" src=${huggingfaceSpaceThumbnail}>
           </a>
           <div class="spaces-model-details">
-            <a href="${huggingfaceSpacesHost}/${model.id}">
+            <a target="_blank" href="${huggingfaceSpacesHost}/${model.id}">
               <h3 class="spaces-model-details-heading">${model.id}</h3>
             </a>
             <p class="spaces-model-title">${model.cardData.title}</p>

--- a/browse/static/js/spaces.js
+++ b/browse/static/js/spaces.js
@@ -1,6 +1,7 @@
 // Labs integration for displaying machine learning demos from huggingface.co/spaces
 
 (function () {
+    console.log("hello spaces");
     const container = document.getElementById("spaces-output")
     const containerAlreadyHasContent = container.innerHTML.trim().length > 0
   

--- a/browse/static/js/spaces.js
+++ b/browse/static/js/spaces.js
@@ -1,0 +1,107 @@
+// Labs integration for displaying machine learning demos from huggingface.co/spaces
+
+(function () {
+    const container = document.getElementById("spaces-output")
+    const containerAlreadyHasContent = container.innerHTML.trim().length > 0
+  
+    // This script is invoked every time the Labs toggle is toggled, even when
+    // it's toggled to disabled. So this check short-circuits the script if the
+    // container already has content.
+    if (containerAlreadyHasContent) {
+      container.innerHTML = ""
+      container.setAttribute("style", "display:none")
+      return
+    } else {
+      container.setAttribute("style", "display:block")
+    }
+  
+    // Get the arXiv paper ID from the URL, e.g. "2103.17249"
+    // (this can be overridden for testing by passing a override_paper_id query parameter in the URL)
+    const params = new URLSearchParams(document.location.search)
+    const arxivPaperId = params.get("override_paper_id") || window.location.pathname.split('/').reverse()[0]
+    if (!arxivPaperId) return
+  
+    const huggingfaceApiHost = "https://huggingface.co/api";
+    const huggingfaceSpacesHost = "https://huggingface.co/spaces";
+    const huggingfaceModelsFromPaperApi = `${huggingfaceApiHost}/models?filter=arxiv:${arxivPaperId}`;
+  
+    // Search the HF Spaces API for models that implement this paper
+  
+    (async () => {
+      let response = await fetch(huggingfaceModelsFromPaperApi);
+      if (!response.ok) {
+        console.error(`Unable to fetch model data from ${huggingfaceModelsFromPaperApi}`)
+        render([]);
+        return;
+      }
+      let models = await response.json();
+      if (models.length === 0) {
+        render([]);
+        return;
+      }
+      const model_ids = models.map(m => m.id).join(",");
+      const huggingfaceSpacesFromModelsApi = `${huggingfaceApiHost}/spaces?models=or:${model_ids}&full=true&sort=likes&direction=-1`;
+      response = await fetch(huggingfaceSpacesFromModelsApi);
+      if (!response.ok) {
+        console.error(`Unable to fetch spaces data from ${huggingfaceSpacesFromModelsApi}`)
+        render([]);
+        return;
+      }
+      const spaces_data = await response.json();
+      render(spaces_data);
+    })()
+  
+    // Generate HTML, sanitize it to prevent XSS, and inject into the DOM
+    function render(models) {
+      container.innerHTML = window.DOMPurify.sanitize(`
+          ${summary(models)}
+          ${renderModels(models)}
+        `)
+    }
+  
+    function summary(models) {
+      switch (models.length) {
+        case 0:
+          return `<p class="spaces-summary">
+          No Spaces demos found for this article. You can <a href="https://huggingface.co/new-space">add one here</a>.
+          </p>`
+          break
+        case 1:
+          return `<p class="spaces-summary">@${models[0].author} has implemented an open-source demo based on this paper. Run it on Spaces:</p>`
+          break
+        default:
+          return `<p class="spaces-summary">There are ${models.length} open-source demos based on this paper. Run them on Spaces:</p>`
+      }
+    }
+  
+    function renderModels(models) {
+      const visibleModels = 10;
+      return models.slice(0, visibleModels).map(m => renderModel(m)).join("\n") + (models.length > visibleModels ? `
+        <input id="spaces-load-all-checkbox" class="spaces-load-all-checkbox" type="checkbox">
+        <label for="spaces-load-all-checkbox" class="spaces-load-all-label">
+            Load all demos
+        </label>
+        <div class="spaces-all-demos">
+          ${models.slice(visibleModels).map(m => renderModel(m)).join("\n")}
+        </div>
+      `: "")
+    }
+  
+    function renderModel(model) {
+      const huggingfaceSpaceThumbnail = `https://thumbnails.huggingface.co/social-thumbnails/spaces/${model.id}.png`;
+      return `
+        <div class="spaces-model">
+          <a href="${huggingfaceSpacesHost}/${model.id}">
+            <img class="spaces-thumbnail" src=${huggingfaceSpaceThumbnail}>
+          </a>
+          <div class="spaces-model-details">
+            <a href="${huggingfaceSpacesHost}/${model.id}">
+              <h3 class="spaces-model-details-heading">${model.id}</h3>
+            </a>
+            <p class="spaces-model-title">${model.cardData.title}</p>
+            <p class="spaces-model-subheader">Created ${(new Date(model.lastModified)).toLocaleDateString()} &bull; ${model.sdk}</p>
+          </div>
+        </div>
+      `
+    }
+  })();

--- a/browse/static/js/toggle-labs.js
+++ b/browse/static/js/toggle-labs.js
@@ -14,6 +14,7 @@ $(document).ready(function() {
   var scripts = {
     "paperwithcode": $('#paperwithcode-toggle').data('script-url') + "?20210727",
     "replicate": $('#replicate-toggle').data('script-url'),
+    "spaces": $('#spaces-toggle').data('script-url'),
     "litmaps": $('#litmaps-toggle').data('script-url'),
     "scite": $('#scite-toggle').data('script-url'),
     "iarxiv": $('#iarxiv-toggle').data('script-url'),
@@ -45,6 +46,7 @@ $(document).ready(function() {
   }
 
   var replicateEnabled = demosEnabled
+  var spacesEnabled = demosEnabled
 
   var labsCookie = Cookies.getJSON("arxiv_labs");
   if (labsCookie) {
@@ -86,6 +88,12 @@ $(document).ready(function() {
           }).fail(function() {
             console.error("failed to load replicate script (on cookie check)", arguments)
           });
+        } else if (key === "spaces-toggle") {
+          $.cachedScript(scripts["spaces"]).done(function(script, textStatus) {
+            console.log(textStatus);
+          }).fail(function() {
+            console.error("failed to load spaces script (on cookie check)", arguments)
+          });
         } else if (key === "connectedpapers-toggle") {
           $.cachedScript(scripts["connectedpapers"]).done(function(script, textStatus) {
             console.log(textStatus);
@@ -97,6 +105,9 @@ $(document).ready(function() {
         }
         if (key === "replicate-toggle") {
           replicateEnabled = false;
+        }
+        if (key === "spaces-toggle") {
+          spacesEnabled = false;
         }
       }
     }
@@ -117,6 +128,15 @@ $(document).ready(function() {
       // console.log(textStatus, "replicate (on load)");
     }).fail(function() {
       console.error("failed to load replicate script (on load)", arguments)
+    });;
+  }
+
+  if(spacesEnabled){
+    $("#spaces-toggle.lab-toggle").toggleClass("enabled",true);
+    $.cachedScript(scripts["spaces"]).done(function(script, textStatus) {
+      console.log(textStatus);
+    }).fail(function() {
+      console.error("failed to load spaces script (on load)", arguments)
     });;
   }
 
@@ -173,6 +193,12 @@ $(document).ready(function() {
         // console.log(textStatus, "replicate (on lab toggle)");
       }).fail(function() {
         console.error("failed to load replicate script (on lab toggle)", arguments)
+      });
+    } else if ($(this).attr("id") == "spaces-toggle") {
+      $.cachedScript(scripts["spaces"]).done(function(script, textStatus) {
+        // console.log(textStatus, "spaces (on lab toggle)");
+      }).fail(function() {
+        console.error("failed to load spaces script (on lab toggle)", arguments)
       });
     } else if ($(this).attr("id") == "connectedpapers-toggle") {
       $.cachedScript(scripts["connectedpapers"]).done(function(script, textStatus) {

--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -16,7 +16,7 @@
   <script src="//code.jquery.com/jquery-latest.min.js" type="text/javascript"></script>
   <script src="//cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js" type="text/javascript"></script>
   <script src="//cdn.jsdelivr.net/npm/dompurify@2.3.5/dist/purify.min.js"></script>
-  <script src="{{ url_for('static', filename='js/toggle-labs.js') }}?20210728" type="text/javascript"></script>
+  <script src="{{ url_for('static', filename='js/toggle-labs.js') }}?20220510" type="text/javascript"></script>
   <script src="{{ url_for('static', filename='js/cite.js') }}" type="text/javascript"></script>
   {%- endif %}
   {%- include "feedback_collector_js.html" -%}

--- a/browse/templates/abs/labs_tabs.html
+++ b/browse/templates/abs/labs_tabs.html
@@ -136,7 +136,7 @@
             </label>
           </div>
           <div class="column lab-name">
-            <span id="label-for-spaces">🤗&nbsp; Spaces</span> <em>(<a href="https://huggingface.co/docs/hub/spaces" target="_blank">What is Spaces?</a>)</em>
+            <span id="label-for-spaces">Hugging Face Spaces</span> <em>(<a href="https://huggingface.co/docs/hub/spaces" target="_blank">What is Spaces?</a>)</em>
           </div>
         </div>
 

--- a/browse/templates/abs/labs_tabs.html
+++ b/browse/templates/abs/labs_tabs.html
@@ -124,8 +124,25 @@
             <span id="label-for-replicate">Replicate</span> <em>(<a href="https://replicate.com/docs/arxiv/about" target="_blank">What is Replicate?</a>)</em>
           </div>
         </div>
+        <div class="columns is-mobile lab-row">
+          <div class="column lab-switch">
+            <label class="switch">
+              <input
+                id="spaces-toggle"
+                data-script-url="{{ url_for('static', filename='js/spaces.js') }}"
+                type="checkbox" class="lab-toggle" aria-labelledby="label-for-spaces">
+              <span class="slider"></span>
+              <span class="is-sr-only">Spaces Toggle</span>
+            </label>
+          </div>
+          <div class="column lab-name">
+            <span id="label-for-spaces">🤗&nbsp; Spaces</span> <em>(<a href="https://huggingface.co/docs/hub/spaces" target="_blank">What is Spaces?</a>)</em>
+          </div>
+        </div>
+
       </div>
       <div id="replicate-output"></div>
+      <div id="spaces-output"></div>
     </div>
 
 


### PR DESCRIPTION
This pull request introduces a new [arXiv Labs](https://labs.arxiv.org/) integration that displays links to interactive machine learning demos from [Hugging Face Spaces](https://huggingface.co/spaces). It mirrors the implementation used for Replicate AI demos.

Screenshot:
![Screen Shot 2022-05-08 at 10 09 08 PM](https://user-images.githubusercontent.com/7870876/167344427-1bcb5e7e-6752-4942-bc14-913e4546def8.png)

Demo:
![arxiv-spaces-integrations](https://user-images.githubusercontent.com/7870876/167343830-3bcfc507-928b-4090-9088-b09b31134c56.gif)

Running the development environment. From the root of this repository, run:
- `docker build . -t arxiv/browse`
- `docker run -it --publish 8000:8000 arxiv/browse`

Once the Docker is running:
- go to any paper, e.g. `http://localhost:8000/abs/0704.0988`
- Because none of the dummy dev papers are linked to any HF model, use the "override_paper_id" URL param to override the paper_id used to search for demos, e.g. `http://localhost:8000/abs/0704.0988?override_paper_id=1810.04805` or `http://localhost:8000/abs/0704.0988?override_paper_id=1912.08777 `
- ArXiv hides the demo tab unless the paper is a CS paper, which none of the dummy dev papers are, so run the follow in the Inspector: `document.querySelector("#labstabs-demos-label").style.display="block"; document.querySelector("#labstabs-demos-input").removeAttribute("disabled")
`
- Click the Demo tab and open the Huggingface Spaces toggle 