### PR TITLE
Fixes home page link for CS

### DIFF
--- a/browse/templates/home/home.html
+++ b/browse/templates/home/home.html
@@ -86,18 +86,23 @@
   <ul>
     {% for archive_key, archive_details in archives.items()|sort(attribute='1.name') if archives[archive_key].in_group == group_key  %}
       {%- set archive_search_url = url_for('search_archive', archive=archive_key) -%}
-      {%- set archive_url = url_for('browse.archive', archive=archive_key) if archive_key != 'cs' else url_for('corr') -%}
+      {%- set archive_url = url_for('browse.archive', archive=archive_key) if archive_key != 'cs' else 'https://info.arxiv.org/help/cs/index.html' -%}
       {%- set archive_name = archives[archive_key].name if archive_key != 'cs' else 'Computing Research Repository' -%}
-
-    {#- TODO: url_for /list, /catchup -#}
     <li>
       <a href="{{ archive_url }}" id="main-{{ archive_key }}" aria-labelledby="main-{{ archive_key }}">{{ archive_name }}</a>
-      (<strong id="{{ archive_key }}">{{ archive_key if archive_key != 'cs' else 'CoRR' }}</strong> <a id="new-{{ archive_key }}" aria-labelledby="new-{{ archive_key }} {{ archive_key }}" href="/list/{{ archive_key }}/new">new</a>, <a id="recent-{{ archive_key }}" aria-labelledby="recent-{{ archive_key }} {{ archive_key }}" href="/list/{{ archive_key }}/recent">recent</a>, <a id="search-{{ archive_key }}" aria-labelledby="search-{{ archive_key }} {{ archive_key }}" href="{{ archive_search_url }}">search</a>{% if 0 %}, <a href="/catchup?archive={{ archive_key }}&amp;sdaysback=30&amp;num=2000&amp;order=reverse&amp;method=without">last month</a>{% endif %})
+      (<strong id="{{ archive_key }}">{{ archive_key if archive_key != 'cs' else 'CoRR' }}</strong>
+      <a id="new-{{ archive_key }}" aria-labelledby="new-{{ archive_key }} {{ archive_key }}" href="/list/{{ archive_key }}/new">new</a>,
+      <a id="recent-{{ archive_key }}" aria-labelledby="recent-{{ archive_key }} {{ archive_key }}" href="/list/{{ archive_key }}/recent">recent</a>,
+      <a id="search-{{ archive_key }}" aria-labelledby="search-{{ archive_key }} {{ archive_key }}" href="{{ archive_search_url }}">search</a>
+      {% if 0 %},<a href="/catchup?archive={{ archive_key }}&amp;sdaysback=30&amp;num=2000&amp;order=reverse&amp;method=without">last month</a>{% endif %})
       {%- if group_key == 'grp_physics' and archive_key not in categories  -%}
       <br/>includes:
+      {%- elif group_key == 'cs' -%}
+      <br/>includes (see <a href="{{url_for('archive', archive=archive_key)}}" id="details-{{ archive_key }}" aria-labelledby="details-{{ archive_key }} main-{{ archive_key }}">detailed description</a>):
       {%- elif group_key != 'grp_physics' -%}
       <br/>includes (see <a href="{{url_for('desc_' ~ archive_key)}}" id="details-{{ archive_key }}" aria-labelledby="details-{{ archive_key }} main-{{ archive_key }}">detailed description</a>):
       {%- endif -%}
+
       {% for category_key, category_details in categories.items()|sort(attribute='1.name') if categories[category_key].in_archive == archive_key %}
       {% if not (loop.first and loop.last and group_key == 'grp_physics') %}<a href="/list/{{ category_key }}/recent" id="{{ category_key }}" aria-labelledby="main-{{ archive_key }} {{ category_key }}">{{ categories[category_key].name }}</a>{% if not loop.last %}; {% endif %}{% endif %}
       {% endfor %}


### PR DESCRIPTION
Set URL to CS as CoRR to info.arxiv.org and set description to archive/cs.

These URLs are currently broken on the home page.

https://arxiv-org.atlassian.net/browse/ARXIVCE-285