### PR TITLE
change banner end date

### DIFF
--- a/browse/templates/home/special-message.html
+++ b/browse/templates/home/special-message.html
@@ -13,10 +13,8 @@
 <div class="message-special dark column">
   <span class="label">arXiv Forum</span>
   <h2>How do we make accessible research papers a reality?</h2>
-  <p>Can we truly call it "Open Science" when most research papers are not fully accessible? <a href="https://info.arxiv.org/about/accessibility_forum.html">Join arXiv's forum</a> on Monday April 17 to chart a path towards truly accessible research papers.</p>
-  <p>This half-day online forum will center the experiences of academic researchers with disabilities who face barriers to accessing and reading papers in their field.
-    The forum will be useful for people across the academic publishing pipeline, including authors and readers. Let's chart a path towards truly accessible research papers.
-    <a href="https://info.arxiv.org/about/accessibility_forum.html">Learn more and register here</a>.</p>
+  <p>Can we truly call it "Open Science" when most research papers are not fully accessible? Though registration has ended early due to extremely high interest levels, you can <a href="https://info.arxiv.org/about/accessibility_forum.html">learn more about the forum arXiv is hosting</a> on Monday April 17 to chart a path towards truly accessible research papers.</p>
+  <p>Recordings of the presentations and panel discussion will be shared after the 17th, along with notes from the breakout discussion groups. Keep an eye out for updates and links.</p>
 </div>
 
 <!-- annual giving message -->

--- a/browse/templates/user_banner.html
+++ b/browse/templates/user_banner.html
@@ -14,7 +14,7 @@ This no longer uses env vars set in httpd/conf/ng_flask.conf on production.
 
 {# Set these variables to a string of YYYYMMMDD of the start and end date #}
 {% set BANNER_START = '20230316' %}
-{% set BANNER_END = '20230324' %}
+{% set BANNER_END = '20230319' %}
 
 {# accessibility CTA banner #}
 {%- macro content(request_datetime) -%}


### PR DESCRIPTION
Ending forum banner early due to the high signup rate. Whenever this can be deployed to production that would be great. This PR includes a single line edit to user_banner.html, and also updates the homepage forum text.