### PR TITLE
updates funders text in header

### DIFF
--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -177,17 +177,20 @@ em.boxed {
   font-weight: normal;
   font-family: 'Lucida Grande', helvetica, arial, verdana, sans-serif;
   color: #fff;
-  width: 380px;
 }
-
-#support-ack a {
+#support-ack-url {
+  max-width: 400px;
+  float:right;
+  display: block;
+}
+#support-ack-url a {
   color: #fff;
-  text-decoration: none;
   border: none;
+  text-decoration: underline;
 }
-
-#support-ack a:hover {
+#support-ack-url a:hover {
   background: #444;
+  color: yellow;
 }
 
 /*
@@ -2711,6 +2714,9 @@ body#front.with-cu-identity #header #search {
   flex-grow: 1;
   flex-shrink: 1;
   padding: 0.75rem;
+}
+#cu-identity .banner-minimal {
+  text-align: center;
 }
 .columns.is-mobile > .column.is-full {
   flex: none;

--- a/browse/templates/base.html
+++ b/browse/templates/base.html
@@ -41,7 +41,7 @@
         </div>
         {%- endif -%}
         <div class="column" id="support-ack">
-          <a id="support-ack-url" href="{{ url_for('acknowledgment') }}">We gratefully acknowledge support from<br/>the Simons Foundation and member institutions.</a>
+          <span id="support-ack-url">We gratefully acknowledge support from the Simons Foundation, <a href="https://info.arxiv.org/about/ourmembers.html">member institutions</a>, and all contributors. <a href="info.arxiv.org/about/donate.html">Donate</a></span>
         </div>
       </div>
 


### PR DESCRIPTION
These edits are to the text in the header about funders that used to read "We gratefully acknowledge support from the Simons Foundation and [member institutions]." [note that 'member institutions' is replaced by your specific institutional name when there is an IP match... though I could not find a js script for that in browse. I assume it is using the script from base.]

A few small changes:

Appends a "Donate" link after the text.
Inserts 'and all contributors' after 'member institutions'.
[member institutions] is a link, and is updated to the new membership listing page instead of an old confluence page.
It now reads:
"We gratefully acknowledge support from the Simons Foundation, [member institutions], and all contributors. Donate"

(a similar PR is open for base. Another is coming for Submit)