### PR TITLE
Update Hugging Face Spaces Integration, minor aesthetic changes

### DIFF
--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -1143,30 +1143,15 @@ p.tagline {
   color: gray;
 }
 
-.spaces-load-all-checkbox {
-  display: none;
-}
-
-.spaces-load-all-label {
-  display: inline-block;
+.spaces-load-all-link {
+  cursor: pointer;
   padding: 0.75em;
   background-color: #eef5f9;
-  cursor: pointer;
+  border: none;
   border-radius: 0.5rem;
+  margin: 0.5em 0;
+  display: inline-block;
 }
-
-.spaces-load-all-checkbox:checked + .spaces-load-all-label {
-  display: none;
-}
-
-.spaces-all-demos {
-  display: none;
-}
-
-.spaces-load-all-checkbox:checked + .spaces-load-all-label + .spaces-all-demos {
-  display: block;
-}
-
 
 /*END Spaces CSS*/
 

--- a/browse/static/js/spaces.js
+++ b/browse/static/js/spaces.js
@@ -41,6 +41,7 @@
       }
       const model_ids = models.map(m => m.id).join(",");
       const huggingfaceSpacesFromModelsApi = `${huggingfaceApiHost}/spaces?models=or:${model_ids}&full=true&sort=likes&direction=-1`;
+      const huggingfaceSpacesFromModelsLink = `${huggingfaceSpacesHost}/?models=or:${model_ids}`;
       response = await fetch(huggingfaceSpacesFromModelsApi);
       if (!response.ok) {
         console.error(`Unable to fetch spaces data from ${huggingfaceSpacesFromModelsApi}`)
@@ -48,14 +49,14 @@
         return;
       }
       const spaces_data = await response.json();
-      render(spaces_data);
+      render(spaces_data, huggingfaceSpacesFromModelsLink);
     })()
   
     // Generate HTML, sanitize it to prevent XSS, and inject into the DOM
-    function render(models) {
+    function render(models, spaces_link) {
       container.innerHTML = window.DOMPurify.sanitize(`
           ${summary(models)}
-          ${renderModels(models)}
+          ${renderModels(models, spaces_link)}
         `)
     }
   
@@ -74,16 +75,14 @@
       }
     }
   
-    function renderModels(models) {
-      const visibleModels = 10;
+    function renderModels(models, spaces_link) {
+      const visibleModels = 5;
       return models.slice(0, visibleModels).map(m => renderModel(m)).join("\n") + (models.length > visibleModels ? `
-        <input id="spaces-load-all-checkbox" class="spaces-load-all-checkbox" type="checkbox">
-        <label for="spaces-load-all-checkbox" class="spaces-load-all-label">
-            Load all demos
-        </label>
-        <div class="spaces-all-demos">
-          ${models.slice(visibleModels).map(m => renderModel(m)).join("\n")}
-        </div>
+        <a href="${spaces_link}" target="_blank">
+          <button class="spaces-load-all-link">
+            View all demos
+          </button>
+        </a>
       `: "")
     }
   


### PR DESCRIPTION
An update to only load 5 Hugging Face Spaces demos in the Demos tab. If a user wants to view more, instead of expanding in the page, we link to the Hugging Face search. This should look cleaner and not overload the page with too much content.

![Recording 2022-11-16 at 03 03 21](https://user-images.githubusercontent.com/7870876/202163920-e14a58f7-2a30-46a8-954b-e944f2ec919c.gif)

Running the development environment. From the root of this repository, run:
- `./script/start`

Once the Docker is running:
- go to any paper, e.g. `http://localhost:8000/abs/0704.0988`
- Because none of the dummy dev papers are linked to any HF model, use the "override_paper_id" URL param to override the paper_id used to search for demos, e.g. `http://localhost:8000/abs/0704.0988?override_paper_id=1810.04805` or `http://localhost:8000/abs/0704.0988?override_paper_id=1912.08777 `
- ArXiv hides the demo tab unless the paper is a CS paper, which none of the dummy dev papers are, so run the follow in the Inspector: `document.querySelector("#labstabs-demos-label").style.display="block"; document.querySelector("#labstabs-demos-input").removeAttribute("disabled")
`
- Click the Demo tab and open the Huggingface Spaces toggle.