### PR TITLE
Adds better error handling for /bibtex 

### DIFF
--- a/tests/test_bibex.py
+++ b/tests/test_bibex.py
@@ -34,3 +34,28 @@ class BibexTest(TestCase):
             txt,
             "citation meta tag must have jref DOI",
         )
+
+    def test_good_bibtex(self):
+        rv = self.app.get(f"/bibtex/0906.3421")
+        self.assertEqual(rv.status_code, 200)
+
+        rv = self.app.get(f"/bibtex/0906.3421v1")
+        self.assertEqual(rv.status_code, 200)
+
+    def test_bibex_none(self):
+        """Don't do a 500 for /bibex/None ARXIVCE-339."""
+        rv = self.app.get(f"/bibtex/None")
+        self.assertEqual(rv.status_code, 400)
+
+    def test_bab_bibtex(self):
+        rv = self.app.get(f"/bibtex/0906.3421v9999")
+        self.assertEqual(rv.status_code, 404)
+
+        rv = self.app.get(f"/bibtex/cs")
+        self.assertEqual(rv.status_code, 400)
+
+        rv = self.app.get(f"/bibtex/0906.3ab1")
+        self.assertEqual(rv.status_code, 400)
+
+        rv = self.app.get(f"/bibtex/0913.1234")
+        self.assertEqual(rv.status_code, 400)


### PR DESCRIPTION
/bibtex/None is throwing 500 when it should be 400. Fixes this and some other cases.

When InternalServerError is explicitly raised the stack trace of the error does not end up in the logs. That hinders investigation of problems. 

ARXIVCE-339