### PR TITLE
Change Hugging Face integration to updated endpoint

### DIFF
--- a/browse/static/js/spaces.js
+++ b/browse/static/js/spaces.js
@@ -73,7 +73,7 @@
   
     function renderModels(models) {
       const visibleModels = 5;
-      const urlSpaces = 75;
+      const urlSpaces = 100;
 
       const space_ids = models.slice(0, urlSpaces).map(m => m.id).join(",");
       const spaces_link = `${huggingfaceSpacesHost}/?sort=likes&id=or:${space_ids}`;

--- a/browse/static/js/spaces.js
+++ b/browse/static/js/spaces.js
@@ -53,6 +53,7 @@
           return b.likes - a.likes;
       });
 
+      /// TODO: Update this to use Spaces filter rather than by linked model
       let models = await paper_data.models;
       const model_ids = models.map(m => m.id).join(",");
       const huggingfaceSpacesFromModelsLink = `${huggingfaceSpacesHost}/?sort=likes&models=or:${model_ids}`;

--- a/browse/static/js/spaces.js
+++ b/browse/static/js/spaces.js
@@ -1,7 +1,6 @@
 // Labs integration for displaying machine learning demos from huggingface.co/spaces
 
 (function () {
-    console.log("Getting Spaces")
     const container = document.getElementById("spaces-output")
     const containerAlreadyHasContent = container.innerHTML.trim().length > 0
   
@@ -49,7 +48,7 @@
         return;
       }
       // To remove after https://github.com/huggingface/moon-landing/pull/6108 
-      let new_data = spaces_data.sort(function(a, b){
+      spaces_data.sort(function(a, b){
           return b.likes - a.likes;
       });
 
@@ -58,7 +57,7 @@
       const model_ids = models.map(m => m.id).join(",");
       const huggingfaceSpacesFromModelsLink = `${huggingfaceSpacesHost}/?sort=likes&models=or:${model_ids}`;
 
-      render(new_data, huggingfaceSpacesFromModelsLink);
+      render(spaces_data, huggingfaceSpacesFromModelsLink);
     })()
   
     // Generate HTML, sanitize it to prevent XSS, and inject into the DOM

--- a/browse/static/js/spaces.js
+++ b/browse/static/js/spaces.js
@@ -64,20 +64,20 @@
           return `<p class="spaces-summary">
           No Spaces demos found for this article. You can <a href="https://huggingface.co/new-space">add one here</a>.
           </p>`
-          break
         case 1:
           return `<p class="spaces-summary">@${models[0].author} has implemented an open-source demo based on this paper. Run it on Spaces:</p>`
-          break
         default:
           return `<p class="spaces-summary">There are ${models.length} open-source demos based on this paper. Run them on Spaces:</p>`
       }
     }
   
     function renderModels(models) {
-      const space_ids = models.map(m => m.id).join(",");
+      const visibleModels = 5;
+      const urlSpaces = 75;
+
+      const space_ids = models.slice(0, urlSpaces).map(m => m.id).join(",");
       const spaces_link = `${huggingfaceSpacesHost}/?sort=likes&id=or:${space_ids}`;
     
-      const visibleModels = 5;
       return models.slice(0, visibleModels).map(m => renderModel(m)).join("\n") + (models.length > visibleModels ? `
         <a href="${spaces_link}" target="_blank">
           <button class="spaces-load-all-link">


### PR DESCRIPTION
The new endpoint (e.g. https://huggingface.co/api/arxiv/1912.13318/repos) provides information of all spaces linked directly to a paper, hence avoiding doing two requests to the Hub to get the required information and simplifying the logic. On top of that, in the link to view all demos, it sorts by likes to give the most relevant ones