### PR TITLE
Update to ScienceCast plugin

### DIFF
--- a/browse/templates/abs/labs_tabs.html
+++ b/browse/templates/abs/labs_tabs.html
@@ -108,7 +108,7 @@
             </label>
           </div>
           <div class="column lab-name">
-            <span id="label-for-sciencecast">ScienceCast</span> <em>(<a href="https://sciencecast.org/pages/about" target="_blank">What is ScienceCast?</a>)</em>
+            <span id="label-for-sciencecast">ScienceCast</span> <em>(<a href="https://sciencecast.org/welcome" target="_blank">What is ScienceCast?</a>)</em>
           </div>
         </div>
 


### PR DESCRIPTION
Replace the link "What is ScienceCast?" with the new one