### PR TITLE
adds homepage news and hiring banner

### DIFF
--- a/browse/templates/home/home.html
+++ b/browse/templates/home/home.html
@@ -50,13 +50,6 @@
          document.getElementById('adv-search-btn').onclick=doAdvSearchBtn;
      },false);
     </script>
-    <h4 class="homepage-news-title">News</h4>
-    <!-- special news section -->
-    {%- include "home/news.html" -%}
-    <div>
-      Read about recent news and updates on <a href="https://blog.arxiv.org/" target="_blank">arXiv's blog</a>.
-      (View the former <a href="{{url_for('new')}}">"what's new" pages</a> here).
-    </div>
   </div>
   <!-- special message column -->
   {%- include "home/special-message.html" -%}

--- a/browse/templates/home/special-message.html
+++ b/browse/templates/home/special-message.html
@@ -14,7 +14,7 @@
 {%- if rd_int >= 202305010100 and rd_int <= 202308010100 -%}
 <div class="message-special column">
   <span class="label">arXiv is hiring!</span>
-  <p>We're looking for a community engagement manager, a few good developers, a program manager, a tech writer/documentation specialist and more.</p>
+  <p>We are looking for a community engagement manager, a few good developers, a program manager, a tech writer/documentation specialist and more.</p>
   <p><a href="https://accessibility2023.arxiv.org/">View open roles</a></p>
 </div>
 {%- endif -%}

--- a/browse/templates/home/special-message.html
+++ b/browse/templates/home/special-message.html
@@ -14,7 +14,7 @@
 {%- if rd_int >= 202305010100 and rd_int <= 202308010100 -%}
 <div class="message-special column">
   <span class="label">arXiv is hiring!</span>
-  <p>We are looking for a community engagement manager, a few good developers, a program manager, a tech writer/documentation specialist and more.</p>
+  <p>We are looking for a community engagement manager.</p>
   <p><a href="https://accessibility2023.arxiv.org/">View open roles</a></p>
 </div>
 {%- endif -%}

--- a/browse/templates/home/special-message.html
+++ b/browse/templates/home/special-message.html
@@ -7,15 +7,14 @@
 <div class="message-special dark column">
   <span class="label">arXiv News</span>
   <h2>TeX Live 2023 Upgrade</h2>
-  <p>Beginning with the Daily Freeze (14:00 Eastern USA Time) on Monday May 22, 2023 arXiv-local time all new submissions and replacements will process under TeX Live 2023.</p>
-  <p>This update will include all of the contents of the TeX Live 2023 release as well as arXiv’s “custom” local packages that have been updated since our last tex upgrade (September, 2020). </p>
+  <p>Beginning on Monday May 22, 2023 all new submissions and replacements will process under TeX Live 2023.</p>
   <p><a href="https://blog.arxiv.org/2023/05/12/tex-live-2023-upgrade-to-occur-may-22nd-2023/">Learn More</a></p>
 </div>
 
 {%- if rd_int >= 202305010100 and rd_int <= 202308010100 -%}
 <div class="message-special column">
   <span class="label">arXiv is hiring!</span>
-  <p>We're looking for a community engagement manager, a few good developers, a program manager, a tech writer/documentation specialist and more.
-    <a href="https://accessibility2023.arxiv.org/">View open roles</a>.</p>
+  <p>We're looking for a community engagement manager, a few good developers, a program manager, a tech writer/documentation specialist and more.</p>
+  <p><a href="https://accessibility2023.arxiv.org/">View open roles</a></p>
 </div>
 {%- endif -%}

--- a/browse/templates/home/special-message.html
+++ b/browse/templates/home/special-message.html
@@ -1,27 +1,21 @@
-{#- Special messages appear in a column to the side of the website intro/news section, each in their own column. Always apply the style "message-special" to the column. You can also apply the style "dark" to override the red styles and add a message with a black background instead. There should preferably be just one, and never more than two. -#}
+{#- Special messages appear in a column to the side of the website intro/news section,
+  each in their own column. Always apply the style "message-special" to the column.
+  You can also apply the style "dark" to override the red styles and add a message with a black background instead.
+  There should preferably be just one, and never more than two. -#}
 {%- set rd_int = request_datetime.strftime("%Y%m%d%H%M")|int -%}
 
-{%- if rd_int >= 202303200100 and rd_int <= 202304180100 -%}
 <div class="message-special dark column">
-  <span class="label">arXiv Forum</span>
-  <h2>How do we make accessible research papers a reality?</h2>
-  <p>If research isn't accessible, can we truly call it "open" science?</p>
-  <p>On Monday April 17, arXiv is hosting a forum on <a href="https://info.arxiv.org/about/accessibility_forum.html">how we can make accessible research papers a reality</a>.
-  We each have a role to play. Together, we can chart a path towards truly accessible research papers.</p>
-  <p><a href="https://info.arxiv.org/about/accessibility_forum.html">Learn More</a></p>
+  <span class="label">arXiv News</span>
+  <h2>TeX Live 2023 Upgrade</h2>
+  <p>Beginning with the Daily Freeze (14:00 Eastern USA Time) on Monday May 22, 2023 arXiv-local time all new submissions and replacements will process under TeX Live 2023.</p>
+  <p>This update will include all of the contents of the TeX Live 2023 release as well as arXiv’s “custom” local packages that have been updated since our last tex upgrade (September, 2020). </p>
+  <p><a href="https://blog.arxiv.org/2023/05/12/tex-live-2023-upgrade-to-occur-may-22nd-2023/">Learn More</a></p>
 </div>
-{%- endif -%}
 
-{%- if rd_int >= 202304180101 and rd_int <= 202305180100 -%}
-<div class="message-special dark column">
-  <span class="label">arXiv Forum</span>
-  <h2>How do we make accessible research papers a reality?</h2>
-  <p>On April 17 arXiv hosted a forum on the accessibility of research papers. <a href="https://accessibility2023.arxiv.org/">Visit our forum website</a> for session recordings, notes, discussion boards, and how to get involved in making accessible research papers a reality.</p>
-  <p><a href="https://accessibility2023.arxiv.org/">Learn More</a> If research isn't accessible, is it really "open" science?</p>
+{%- if rd_int >= 202305010100 and rd_int <= 202308010100 -%}
+<div class="message-special column">
+  <span class="label">arXiv is hiring!</span>
+  <p>We're looking for a community engagement manager, a few good developers, a program manager, a tech writer/documentation specialist and more.
+    <a href="https://accessibility2023.arxiv.org/">View open roles</a>.</p>
 </div>
-{%- endif -%}
-
-<!-- annual giving message -->
-{%- if rd_int >= 2019092300 and rd_int <= 2019092700 -%}
-23 Sep 2019: Our giving campaign is this week. <a href="https://blogs.cornell.edu/arxiv/2019/09/19/donate-to-arxiv-4/">Support arXiv with a donation!</a><br/>
 {%- endif -%}


### PR DESCRIPTION
This PR removes some older references to news, and adds a permanent banner area on the homepage for notes of that kind.  This PR also adds a second, temporary banner area with a note about hiring and open roles. See screenshot:

![Screen Shot 2023-05-22 at 2 06 33 PM](https://github.com/arXiv/arxiv-browse/assets/56078140/d5f2ec39-0755-40fc-9886-a7bc67a43f6c)