### PR TITLE
Integrate arXiv with DagsHub

### DIFF
--- a/browse/static/js/dagshub.js
+++ b/browse/static/js/dagshub.js
@@ -1,0 +1,54 @@
+(function() {
+	const container = document.getElementById("dagshub-output")
+	const containerAlreadyHasContent = container.innerHTML.trim().length > 0
+	console.log("Invoked!")
+	// This script is invoked every time the Labs toggle is toggled, even when
+	// it's toggled to disabled. So this check short-circuits the script if the
+	// container already has content.
+	if (containerAlreadyHasContent) {
+	  container.innerHTML = ""
+	  container.setAttribute("style", "display:none")
+	  return
+	} else {
+	  container.setAttribute("style", "display:block")
+	}
+
+	// Get the arXiv paper ID from the URL, e.g. "2103.17249"
+    // (this can be overridden for testing by passing a override_paper_id query parameter in the URL)
+    const params = new URLSearchParams(document.location.search)
+    const arxivPaperId = params.get("override_paper_id") || window.location.pathname.split('/').reverse()[0]
+    if (!arxivPaperId) return
+	
+	const dagshubAPIHost = "https://dagshub.com/api/v1"
+	const dagshubRepositoryFromPaperApi = `${dagshubAPIHost}/repos/arxiv/${arxivPaperId}`;
+	
+	// Search DagsHub for a project that implements the paper
+	(async () => {
+		let response = await fetch(dagshubRepositoryFromPaperApi);
+		if (!response.ok) {
+		  console.error(`Unable to fetch data from ${dagshubRepositoryFromPaperApi}`)
+		  render({"DagsHub is not available": "an error occurred while fetching"});
+		  return;
+		}
+		const dagshub_data = await response.json();
+		render(dagshub_data);
+	  })()
+
+	  // Generate HTML, sanitize it to prevent XSS, and inject into the DOM
+	  function render(data) {
+		container.innerHTML = window.DOMPurify.sanitize(`
+			${summary(data)}
+		  `)
+	  }
+	
+	  function summary(data) {
+		let output = ``
+		for (const key in data) {
+			output += `
+				<h3>${key}</h3>
+				<p>${data[key]}</p>
+				`
+		}
+		return output;
+	  }
+})();

--- a/browse/static/js/toggle-labs.js
+++ b/browse/static/js/toggle-labs.js
@@ -15,6 +15,7 @@ $(document).ready(function() {
     "paperwithcode": $('#paperwithcode-toggle').data('script-url') + "?20210727",
     "replicate": $('#replicate-toggle').data('script-url'),
     "spaces": $('#spaces-toggle').data('script-url'),
+    "dagshub": $('#dagshub-toggle').data('script-url'),
     "litmaps": $('#litmaps-toggle').data('script-url'),
     "scite": $('#scite-toggle').data('script-url'),
     "iarxiv": $('#iarxiv-toggle').data('script-url'),
@@ -88,7 +89,13 @@ $(document).ready(function() {
            }).fail(function() {
              console.error("failed to load sciencecast script (on cookie check)", arguments)
            });
-        }
+        } else if (key === "dagshub-toggle") {
+          $.cachedScript(scripts["dagshub"]).done(function(script, textStatus) {
+            console.log("DagsHub load: ", textStatus);
+          }).fail(function() {
+            console.error("failed to load DagsHub script (on cookie check)", arguments)
+          });
+       }
       }
     }
   } else {
@@ -165,7 +172,14 @@ $(document).ready(function() {
        }).fail(function() {
          console.error("failed to load sciencecast script (on lab toggle)", arguments)
        });
-    }
+    } else if ($(this).attr("id") == "dagshub-toggle") {
+      $.cachedScript(scripts["dagshub"]).done(function(script, textStatus) {
+        console.log(textStatus, "dagshub (on lab toggle)");
+      }).fail(function() {
+        console.error("failed to load dagshub script (on lab toggle)", arguments)
+      });
+   }
+  
 
     // TODO: clean this up
     if (cookie_val == 'disabled') {

--- a/browse/templates/abs/labs_tabs.html
+++ b/browse/templates/abs/labs_tabs.html
@@ -84,6 +84,21 @@
           <div class="column lab-switch">
             <label class="switch">
               <input
+                id="dagshub-toggle"
+                data-script-url="{{ url_for('static', filename='js/dagshub.js') }}"
+                type="checkbox" class="lab-toggle" aria-labelledby="label-for-dagshub">
+              <span class="slider"></span>
+              <span class="is-sr-only">DagsHub Toggle</span>
+            </label>
+          </div>
+          <div class="column lab-name">
+            <span id="label-for-dagshub">DagsHub</span> <em>(<a href="https://dagshub.com/" target="_blank">What is DagsHub?</a>)</em>
+          </div>
+        </div>
+        <div class="columns is-mobile lab-row">
+          <div class="column lab-switch">
+            <label class="switch">
+              <input
                 id="paperwithcode-toggle"
                 data-script-url="{{ url_for('static', filename='js/paperswithcode.js') }}"
                 type="checkbox" class="lab-toggle" aria-labelledby="label-for-pwc">
@@ -113,6 +128,7 @@
         </div>
 
       </div>
+      <div id="dagshub-output" style="display:none"></div>
       <div id="pwc-output" style="display:none"></div>
       <div id="pwc-data-output" style="display:none"></div>
       <div id="sciencecast-output" style="display:none"></div>


### PR DESCRIPTION
This PR introduces an integration with DagsHub. This integration shows Links for DagsHub projects that implement a paper.


The implementing repository also get an arXiv link on the top of the page on DagsHub 😄 
<img width="967" alt="Screen Shot 2023-01-25 at 14 21 39" src="https://user-images.githubusercontent.com/15911452/214562074-9ab999a0-82e1-4b8f-a6cd-4ac9bf0a5bcf.png">

This is how it looks on arXiv:
<img width="945" alt="Screen Shot 2023-01-25 at 14 28 41" src="https://user-images.githubusercontent.com/15911452/214563505-cceeb407-a899-4597-a364-dec264fe25cb.png">
