### PR TITLE
take down forum banner

### DIFF
--- a/browse/templates/user_banner.html
+++ b/browse/templates/user_banner.html
@@ -17,7 +17,7 @@ production. -#}
 
 {# Set these variables to a string of YYYYMMMDD of the start and end date #}
 {% set BANNER_START = '20230329' %}
-{% set BANNER_END = '20230417' %}
+{% set BANNER_END = '20230409' %}
 
 
 {%- macro content(request_datetime) -%}


### PR DESCRIPTION
Changed the end date to 04/09 (Sunday) which should hide the banner. This change can go live anytime. Steinn reports he is hearing grumbling from people annoyed at the banner presence, and we have enough attendees.