### PR TITLE
ARXIVCE-62: abs-canonical-url

### DIFF
--- a/browse/config.py
+++ b/browse/config.py
@@ -368,7 +368,6 @@ CLASSIC_DATABASE_URI = os.environ.get(
 CLASSIC_SESSION_HASH = os.environ.get("CLASSIC_SESSION_HASH", "foosecret")
 SESSION_DURATION = os.environ.get("SESSION_DURATION", "36000")
 
-BASE_SERVER = os.environ.get("BASE_SERVER", "arxiv.org")
 URLS = [
     ("ui.login", "/login", os.environ.get("SERVER_NAME", "arxiv.org"))
     # This is a temporary workaround for ARXIVNG-2063

--- a/browse/config.py
+++ b/browse/config.py
@@ -368,8 +368,10 @@ CLASSIC_DATABASE_URI = os.environ.get(
 CLASSIC_SESSION_HASH = os.environ.get("CLASSIC_SESSION_HASH", "foosecret")
 SESSION_DURATION = os.environ.get("SESSION_DURATION", "36000")
 
+BASE_SERVER = os.environ.get("BASE_SERVER", "arxiv.org")
 URLS = [
-    ("ui.login", "/login", os.environ.get("SERVER_NAME", "arxiv.org"))
-    # This is a temporary workaround for ARXIVNG-2063
+    ("abs", "/abs/<arxiv:paper_id>v<string:version>", BASE_SERVER),
+    ("abs_by_id", "/abs/<arxiv:paper_id>", BASE_SERVER),
+    ("ui.login", "/login", BASE_SERVER), # workaround for ARXIVNG-2063
 ]
 """External URLs."""

--- a/browse/config.py
+++ b/browse/config.py
@@ -370,8 +370,7 @@ SESSION_DURATION = os.environ.get("SESSION_DURATION", "36000")
 
 BASE_SERVER = os.environ.get("BASE_SERVER", "arxiv.org")
 URLS = [
-    ("abs", "/abs/<arxiv:paper_id>v<string:version>", BASE_SERVER),
-    ("abs_by_id", "/abs/<arxiv:paper_id>", BASE_SERVER),
-    ("ui.login", "/login", BASE_SERVER), # workaround for ARXIVNG-2063
+    ("ui.login", "/login", os.environ.get("SERVER_NAME", "arxiv.org"))
+    # This is a temporary workaround for ARXIVNG-2063
 ]
 """External URLs."""

--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -6,7 +6,7 @@
 
 {% block head %}
   {{ super() -}}
-  <link rel="canonical" href="{{ url_for('abs_by_id', paper_id=abs_meta.arxiv_id) }}"/>
+  <link rel="canonical" href="{{ url_for('browse.abstract', arxiv_id=abs_meta.arxiv_id) }}"/>
   <link rel="stylesheet" media="screen" type="text/css" href="{{ url_for('static', filename='css/tooltip.css') }}"/>
   {%- if config['LABS_ENABLED'] and config['LABS_BIBEXPLORER_ENABLED'] -%}
   <link rel="stylesheet" media="screen" type="text/css" href="https://static.arxiv.org/js/bibex-dev/bibex.css?20200709"/>

--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -6,6 +6,7 @@
 
 {% block head %}
   {{ super() -}}
+  <link rel="canonical" href="{{ url_for('abs_by_id', paper_id=abs_meta.arxiv_id) }}"/>
   <link rel="stylesheet" media="screen" type="text/css" href="{{ url_for('static', filename='css/tooltip.css') }}"/>
   {%- if config['LABS_ENABLED'] and config['LABS_BIBEXPLORER_ENABLED'] -%}
   <link rel="stylesheet" media="screen" type="text/css" href="https://static.arxiv.org/js/bibex-dev/bibex.css?20200709"/>


### PR DESCRIPTION
Some of our paper's abs pages aren't searchable at google. Maybe our multiple urls look like we're trying to game the page rank.