### PR TITLE
Fixes 500 errors abs file due to // for TeX cases

### DIFF
--- a/tests/data/abs_files/ftp/arxiv/papers/2004/2004.02153.abs
+++ b/tests/data/abs_files/ftp/arxiv/papers/2004/2004.02153.abs
@@ -13,8 +13,13 @@ MSC-class: 35K55 (primary), 35D99, 35Q92, 92C17 (secondary)
 License: http://arxiv.org/licenses/nonexclusive-distrib/1.0/
 \\
   We construct global generalized solutions to the chemotaxis system
-\begin{align*} \begin{cases} u_t = \Delta u - \nabla \cdot (u \nabla v) + \lambda(x) u - \mu(x) u^\kappa,
-\\ v_t = \Delta v - v + u \end{cases} \end{align*} in smooth, bounded domains $\Omega \subset \mathbb R^n$, $n \geq
+  \begin{align*}
+  \begin{cases}
+  u_t = \Delta u - \nabla \cdot (u \nabla v) + \lambda(x) u - \mu(x) u^\kappa,
+\\
+  v_t = \Delta v - v + u
+  \end{cases}
+  \end{align*} in smooth, bounded domains $\Omega \subset \mathbb R^n$, $n \geq
 2$, for certain choices of $\lambda, \mu$ and $\kappa$.
 Here, inter alia, the selections $\mu(x) = |x|^\alpha$ with $\alpha < 2$ and
 $\kappa = 2$as well as $\mu \equiv \mu_1 > 0$ and $\kappa >

--- a/tests/data/abs_files/ftp/arxiv/papers/2004/2004.02153.abs
+++ b/tests/data/abs_files/ftp/arxiv/papers/2004/2004.02153.abs
@@ -1,0 +1,29 @@
+------------------------------------------------------------------------------
+\\
+arXiv:2004.02153
+From: Mario Fuest <fuestm@math.upb.de>
+Date: Sun, 5 Apr 2020 10:46:18 GMT   (21kb)
+
+Title: When do Keller-Segel systems with heterogeneous logistic sources admit
+  generalized solutions?
+Authors: Jianlu Yan and Mario Fuest
+Categories: math.AP
+Comments: 16 pages
+MSC-class: 35K55 (primary), 35D99, 35Q92, 92C17 (secondary)
+License: http://arxiv.org/licenses/nonexclusive-distrib/1.0/
+\\
+  We construct global generalized solutions to the chemotaxis system
+\begin{align*} \begin{cases} u_t = \Delta u - \nabla \cdot (u \nabla v) + \lambda(x) u - \mu(x) u^\kappa,
+\\ v_t = \Delta v - v + u \end{cases} \end{align*} in smooth, bounded domains $\Omega \subset \mathbb R^n$, $n \geq
+2$, for certain choices of $\lambda, \mu$ and $\kappa$.
+Here, inter alia, the selections $\mu(x) = |x|^\alpha$ with $\alpha < 2$ and
+$\kappa = 2$as well as $\mu \equiv \mu_1 > 0$ and $\kappa >
+\min\{\frac{2n-2}{n}, \frac{2n+4}{n+4}\}$ are admissible (in both cases for any
+sufficiently smooth $\lambda$).
+While the former case appears to be novel in general, in the two- and
+three-dimensional setting, the latter improves on a recent result by Winkler
+(Adv. Nonlinear Anal. 9 (2019), no. 1, 526-566), where the condition $\kappa >
+\frac{2n+4}{n+4}$ has been imposed. In particular, for $n = 2$, our result
+shows that taking any $\kappa > 1$ suffices to exclude the possibility of
+collapse into a persistent Dirac distribution.
+\\

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -487,3 +487,16 @@ class BrowseTest(unittest.TestCase):
                 dm = AbsMetaSession.parse_abs_file(filename=fname_path)
                 rv = self.app.get(f'/bibtex/{dm.arxiv_id}')
                 self.assertEqual(rv.status_code, 200, f'checking /bibtex for {dm.arxiv_id}')
+
+    def test_2004_02153(self):
+        """Test when more than one \\ begins a line in the .abs file. ARXIVNG-3128"""
+        rv = self.app.get('/abs/2004.02153')
+        self.assertEqual(rv.status_code, 200)
+        txt = rv.data.decode('utf-8')
+        self.assertIn("We construct global generalized solutions to the chemotaxis system",
+                      txt,
+                      "Expect the abstract including the first sentence.")
+        self.assertIn("\\\\ v_t = \\Delta", txt, "Expect the TeX case")
+        self.assertIn("collapse into a persistent Dirac distribution.",
+                      txt,
+                      "Expect the abstract including the last sentence.")


### PR DESCRIPTION
// at the start of a line for TeX cases was causing the abs parser to fail for https://arxiv.org/abs/2004.02153

https://arxiv.org/abs/2004.02153 works because Jake manually fixed the abs file.

This PR adds an alternative way to split the abs file to handle this case.  

