### PR TITLE
Fixes bug with withdraw message on some older submissions

### DIFF
--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -198,6 +198,38 @@
   {% endif %}
 {% endmacro %}
 
+{%- macro withdrawn_msg() -%}
+    {% if higher_version_withdrawn and higher_version_withdrawn_submitter != None %}
+    <span class="error" style="border: 2px solid grey">A newer version of this paper has been withdrawn by {{ higher_version_withdrawn_submitter|tex2utf }}</span>
+    {% elif higher_version_withdrawn and higher_version_withdrawn_submitter == None %}
+    <span class="error" style="border: 2px solid grey">A newer version of this paper has been withdrawn    <div class="button-and-tooltip">
+      <button class="more-info" aria-describedby="more-info-desc-1">
+        <svg height="15" role="presentation" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z" class=""></path></svg>
+        <span class="visually-hidden">Focus to learn more</span>
+      </button>
+      <!-- tooltip description -->
+      <div role="tooltip" id="more-info-desc-1">
+        <span class="left-corner"></span>
+        Older arxiv papers may lack submitter name
+      </div>
+    </div></span>
+    {% elif abs_meta.submitter.name != None %}
+    <span class="error" style="border: 2px solid grey">This paper has been withdrawn by {{ abs_meta.submitter.name|tex2utf }}</span>
+    {% elif abs_meta.submitter.name == None %}
+    <span class="error" style="border: 2px solid grey">This paper has been withdrawn     <div class="button-and-tooltip">
+      <button class="more-info" aria-describedby="more-info-desc-1">
+        <svg height="15" role="presentation" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z" class=""></path></svg>
+        <span class="visually-hidden">Focus to learn more</span>
+      </button>
+      <!-- tooltip description -->
+      <div role="tooltip" id="more-info-desc-1">
+        <span class="left-corner"></span>
+        Older arxiv papers may lack submitter name
+      </div>
+    </div></span>
+    {% endif %}
+{% endmacro %}
+
 {% macro abs(
     arxiv_id,
     title,
@@ -230,11 +262,7 @@
 {% endif %}
 <div id="content-inner">
   <div id="abs">
-      {% if withdrawn %}
-          <span class="error" style="border: 2px solid grey">This paper has been withdrawn by {{ abs_meta.submitter.name|tex2utf if abs_meta.submitter.name != None }}</span>
-      {% elif higher_version_withdrawn %}
-          <span class="error" style="border: 2px solid grey">A newer version of this paper has been withdrawn by {{ higher_version_withdrawn_submitter|tex2utf }}</span>
-      {% endif %}
+    {% if withdrawn or higher_version_withdrawn %}{{ withdrawn_msg() }}{% endif %}
     <div class="dateline">{{ base_macros.abs_date_line(arxiv_id, submitted_date, version, submission_history) }}</div>
     <h1 class="title mathjax"><span class="descriptor">Title:</span>{{ title|tex2utf|arxiv_id_urlize|safe }}</h1>
     <div class="authors"><span class="descriptor">Authors:</span>{{ authors }}</div>

--- a/tests/data/abs_files/ftp/astro-ph/papers/9709/9709175.abs
+++ b/tests/data/abs_files/ftp/astro-ph/papers/9709/9709175.abs
@@ -1,0 +1,30 @@
+------------------------------------------------------------------------------
+\\
+arXiv:astro-ph/9709175
+From: <ex@example.com>
+Date: Wed, 17 Sep 1997 22:23:48 GMT   (130kb)
+Date (revised v2): Thu, 18 Sep 1997 00:01:57 GMT   (0kb,I)
+Date (revised v3): Fri, 19 Sep 1997 20:41:32 GMT   (136kb)
+
+Title: Morphology Transformation in Pairs of Galaxies - The Local Sample
+Authors: Selma Junqueira (Observatorio Nacional - Brazil), Duilia F. de Mello
+  (Observatorio Nacional - Brazil), Leopoldo Infante (P. Universidad Catolica -
+  Chile)
+Categories: astro-ph
+Comments: 14 pages LaTeX file, 7 gif figures, uses epsf.sty, l-aa.sty
+DOI: 10.1051/aas:1998174
+\\
+  We present photometric analysis of a local sample of 14 isolated pairs of
+galaxies. The photometric properties analyzed in the local pairs are: colors,
+morphology, tidal effects and activity. We verify that close pairs have an
+excess of early-type galaxies and many elliptical galaxies in this pairs are,
+in fact, lenticular galaxies. Many late-pairs in our sample show strong tidal
+damage and blue star formation regions. We conclude that pairs of different
+morphologies may have passed through different evolution processes which
+violently transformed their morphology. Pairs with at least one early-type
+component may be descendents of groups of galaxies. However, late-type pairs
+are probably long-lived showing clearly signs of interaction. Some of them
+could be seen as an early stage of mergers. These photometric database will be
+used for future comparison with more distant pairs in order to study galaxy
+evolution.
+\\

--- a/tests/data/abs_files/orig/astro-ph/papers/9709/9709175v1.abs
+++ b/tests/data/abs_files/orig/astro-ph/papers/9709/9709175v1.abs
@@ -1,0 +1,26 @@
+------------------------------------------------------------------------------
+\\
+arXiv:astro-ph/9709175
+From: Selma Junqueira <ex@example.com>
+Date: Wed, 17 Sep 1997 22:23:48 GMT   (130kb)
+
+Title: Morphology Transformation in Pairs of Galaxies - The Local Sample
+Authors: Selma Junqueira (Observatorio Nacional - Brazil), Duilia F. de Mello
+  (Observatorio Nacional - Brazil), Leopoldo Infante (P. Universidad Catolica -
+  Chile)
+Comments: 14 pages LaTeX file, 7 gif figures, uses epsf.sty, l-aa.sty
+\\
+  We present photometric analysis of a local sample of 14 isolated pairs of
+galaxies. The photometric properties analyzed in the local pairs are: colors,
+morphology, tidal effects and activity. We verify that close pairs have an
+excess of early-type galaxies and many elliptical galaxies in this pairs are,
+in fact, lenticular galaxies. Many late-pairs in our sample show strong tidal
+damage and blue star formation regions. We conclude that pairs of different
+morphologies may have passed through different evolution processes which
+violently transformed their morphology. Pairs with at least one early-type
+component may be descendents of groups of galaxies. However, late-type pairs
+are probably long-lived showing clearly signs of interaction. Some of them
+could be seen as an early stage of mergers. These photometric database will be
+used for future comparison with more distant pairs in order to study galaxy
+evolution.
+\\

--- a/tests/data/abs_files/orig/astro-ph/papers/9709/9709175v2.abs
+++ b/tests/data/abs_files/orig/astro-ph/papers/9709/9709175v2.abs
@@ -1,0 +1,29 @@
+------------------------------------------------------------------------------
+\\
+arXiv:astro-ph/9709175
+From: <ex@example.com>
+Date: Wed, 17 Sep 1997 22:23:48 GMT   (130kb)
+Date (revised v2): Thu, 18 Sep 1997 00:01:57 GMT   (0kb,I)
+
+Title: Morphology Transformation in Pairs of Galaxies - The Local Sample
+Authors: Selma Junqueira (Observatorio Nacional - Brazil), Duilia F. de Mello
+  (Observatorio Nacional - Brazil), Leopoldo Infante (P. Universidad Catolica -
+  Chile)
+Categories: astro-ph
+Comments: This version (astro-ph/9709175v2) was not stored by arXiv. A
+  subsequent replacement was made before versioning was introduced.
+\\
+  We present photometric analysis of a local sample of 14 isolated pairs of
+galaxies. The photometric properties analyzed in the local pairs are: colors,
+morphology, tidal effects and activity. We verify that close pairs have an
+excess of early-type galaxies and many elliptical galaxies in this pairs are,
+in fact, lenticular galaxies. Many late-pairs in our sample show strong tidal
+damage and blue star formation regions. We conclude that pairs of different
+morphologies may have passed through different evolution processes which
+violently transformed their morphology. Pairs with at least one early-type
+component may be descendents of groups of galaxies. However, late-type pairs
+are probably long-lived showing clearly signs of interaction. Some of them
+could be seen as an early stage of mergers. These photometric database will be
+used for future comparison with more distant pairs in order to study galaxy
+evolution.
+\\

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -587,3 +587,35 @@ class BrowseTest(unittest.TestCase):
                       "Expect an admin withdrawn message on earlier verison.")
         self.assertIn('href="/pdf/2101.10016', txt,
                          "Should have link to pdf")
+
+
+    def test_withdrawn_then_new_version(self):
+        """Tess where v2 is withdrawn but then there is a non-withdrawn v3."""
+        rv = self.app.get('/abs/astro-ph/9709175')
+        self.assertEqual(rv.status_code, 200)
+        txt = rv.data.decode('utf-8')
+        self.assertNotIn("This paper has been withdrawn", txt,
+                      "Do not expect a withdrawn message in latest version.")
+
+        rv = self.app.get('/abs/astro-ph/9709175v3')
+        self.assertEqual(rv.status_code, 200)
+        txt = rv.data.decode('utf-8')
+        self.assertNotIn("This paper has been withdrawn", txt,
+                      "Do not expect a withdrawn message in v3.")
+
+
+        rv = self.app.get('/abs/astro-ph/9709175v2')
+        self.assertEqual(rv.status_code, 200)
+        txt = rv.data.decode('utf-8')
+        self.assertIn("This paper has been withdrawn", txt,
+                      "Expect a withdrawn message in v2.")
+
+
+        rv = self.app.get('/abs/astro-ph/9709175v1')
+        self.assertEqual(rv.status_code, 200)
+        txt = rv.data.decode('utf-8')
+        self.assertIn("paper has been withdrawn", txt,
+                      "Expect a withdrawn message in v1 since v2 is withdrawn.")
+
+        self.assertIn("Older arxiv papers may lack submitter name", txt,
+                      "Expect a message about lack of submitter name on old paper")

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -590,7 +590,7 @@ class BrowseTest(unittest.TestCase):
 
 
     def test_withdrawn_then_new_version(self):
-        """Tess where v2 is withdrawn but then there is a non-withdrawn v3."""
+        """Test where v2 is withdrawn but then there is a non-withdrawn v3."""
         rv = self.app.get('/abs/astro-ph/9709175')
         self.assertEqual(rv.status_code, 200)
         txt = rv.data.decode('utf-8')


### PR DESCRIPTION
Older submissions sometimes lack the submitter name. This is probably due to the early arxiv being email based and the submitter name being the optional name part of the from: email field.  



Compare newer abs file:

    ------------------------------------------------------------------------------
    \\
    arXiv:2101.10016
    From: arXiv Admin <help@arxiv.org>
    Date: Mon, 25 Jan 2021 11:32:05 GMT   (171kb)

To older abs file:

    ------------------------------------------------------------------------------
    \\
    arXiv:astro-ph/9709175
    From: <ex@example.com>
    Date: Wed, 17 Sep 1997 22:23:48 GMT   (130kb)

This fixes the code so it handles this unusual case. The display will look like this:
<img width="1867" alt="Screenshot 2023-05-15 124228" src="https://github.com/arXiv/arxiv-browse/assets/1616/24de2dac-2d8b-4315-bbf7-c99fd8d170cb">
And a hover over info icon looks like this:
![Screenshot 2023-05-15 124428](https://github.com/arXiv/arxiv-browse/assets/1616/321e6810-2dd3-42ec-8597-0317d1ec000c)
