### PR TITLE
remove Mendeley and Sciencewise bookmark links from abs

### DIFF
--- a/browse/templates/abs/bookmarking.html
+++ b/browse/templates/abs/bookmarking.html
@@ -7,19 +7,9 @@
     <img src="{{ url_for('static', filename='images/icons/social/bibsonomy.png') }}"
          alt="BibSonomy logo"/>
   </a>
-  <a class="abs-button abs-button-grey abs-button-small" href="{{('https://www.mendeley.com/import/?url=' + absUrl) | clickthrough_url_for}}"
-     title="Bookmark on Mendeley">
-    <img src="{{ url_for('static', filename='images/icons/social/mendeley.png') }}"
-         alt="Mendeley logo"/>
-  </a>
   <a class="abs-button abs-button-grey abs-button-small" href="{{('https://reddit.com/submit?url=' + absUrl + '&title=' + title) | clickthrough_url_for}}"
      title="Bookmark on Reddit">
     <img src="{{ url_for('static', filename='images/icons/social/reddit.png') }}"
          alt="Reddit logo"/>
-  </a>
-  <a class="abs-button abs-button-grey abs-button-small" href="{{('http://sciencewise.info/bookmarks/add?url=' + absUrl ) | clickthrough_url_for}}"
-     title="Bookmark on ScienceWISE">
-    <img src="{{ url_for('static', filename='images/icons/social/sciencewise.png') }}"
-         alt="ScienceWISE logo"/>
   </a>
 </div>


### PR DESCRIPTION
Removes 2 bookmark links. 

Mendeley was bought by elsevier and you are redirected to an Elsevier login page. That is a bad association for arXiv and not worth the small benefit to users of having that link on our page.

Sciencewise appears to not offer that service anymore, even on the new sciencewise.org.uk. Removing it for now, and if the service resurfaces we can add it back in.