### PR TITLE
Increase labs cookie expiry time

### DIFF
--- a/browse/static/js/toggle-labs.js
+++ b/browse/static/js/toggle-labs.js
@@ -92,14 +92,14 @@ $(document).ready(function() {
       }
     }
   } else {
-    Cookies.set("arxiv_labs", { sameSite: "strict" });
+    Cookies.set("arxiv_labs", { sameSite: "strict", expires: 365 });
   }
 
   // record last-clicked tab
   $("div.labstabs input[name='tabs']").on("click", function() {
     var labsCookie = Cookies.getJSON("arxiv_labs") || {};
     labsCookie["last_tab"] = $(this).attr("id");
-    Cookies.set("arxiv_labs", labsCookie, { sameSite: "strict" });
+    Cookies.set("arxiv_labs", labsCookie, { sameSite: "strict", expires: 365 });
   });
 
   $(".lab-toggle").on("click", function() {
@@ -115,11 +115,11 @@ $(document).ready(function() {
       bibex_val = true;
     }
     labsCookie[$(this).attr("id")] = cookie_val;
-    Cookies.set("arxiv_labs", labsCookie, { sameSite: "strict" });
+    Cookies.set("arxiv_labs", labsCookie, { sameSite: "strict", expires: 365 });
 
     if ($(this).attr("id") == "bibex-toggle") {
       bibexCookie[bibex_key] = bibex_val;
-      Cookies.set("arxiv_bibex", bibexCookie);
+      Cookies.set("arxiv_bibex", bibexCookie, { expires: 365 });
       if (bibex_val) {
         $.cachedScript(scripts["bibex"]["url"]).done(function(script, textStatus) {
           console.log(textStatus);


### PR DESCRIPTION
At the moment the labs cookie expires every time the user closes the browser window (ie they are session-bound). Because of this I find myself having to re-enable my favorite labs extensions multiple times a day, which is quite inconvenient and annoying. 

In this PR I've set the lab cookies to expire in 365 days instead of being session bound. I think this is going to make for a better experience and let users better customize their labs experience. Tested locally and seems to work as expected. 

