### PR TITLE
Accessibility banner and homepage message

### DIFF
--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -656,6 +656,10 @@ footer .sorry-app-links .a11y-main-link {
     width: 88%;
   }
 }
+/* special header banner, dark override */
+.slider-wrapper.bps-banner.dark {
+  background-color: black;
+}
 
 /****************************************
  * Stats pages (/stats)

--- a/browse/templates/home/special-message.html
+++ b/browse/templates/home/special-message.html
@@ -1,12 +1,12 @@
 {#- Special messages appear in a column to the side of the website intro/news section, each in their own column. Always apply the style "message-special" to the column. You can also apply the style "dark" to override the red styles and add a message with a black background instead. There should preferably be just one, and never more than two. -#}
 {%- set rd_int = request_datetime.strftime("%Y%m%d%H%M")|int -%}
 
-{%- if rd_int >= 202206210800 and rd_int <= 202207012300 -%}
+{%- if rd_int >= 202206270100 and rd_int <= 202207012300 -%}
 <div class="message-special dark column">
   <span class="label">Accessible arXiv</span>
-  <p>Our goal is for arXiv to be open to all. One of the great challenges is making diverse scientific papers accessible to assistive technology.</p>
-  <p>Are you a researcher who uses a screen reader or other technology to access arXiv, or a professor who helps students do so? We would love to hear from you as we strive to understand the challenges and creative measures scientists employ to access research on arXiv.
-  <a target="_blank" href="https://cornell.ca1.qualtrics.com/jfe/form/SV_3K3qwdEH5gnzw6q">Sign up here to share your expertise</a></p>
+  <p>arXiv strives to be open, above all. One of the great challenges to that goal is making diverse scientific papers accessible to assistive technology.</p>
+  <p>Are you a researcher who uses a screen reader or other technology to access arXiv, or a professor who helps students do so? We would love to hear from you about the challenges and creative measures you employ to access research on arXiv.
+  <a target="_blank" href="https://cornell.ca1.qualtrics.com/jfe/form/SV_3K3qwdEH5gnzw6q">Sign up here to share your expertise</a>.</p>
 </div>
 {%- endif -%}
 

--- a/browse/templates/home/special-message.html
+++ b/browse/templates/home/special-message.html
@@ -1,6 +1,15 @@
 {#- Special messages appear in a column to the side of the website intro/news section, each in their own column. Always apply the style "message-special" to the column. You can also apply the style "dark" to override the red styles and add a message with a black background instead. There should preferably be just one, and never more than two. -#}
 {%- set rd_int = request_datetime.strftime("%Y%m%d%H%M")|int -%}
 
+{%- if rd_int >= 2206212300 and rd_int <= 2207012300 -%}
+<div class="message-special dark column">
+  <span class="label">Accessible arXiv</span>
+  <p>Our goal is for arXiv to be open to all. One of the great challenges is making diverse scientific papers accessible to assistive technology.</p>
+  <p>Are you a researcher who uses a screen reader or other technology to access arXiv, or a professor who helps students do so? We would love to hear from you as we strive to understand the challenges and creative measures scientists employ to access research on arXiv.
+  <a target="_blank" href="https://cornell.ca1.qualtrics.com/jfe/form/SV_3K3qwdEH5gnzw6q">Sign up here to share your expertise</a></p>
+</div>
+{%- endif -%}
+
 <div class="message-special column">
   <span class="label">COVID-19 Quick Links</span>
   <p>See COVID-19 SARS-CoV-2 preprints from</p>

--- a/browse/templates/home/special-message.html
+++ b/browse/templates/home/special-message.html
@@ -1,7 +1,7 @@
 {#- Special messages appear in a column to the side of the website intro/news section, each in their own column. Always apply the style "message-special" to the column. You can also apply the style "dark" to override the red styles and add a message with a black background instead. There should preferably be just one, and never more than two. -#}
 {%- set rd_int = request_datetime.strftime("%Y%m%d%H%M")|int -%}
 
-{%- if rd_int >= 2206212300 and rd_int <= 2207012300 -%}
+{%- if rd_int >= 202206210800 and rd_int <= 202207012300 -%}
 <div class="message-special dark column">
   <span class="label">Accessible arXiv</span>
   <p>Our goal is for arXiv to be open to all. One of the great challenges is making diverse scientific papers accessible to assistive technology.</p>

--- a/browse/templates/user_banner.html
+++ b/browse/templates/user_banner.html
@@ -33,7 +33,7 @@ that slides the header away.
   </div>
   <div class="amount-donation bps-banner">
     <div class="wrapper">
-      <div class="donate-cta"><a class="banner_link banner-btn-grad" target="_blank" href="https://cornell.ca1.qualtrics.com/jfe/form/SV_3K3qwdEH5gnzw6q"><b>Take Survey</b></a>
+      <div class="donate-cta"><a class="banner_link banner-btn-grad" target="_blank" href="https://cornell.ca1.qualtrics.com/jfe/form/SV_3K3qwdEH5gnzw6q"><b>Share Insights</b></a>
       </div>
     </div>
   </div>

--- a/browse/templates/user_banner.html
+++ b/browse/templates/user_banner.html
@@ -29,7 +29,8 @@ that slides the header away.
   <a class="close-slider bps-banner" href="#"><img src="{{ url_for('static', filename='images/icons/close-slider.png') }}" alt="close this message"></a>
   <div class="copy-donation bps-banner">
     <h1>Accessible arXiv</h1>
-    <p>Do you access arXiv using a screen reader or other assistive technology? We want to hear from you. Please consider <a href="https://cornell.ca1.qualtrics.com/jfe/form/SV_3K3qwdEH5gnzw6q" target="_blank">sharing your expertise</a> with arXiv as we work to improve this service for all users.</p>
+    <p>Do you navigate arXiv using a screen reader or other assistive technology? Are you a professor who helps students do so? We want to hear from you.
+      Please consider <a href="https://cornell.ca1.qualtrics.com/jfe/form/SV_3K3qwdEH5gnzw6q" target="_blank">signing up to share your insights</a> as we work to make arXiv even more open.</p>
   </div>
   <div class="amount-donation bps-banner">
     <div class="wrapper">

--- a/browse/templates/user_banner.html
+++ b/browse/templates/user_banner.html
@@ -24,8 +24,23 @@ Setting these will also cause an additonal CSS file to be loadded
 that slides the header away.
 
 -#}
+{# accessibility CTA banner #}
+<aside class="slider-wrapper bps-banner dark" style="display:none">
+  <a class="close-slider bps-banner" href="#"><img src="{{ url_for('static', filename='images/icons/close-slider.png') }}" alt="close this message"></a>
+  <div class="copy-donation bps-banner">
+    <h1>Accessible arXiv</h1>
+    <p>Do you access arXiv using a screen reader or other assistive technology? We want to hear from you. Please consider <a href="https://cornell.ca1.qualtrics.com/jfe/form/SV_3K3qwdEH5gnzw6q" target="_blank">sharing your expertise</a> with arXiv as we work to improve this service for all users.</p>
+  </div>
+  <div class="amount-donation bps-banner">
+    <div class="wrapper">
+      <div class="donate-cta"><a class="banner_link banner-btn-grad" target="_blank" href="https://cornell.ca1.qualtrics.com/jfe/form/SV_3K3qwdEH5gnzw6q"><b>Take Survey</b></a>
+      </div>
+    </div>
+  </div>
+</aside>
+
 {# donation banner #}
-<aside class="slider-wrapper bps-banner" style="display:none">
+<!-- <aside class="slider-wrapper bps-banner" style="display:none">
   <a class="close-slider bps-banner" href="#"><img src="{{ url_for('static', filename='images/icons/close-slider.png') }}" alt="close this message"></a>
   <div class="copy-donation bps-banner">
     <img role="presentation" class="banner-smileybones-icon" width="50" src="{{ url_for('static', filename='images/icons/smileybones-pixel.png') }}" alt="arXiv smileybones icon" />
@@ -38,7 +53,7 @@ that slides the header away.
       </div>
     </div>
   </div>
-</aside>
+</aside> -->
 
 {%- if 0 -%}
 {# downtime #}


### PR DESCRIPTION
Background: Per Steinn, there may be budget and more pressure for accessibility improvements this year. We need to talk to researchers who access arXiv with assistive technologies to ensure accessibility efforts are guided by real user needs. Our existing list of users with accessibility needs has a response rate of 0%. We need to cast a wider net.

This PR temporarily adds a banner to the header, and a message on the homepage, requesting input. The link takes them to a [very brief qualtrics survey](https://cornell.ca1.qualtrics.com/jfe/form/SV_3K3qwdEH5gnzw6q?jfefe=new), I will then reach out to set up individual interviews. My goal is to build a more active feedback group, and conduct at least 8 initial interviews.
![Screen Shot 2022-06-23 at 1 21 57 PM](https://user-images.githubusercontent.com/56078140/175358352-74f59260-3c5e-419a-b754-d7e3d1f373b9.png)