### PR TITLE
Changes withdrawn abs page

### DIFF
--- a/browse/controllers/abs_page/__init__.py
+++ b/browse/controllers/abs_page/__init__.py
@@ -140,13 +140,9 @@ def get_abs_page(arxiv_id: str) -> Response:
                     response_data["higher_version_withdrawn"] = True
                     response_data["higher_version_withdrawn_submitter"] = _get_submitter(abs_meta.arxiv_identifier, ver_index+1)
 
+        response_data["withdrawn"] = abs_meta.version_history[abs_meta.version - 1] in response_data["withdrawn_versions"]
 
-        # Following are less critical and template must display without them
-        # try:
         _non_critical_abs_data(abs_meta, arxiv_identifier, response_data)
-        # except Exception:
-        #    logger.warning("Error getting non-critical abs page data",
-        #                   exc_info=app.debug)
 
     except AbsNotFoundException:
         if (

--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -230,8 +230,7 @@
 {% endif %}
 <div id="content-inner">
   <div id="abs">
-      {%- set current = abs_meta.version == abs_meta.version_history[-1].version -%}
-      {% if abs_meta.version_history[abs_meta.version - 1] in withdrawn_versions %}
+      {% if withdrawn %}
           <span class="error" style="border: 2px solid grey">This paper has been withdrawn by {{ abs_meta.submitter.name|tex2utf if abs_meta.submitter.name != None }}</span>
       {% elif higher_version_withdrawn %}
           <span class="error" style="border: 2px solid grey">A newer version of this paper has been withdrawn by {{ higher_version_withdrawn_submitter|tex2utf }}</span>
@@ -255,7 +254,7 @@
         {%- if comments %}
         <tr>
           <td class="tablecell label">Comments:</td>
-          <td class="tablecell comments mathjax">{{ comments|tex2utf|urlize|safe }}</td>
+          <td class="tablecell comments mathjax">{%- if withdrawn -%}<em style="color: unset">{%- endif -%}{{ comments|tex2utf|urlize|safe }}{%- if withdrawn -%}</em>{%- endif -%}</td>
         </tr>
         {% endif -%}
         <tr>

--- a/browse/templates/abs/extra_services.html
+++ b/browse/templates/abs/extra_services.html
@@ -30,19 +30,11 @@
 
 {%- macro generate_download_links(format_list=[]) -%}
 <ul>
-  {% set author_list = abs_meta.authors.raw.split(',') %}
-  <div id="download-button-info" hidden>
-    {%- if author_list|length > 1 -%}
-    Download a PDF of the paper titled {{abs_meta.title}}, by {{author_list[0]}} and {{author_list|length - 1}} other authors
-    {%- elif author_list|length == 1 -%}
-    Download a PDF of the paper titled {{abs_meta.title}}, by {{author_list[0]}}
-    {%- else -%}
-    Download a PDF of the paper titled {{abs_meta.title}}
-    {%- endif -%}
-  </div>
   {%- set current = abs_meta.version == abs_meta.version_history[-1].version -%}
   {%- if format_list|length == 0 or ( not current and format_list|length == 1 and format_list[0] == 'src' ) -%}
   <li>Unavailable</li>
+  {%- elif withdrawn -%}
+  <li>Withdrawn</li>
   {% else %}
     {#- We have to skip the 'src' format unless we're viewing the current version of the article -#}
     {%- for format in format_list if not (format == 'src' and not current) %}
@@ -52,6 +44,16 @@
     {%- elif format.startswith('ps') -%}
     <a href="{{url_for('.ps', arxiv_id=requested_id)}}" class="abs-button download-ps">PostScript{% if format.endswith('(400)') %} (400 dpi){% elif format.endswith('(600)') %} (600 dpi){% elif format.endswith('(cm)') %} (Type I cm){% elif format.endswith('(CM)') %} (Type I CM){% endif %}</a>
     {%- elif format.startswith('pdf') -%}
+    <div id="download-button-info" hidden>
+      {% set author_list = abs_meta.authors.raw.split(',') %}
+      {%- if author_list|length > 1 -%}
+      Download a PDF of the paper titled {{abs_meta.title}}, by {{author_list[0]}} and {{author_list|length - 1}} other authors
+      {%- elif author_list|length == 1 -%}
+      Download a PDF of the paper titled {{abs_meta.title}}, by {{author_list[0]}}
+      {%- else -%}
+      Download a PDF of the paper titled {{abs_meta.title}}
+      {%- endif -%}
+    </div>
     <a href="{{url_for('.pdf', arxiv_id=requested_id)}}" aria-describedby="download-button-info" accesskey="f" class="abs-button download-pdf">PDF{% if format.endswith('only') %} only{% endif %}</a>
     {%- elif format == 'dvi' -%}
     <a href="{{url_for('.dvi', arxiv_id=requested_id)}}" class="abs-button download-dvi">{{ format.upper() }}</a>
@@ -190,7 +192,9 @@
       <h2>Download:</h2>
       {{ generate_download_links(format_list=formats) }}
       <div class="abs-license">
-        {%- if abs_meta.license.icon_uri_path -%}
+        {%- if withdrawn -%}
+        <div hidden>No license for this version due to withdrawn</div>
+        {%- elif abs_meta.license.icon_uri_path -%}
         <a href="{{abs_meta.license.effective_uri}}" title="Rights to this article"><img src="https://arxiv.org{{ abs_meta.license.icon_uri_path }}"/></a>
         {%- else -%}
         (<a href="{{abs_meta.license.effective_uri}}" title="Rights to this article">license</a>)

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -522,6 +522,9 @@ class BrowseTest(unittest.TestCase):
         self.assertIn("This paper has been withdrawn by arXiv Admin", txt,
                       "Expect an admin withdrawn message.")
 
+        self.assertNotIn('href="/e-print/2101.10016"', txt,
+                         "Should not have link to source since it is useless, src is empty")
+
         rv = self.app.get('/abs/2101.10016v8')
         self.assertEqual(rv.status_code, 200)
         txt = rv.data.decode('utf-8')
@@ -534,39 +537,53 @@ class BrowseTest(unittest.TestCase):
         txt = rv.data.decode('utf-8')
         self.assertIn("A newer version of this paper has been withdrawn by arXiv Admin", txt,
                       "Expect an admin withdrawn message on earlier verison.")
+        self.assertIn('href="/pdf/2101.10016', txt,
+                         "Should have link to pdf")
 
         rv = self.app.get('/abs/2101.10016v6')
         self.assertEqual(rv.status_code, 200)
         txt = rv.data.decode('utf-8')
         self.assertIn("A newer version of this paper has been withdrawn by arXiv Admin", txt,
                       "Expect an admin withdrawn message on earlier verison.")
+        self.assertIn('href="/pdf/2101.10016', txt,
+                         "Should have link to pdf")
 
         rv = self.app.get('/abs/2101.10016v5')
         self.assertEqual(rv.status_code, 200)
         txt = rv.data.decode('utf-8')
         self.assertIn("A newer version of this paper has been withdrawn by arXiv Admin", txt,
                       "Expect an admin withdrawn message on earlier verison.")
+        self.assertIn('href="/pdf/2101.10016', txt,
+                         "Should have link to pdf")
 
         rv = self.app.get('/abs/2101.10016v4')
         self.assertEqual(rv.status_code, 200)
         txt = rv.data.decode('utf-8')
         self.assertIn("A newer version of this paper has been withdrawn by arXiv Admin", txt,
                       "Expect an admin withdrawn message on earlier verison.")
+        self.assertIn('href="/pdf/2101.10016', txt,
+                         "Should have link to pdf")
 
         rv = self.app.get('/abs/2101.10016v3')
         self.assertEqual(rv.status_code, 200)
         txt = rv.data.decode('utf-8')
         self.assertIn("A newer version of this paper has been withdrawn by arXiv Admin", txt,
                       "Expect an admin withdrawn message on earlier verison.")
+        self.assertIn('href="/pdf/2101.10016', txt,
+                         "Should have link to pdf")
 
         rv = self.app.get('/abs/2101.10016v2')
         self.assertEqual(rv.status_code, 200)
         txt = rv.data.decode('utf-8')
         self.assertIn("A newer version of this paper has been withdrawn by arXiv Admin", txt,
                       "Expect an admin withdrawn message on earlier verison.")
+        self.assertIn('href="/pdf/2101.10016', txt,
+                         "Should have link to pdf")
 
         rv = self.app.get('/abs/2101.10016v1')
         self.assertEqual(rv.status_code, 200)
         txt = rv.data.decode('utf-8')
         self.assertIn("A newer version of this paper has been withdrawn by arXiv Admin", txt,
                       "Expect an admin withdrawn message on earlier verison.")
+        self.assertIn('href="/pdf/2101.10016', txt,
+                         "Should have link to pdf")


### PR DESCRIPTION
Red boarder to black border. 

Withdrawn is not an error state. 

Removes download link to source ( https://arxiv.org/e-print/{arxiv_id} ) since there is not any source.

Bolds comment. Jim asked for a box similar to the withdrawn message but that doesn't work due tot he comment being in a table.

<img width="1868" alt="image" src="https://github.com/arXiv/arxiv-browse/assets/1616/39676c7d-acb5-49da-a778-c89bd47bdb2b">
