### PR TITLE
Add astro-ph subcategories

### DIFF
--- a/browse/templates/abs/labs_tabs.html
+++ b/browse/templates/abs/labs_tabs.html
@@ -160,7 +160,7 @@
             <span id="label-for-core">CORE Recommender</span> <em>(<a href="https://labs.arxiv.org/">What is CORE?</a>)</em>
           </div>
         </div>
-        {%- if abs_meta.primary_category in ['astro-ph', 'hep-ph', 'hep-th', 'gr-qc'] %}
+        {%- if abs_meta.primary_category and (abs_meta.primary_category in ['hep-ph', 'hep-th', 'gr-qc'] or abs_meta.primary_category.startswith('astro-ph')) %}
         <div class="columns is-mobile lab-row">
           <div class="column lab-switch">
             <label class="switch">


### PR DESCRIPTION
Add the subcategories of astro-ph to the list that display the IArxiv recommender button.
The abs page was checking for "astro-ph", but should have been checking any subcategory.
