### PR TITLE
labs pages: not default enabled for the demo tab, links for CORE and PwC

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You can run the browse app directly. Using pipenv:
 
 ```bash
 pipenv install
-FLASK_APP=app.py FLASK_DEBUG=1 pipenv run flask run
+pipenv run python main.py
 ```
 
 

--- a/browse/static/js/toggle-labs.js
+++ b/browse/static/js/toggle-labs.js
@@ -31,23 +31,6 @@ $(document).ready(function() {
 
   var pwcEnabled = true;
 
-  const currentCategory = $('.current')?.text()?.toLowerCase();
-  const demoCategories = [
-    "cs",   // Computer Science
-    "eess", // Electrical Engineering and Systems Science
-    "stat"  // Statistics
-  ]
-
-  const demosEnabled = currentCategory && demoCategories.some(category => currentCategory.startsWith(category));
-
-  if (demosEnabled) {
-    document.getElementById("labstabs-demos-input").removeAttribute("disabled");
-    document.getElementById("labstabs-demos-label").style.display = "block";
-  }
-
-  var replicateEnabled = demosEnabled
-  var spacesEnabled = demosEnabled
-
   var labsCookie = Cookies.getJSON("arxiv_labs");
   if (labsCookie) {
     has_enabled = false;
@@ -99,45 +82,10 @@ $(document).ready(function() {
             console.log(textStatus);
           });
         }
-      } else if (labsCookie[key] && labsCookie[key] == "disabled"){
-        if (key === "paperwithcode-toggle") {
-          pwcEnabled = false;
-        }
-        if (key === "replicate-toggle") {
-          replicateEnabled = false;
-        }
-        if (key === "spaces-toggle") {
-          spacesEnabled = false;
-        }
       }
     }
   } else {
     Cookies.set("arxiv_labs", { sameSite: "strict" });
-  }
-
-  if(pwcEnabled){
-    $("#paperwithcode-toggle.lab-toggle").toggleClass("enabled",true);
-    $.cachedScript(scripts["paperwithcode"]).done(function(script, textStatus) {
-      console.log(textStatus);
-    });
-  }
-
-  if(replicateEnabled){
-    $("#replicate-toggle.lab-toggle").toggleClass("enabled",true);
-    $.cachedScript(scripts["replicate"]).done(function(script, textStatus) {
-      // console.log(textStatus, "replicate (on load)");
-    }).fail(function() {
-      console.error("failed to load replicate script (on load)", arguments)
-    });;
-  }
-
-  if(spacesEnabled){
-    $("#spaces-toggle.lab-toggle").toggleClass("enabled",true);
-    $.cachedScript(scripts["spaces"]).done(function(script, textStatus) {
-      console.log(textStatus);
-    }).fail(function() {
-      console.error("failed to load spaces script (on load)", arguments)
-    });;
   }
 
   // record last-clicked tab

--- a/browse/templates/abs/labs_tabs.html
+++ b/browse/templates/abs/labs_tabs.html
@@ -92,7 +92,7 @@
             </label>
           </div>
           <div class="column lab-name">
-            <span id="label-for-pwc">arXiv Links to Code &amp; Data</span> <em>(<a href="https://labs.arxiv.org/" target="_blank">What is Links to Code &amp; Data?</a>)</em>
+            <span id="label-for-pwc">arXiv Links to Code &amp; Data</span> <em>(<a href="https://paperswithcode.com/" target="_blank">What is Links to Code &amp; Data?</a>)</em>
           </div>
         </div>
       </div>
@@ -104,8 +104,8 @@
       hide the "Demos" tab by default, and conditionally display it using 
       JavaScript on pages in specific categories like `cs`, `eess``, and `stat`
      -->
-    <input type="radio" name="tabs" id="labstabs-demos-input" disabled>
-    <label for="labstabs-demos-input" id="labstabs-demos-label" style="display:none">Demos</label>
+    <input type="radio" name="tabs" id="labstabs-demos-input">
+    <label for="labstabs-demos-input" id="labstabs-demos-label">Demos</label>
     <div class="tab">
       <h1>Demos</h1>
       <div class="toggle">
@@ -174,7 +174,7 @@
             </label>
           </div>
           <div class="column lab-name">
-            <span id="label-for-core">CORE Recommender</span> <em>(<a href="https://labs.arxiv.org/">What is CORE?</a>)</em>
+            <span id="label-for-core">CORE Recommender</span> <em>(<a href="https://core.ac.uk/services/recommender">What is CORE?</a>)</em>
           </div>
         </div>
         {%- if abs_meta.primary_category and (abs_meta.primary_category in ['cs.LG', 'gr-qc', 'hep-ph', 'hep-th'] or abs_meta.primary_category.startswith('astro-ph') or abs_meta.primary_category.startswith('cond-mat')) %}

--- a/main.py
+++ b/main.py
@@ -1,0 +1,7 @@
+from browse.factory import create_web_app
+
+if __name__ == "__main__":
+    app = create_web_app()
+    app.config['TEMPLATES_AUTO_RELOAD'] = True
+    app.config['DEBUG'] = True
+    app.run(debug=True)


### PR DESCRIPTION
This undoes changes in 8dc1713 which made the demo tab visible and also enabled the replicate labs items in that tab for a subset of archives. It is an arXiv policy that the labs items are opt-in. 

This also has the effect of making the Demo tab enabled for all archives and categories. Previously it was just for cs, eess and stats.

Adds missing about links for CORE and PwC.

Adds main.py for easy startup of the flask app.