### PR TITLE
banner and news link to BPS

### DIFF
--- a/browse/templates/home/news.html
+++ b/browse/templates/home/news.html
@@ -8,9 +8,9 @@ Celebrating <a href="https://blog.arxiv.org/2021/08/13/celebrating-arxivs-30th-a
 {%- endif -%}
 
 <!-- brand perception survey -->
-{%- if rd_int >= 202111150100 and rd_int <= 202111160100 -%}
-<p><strong>Global survey:</strong> In just 3 minutes help us understand how you see arXiv, today.
-<a class="btn-slim" target="_blank" href="https://cornell.ca1.qualtrics.com/jfe/form/SV_a9o63a8zW62EwLk?continent={{ session['continent']['name'] if ('continent' in session and session['continent'] != None) else '' }}">Take survey</a>
+{%- if rd_int >= 202211080100 and rd_int <= 202211090100 -%}
+<p><strong>Global survey:</strong> In just 3 minutes help us understand how you see arXiv.
+<a class="btn-slim" target="_blank" href="https://cornell.ca1.qualtrics.com/jfe/form/SV_9BJDfYPfmvvSAGq?continent={{ session['continent']['name'] if ('continent' in session and session['continent'] != None) else '' }}">Take survey</a>
 <br><br>
 {%- endif -%}
 

--- a/browse/templates/user_banner.html
+++ b/browse/templates/user_banner.html
@@ -45,12 +45,12 @@ that slides the header away.
   <a class="close-slider bps-banner" href="#"><img src="{{ url_for('static', filename='images/icons/close-slider.png') }}" alt="close this message"></a>
   <div class="copy-donation bps-banner">
     <img role="presentation" class="banner-smileybones-icon" width="50" src="{{ url_for('static', filename='images/icons/smileybones-pixel.png') }}" alt="arXiv smileybones icon" />
-    <h1>Giving Week!</h1>
-    <p>Show your support for Open Science by <a href="http://bit.ly/arXivDONATEa" target="_blank">donating to arXiv</a> during Giving Week, October 24th-28th.</p>
+    <h1>Global Survey</h1>
+    <p>In just 3 minutes help us understand <a href="https://cornell.ca1.qualtrics.com/jfe/form/SV_9BJDfYPfmvvSAGq?continent={{ session['continent']['name'] if ('continent' in session and session['continent'] != None) else '' }}" target="_blank">how you see arXiv</a>.</p>
   </div>
   <div class="amount-donation bps-banner">
     <div class="wrapper">
-      <div class="donate-cta"><a class="banner_link banner-btn-grad" target="_blank" href="http://bit.ly/arXivDONATEa"><b>DONATE</b></a>
+      <div class="donate-cta"><a class="banner_link banner-btn-grad" target="_blank" href="https://cornell.ca1.qualtrics.com/jfe/form/SV_9BJDfYPfmvvSAGq?continent={{ session['continent']['name'] if ('continent' in session and session['continent'] != None) else '' }}"><b>TAKE SURVEY</b></a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This commit adds a banner with link to the survey, and a news item on the homepage with a link to the same.

The start and end date on news.html should be updated to match whatever the start and end date of the banner are, so they appear at the same time. We want to display both for a 24 hour period. It is not so important exactly what time that 24 hour period begins, but preferably on Monday or Tuesday so we match previous years. 

Could we also preview it on dev or beta ahead of time, just to make sure all is well. 