### PR TITLE
updates giving week banner

### DIFF
--- a/browse/templates/user_banner.html
+++ b/browse/templates/user_banner.html
@@ -25,7 +25,7 @@ that slides the header away.
 
 -#}
 {# accessibility CTA banner #}
-<aside class="slider-wrapper bps-banner dark" style="display:none">
+<!-- <aside class="slider-wrapper bps-banner dark" style="display:none">
   <a class="close-slider bps-banner" href="#"><img src="{{ url_for('static', filename='images/icons/close-slider.png') }}" alt="close this message"></a>
   <div class="copy-donation bps-banner">
     <h1>Accessible arXiv</h1>
@@ -38,15 +38,15 @@ that slides the header away.
       </div>
     </div>
   </div>
-</aside>
+</aside> -->
 
 {# donation banner #}
-<!-- <aside class="slider-wrapper bps-banner" style="display:none">
+<aside class="slider-wrapper bps-banner" style="display:none">
   <a class="close-slider bps-banner" href="#"><img src="{{ url_for('static', filename='images/icons/close-slider.png') }}" alt="close this message"></a>
   <div class="copy-donation bps-banner">
     <img role="presentation" class="banner-smileybones-icon" width="50" src="{{ url_for('static', filename='images/icons/smileybones-pixel.png') }}" alt="arXiv smileybones icon" />
     <h1>Giving Week!</h1>
-    <p>Show your support for Open Science by <a href="http://bit.ly/arXivDONATEa" target="_blank">donating to arXiv</a> during Giving Week, April 25th-29th.</p>
+    <p>Show your support for Open Science by <a href="http://bit.ly/arXivDONATEa" target="_blank">donating to arXiv</a> during Giving Week, October 24th-28th.</p>
   </div>
   <div class="amount-donation bps-banner">
     <div class="wrapper">
@@ -54,7 +54,7 @@ that slides the header away.
       </div>
     </div>
   </div>
-</aside> -->
+</aside>
 
 {%- if 0 -%}
 {# downtime #}


### PR DESCRIPTION
This PR is for the Fall 2022 Giving Week banner. 

Devs, could you help Alison and I with two things:
- test view it on dev server
- queue the banner to go live on the morning of Monday October 24th, and stop displaying on the evening of Sunday October 30th.