### PR TITLE
Hiring banner

### DIFF
--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -655,6 +655,28 @@ footer .sorry-app-links .a11y-main-link {
     width: 88%;
   }
 }
+.banner-minimal {
+  width: 300px;
+  border: 2px solid #b31b1b;;
+  border-radius: 8px;
+  font-size: 1.4em;
+  text-align: center;
+  padding: .5em 1em;
+  background-color: #000000;
+  color: #fb595a;
+  display: flex;
+  align-items: center;
+  justify-content:center;
+}
+.banner-minimal strong {
+  font-size: 1.3em;
+  margin-bottom: 3px;
+  margin-right: 8px;
+}
+.banner-minimal a {
+  color: #f9f7f7;
+  text-decoration: underline;
+}
 /* special header banner, dark override */
 .slider-wrapper.bps-banner.dark {
   background-color: black;

--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -656,26 +656,29 @@ footer .sorry-app-links .a11y-main-link {
   }
 }
 .banner-minimal {
-  width: 300px;
-  border: 2px solid #b31b1b;;
-  border-radius: 8px;
-  font-size: 1.4em;
-  text-align: center;
-  padding: .5em 1em;
-  background-color: #000000;
-  color: #fb595a;
+  width: auto;
   display: flex;
   align-items: center;
   justify-content:center;
 }
-.banner-minimal strong {
-  font-size: 1.3em;
-  margin-bottom: 3px;
-  margin-right: 8px;
-}
 .banner-minimal a {
+  -webkit-box-shadow: 0px 3px 6px 0px #000000);
+  -moz-box-shadow: 0px 3px 6px 0px #000000;
+  box-shadow: 0px 3px 6px 0px #000000;
+  display: inline-block;
+  padding: .25em 1em;
+  border-radius: .3em;
+  font-size: 2em;
+  background-color: #1c1a17;
+  border: 2px solid #6b6459;;
+  color: #fb595a;
+  text-decoration: none;
+  transition: all .5s ease-in-out;
+}
+.banner-minimal a:hover {
+  background-color: #;
+  border-color: #dbc6c6;
   color: #f9f7f7;
-  text-decoration: underline;
 }
 /* special header banner, dark override */
 .slider-wrapper.bps-banner.dark {

--- a/browse/templates/base.html
+++ b/browse/templates/base.html
@@ -36,9 +36,8 @@
         </div>
         {%- set rd_int = request_datetime.strftime("%Y%m%d%H%M")|int -%}
         {%- if rd_int >= 202305010100 and rd_int <= 202308010100 -%}
-        <div class="banner-minimal">
-            <strong>We Are Hiring</strong>
-            <a href="https://info.arxiv.org/hiring/">View open roles</a></p>
+        <div class="column banner-minimal">
+            <a href="https://info.arxiv.org/hiring/">We are hiring</a></p>
         </div>
         {%- endif -%}
         <div class="column" id="support-ack">

--- a/browse/templates/base.html
+++ b/browse/templates/base.html
@@ -34,7 +34,13 @@
         <div class="column" id="cu-logo">
           <a href="https://www.cornell.edu/"><img src="{{ url_for('static', filename='images/icons/cu/cornell-reduced-white-SMALL.svg') }}" alt="Cornell University" /></a>
         </div>
-
+        {%- set rd_int = request_datetime.strftime("%Y%m%d%H%M")|int -%}
+        {%- if rd_int >= 202305010100 and rd_int <= 202308010100 -%}
+        <div class="banner-minimal">
+            <strong>We're Hiring</strong>
+            <a href="https://info.arxiv.org/hiring/">View open roles</a></p>
+        </div>
+        {%- endif -%}
         <div class="column" id="support-ack">
           <a id="support-ack-url" href="{{ url_for('acknowledgment') }}">We gratefully acknowledge support from<br/>the Simons Foundation and member institutions.</a>
         </div>

--- a/browse/templates/base.html
+++ b/browse/templates/base.html
@@ -37,7 +37,7 @@
         {%- set rd_int = request_datetime.strftime("%Y%m%d%H%M")|int -%}
         {%- if rd_int >= 202305010100 and rd_int <= 202308010100 -%}
         <div class="banner-minimal">
-            <strong>We're Hiring</strong>
+            <strong>We Are Hiring</strong>
             <a href="https://info.arxiv.org/hiring/">View open roles</a></p>
         </div>
         {%- endif -%}


### PR DESCRIPTION
adds minimal time-boxed banner to header with hiring link. It does not use our traditional banner code. This banner cannot be closed, but it also does not add to the header height or cover up any other content. It is set to stop displaying on August 1st, but this date can easily be adjusted.

Here are two color options for red-themed (current):
![Screen Shot 2023-05-22 at 11 36 29 AM](https://github.com/arXiv/arxiv-browse/assets/56078140/95f63418-fe7c-4e9e-8c7d-8bed26afcc9e)

and blue-themed:
![Screen Shot 2023-05-22 at 11 39 45 AM](https://github.com/arXiv/arxiv-browse/assets/56078140/4c72cf1e-ba51-4d62-aa16-043280c70a5b)
