### PR TITLE
edit description and fix href for influence flowers

### DIFF
--- a/browse/static/js/inf-script.js
+++ b/browse/static/js/inf-script.js
@@ -82,9 +82,14 @@ var InfluenceFlower = class InfluenceFlower {
     var link_g = document.createElement("g");
     var text_g = document.createElement("g");
 
+    var egoLink = ego_url_base+"&tab="+idx;
+
     // flower graph nodes
     for (var i = 0; i < nodes.length; i++) {
       var d = nodes[i];
+      var outerNode = document.createElement('a');
+      outerNode.setAttribute("href", egoLink);
+      outerNode.setAttribute("target", '_blank');
       var node = document.createElement('circle');
       node.setAttribute("id", d.id);
       node.setAttribute("name", d.name);
@@ -115,7 +120,8 @@ var InfluenceFlower = class InfluenceFlower {
       // node.setAttribute('onmouseout', 'highlight_off()');
 
       this.node_out[i] = node;
-      node_g.appendChild(node);
+      outerNode.appendChild(node)
+      node_g.appendChild(outerNode);
     }
 
     // flower graph node text
@@ -141,7 +147,6 @@ var InfluenceFlower = class InfluenceFlower {
       text.setAttribute("node_size", d.size);
 
       var capName = this.capitalizeString(d.id==0, d.gtype, d.name);
-      var egoLink = ego_url_base+"&tab="+idx;
       var influencemap_url_base = "https://influencemap.cmlab.dev/submit/?id="
       if (d.id == 0) {
         text.innerHTML = "<a href='"+egoLink+"' target='_blank'>"+capName+"</a>";

--- a/browse/static/js/influenceflower.js
+++ b/browse/static/js/influenceflower.js
@@ -46,9 +46,9 @@
 
       $.get(flowerQuery).done(function (response) {
         if (response['status'] === 'Success') {
-          output.innerHTML = '<p>Influence flowers are visualisations for citation influences '
-            + 'among academic entities, including papers, authors, institutions, and research topics, '
-            + 'computed using the Microsoft Academic Graph.</p>';
+          output.innerHTML = '<p>Influence flowers are visualizations for citation influences '
+            + 'among academic entities, including papers, authors, institutions, and research topics. '
+            + 'See <a href="https://influencemap.cmlab.dev/" target="_blank">here</a> for more detail.</p>';
           output_graph.style.display='block';
           flowerData = response;
           drawInfluenceFlowers(response);


### PR DESCRIPTION
This pull request edits the description sentence of the influence flowers. Also, it fixes hyperlinks on flower nodes.

The sentence changes from 
> "Influence flowers are visualizations for citation influences among academic entities, including papers, authors, institutions, and research topics, computed using the Microsoft Academic Graph."

to
> "Influence flowers are visualizations for citation influences among academic entities, including papers, authors, institutions, and research topics. See [here](https://influencemap.cmlab.dev/) for more detail."