### PR TITLE
Adds a flask cli command to invalidate PDF paths in the CDN

### DIFF
--- a/browse/commands/invalidate.py
+++ b/browse/commands/invalidate.py
@@ -1,0 +1,97 @@
+"""Invalidates pages in the CDN."""
+import re
+from typing import Optional, Iterable, List
+
+import click
+from flask import Blueprint
+from google.api_core import retry
+
+from google.cloud import compute_v1
+from sqlalchemy.orm import Session
+
+from browse.services.database.models import db, NextMail
+
+bp = Blueprint("invalidate", __name__)
+
+
+@bp.cli.command(short_help="invalidates CDN for PDFs from a mailing")
+@click.argument("mailings",
+                #help="Invalidate all PDFs from these mailings. May have more than one. Format YYMMDD.",
+                nargs=-1)
+@click.option("--project", default="arxiv-production")
+@click.option("--cdn", default="browse-arxiv-org-load-balancer2",
+              help="Url-map of the CDN. Find it with `gcloud compute url-maps list`"
+              )
+@click.option("-n", "--dry-run", "dry_run", is_flag=True,
+              help="Only display what paths would be invalidated.",
+              default=False)
+@click.option("-v", is_flag=True,
+              help="Verbose.",
+              default=False)
+def invalidate_mailings(project: str, cdn: str, mailings: List[str], dry_run: bool, v: bool):
+    """Invalidate CDN for PDFs in a mailing."""
+    if not mailings:
+        raise ValueError("mailing must not be empty.")
+
+    mailings = [date for date in mailings if date]
+    if any([not re.match(r'\d{6}', mailing) for mailing in mailings]):
+        raise ValueError("mailings values must be like '230130'")
+
+    paths: List[str] = []
+    session: Session = db.session
+    for mailing in mailings:
+        if v:
+            print(f"About to query for {mailing}")
+        papers = (session.query(NextMail.paper_id, NextMail.version)
+                  .filter(NextMail.mail_id == int(mailing)))
+
+        nn=0;
+        for paper_id, version in papers.all():
+            paths.append(f"/pdf/{paper_id}.pdf")
+            paths.append(f"/pdf/{paper_id}v{version}.pdf")
+            nn = nn+1
+
+        if v:
+            print(f"For {mailing} found {nn} papers.")
+
+    if v:
+        print(f"{len(paths)} paths to invalidate. "
+              "Two for each paper. One with version and one without.")
+
+    _invalidate(project, cdn, paths, dry_run=dry_run, v=v)
+
+
+def _invalidate(proj: str, cdn: str, paths: Iterable[str], dry_run: bool = False, v: bool = False):
+    """Invalidates `paths` on `cdn` in `proj`."""
+    paths.sort()
+    if v:
+        for path in paths:
+            print(path)
+
+    if dry_run:
+        print("Skipping actual invalidate due to dry_run")
+    else:
+        if v:
+            print("Starting invalidation of paths in CDN.")
+        client = compute_v1.UrlMapsClient()
+        for path in paths:
+            request = compute_v1.InvalidateCacheUrlMapRequest(
+                project=proj,
+                url_map=cdn,
+                cache_invalidation_rule_resource=
+                compute_v1.CacheInvalidationRule(
+                    #host="*",
+                    path=path),
+            )
+            _invalidate_req(client, request)
+            if v:
+                print(f"Invalidated {path}.")
+
+def _exception_pred(ex:Exception) -> bool:
+    return (ex and
+            (isinstance(ex, BaseException)
+             or "rate limit exceeded" in str(ex).lower()))
+
+@retry.Retry(predicate=_exception_pred)
+def _invalidate_req(client, request) -> None:
+    client.invalidate_cache_unary(request=request)

--- a/browse/config.py
+++ b/browse/config.py
@@ -411,7 +411,7 @@ class Settings(BaseSettings):
            self.DOCUMENT_LATEST_VERSIONS_PATH.startswith("gs://"):
            self.FS_TZ = "UTC"
            log.warning("Switching FS_TZ to UTC since DOCUMENT_LATEST_VERSIONS_PATH "
-                       "and DOCUMENT_ORIGNAL_VERSIONS_PATH are Google Storage")
+                       "and DOCUMENT_ORIGINAL_VERSIONS_PATH are Google Storage")
            if os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
                log.warning("GOOGLE_APPLICATION_CREDENTIALS is set")
            else:

--- a/browse/factory.py
+++ b/browse/factory.py
@@ -18,6 +18,7 @@ from flask_s3 import FlaskS3
 
 from browse.config import Settings
 from browse.routes import ui, dissemination, src, unimplemented, redirects
+from browse.commands import invalidate
 from browse.services.database import models
 from browse.services.check import service_statuses
 from browse.formatting.email import generate_show_email_hash
@@ -39,14 +40,19 @@ def create_web_app(**kwargs) -> Flask: # type: ignore
     app.config.from_object(settings)
 
     models.init_app(app)  # type: ignore
-
     Base(app)
     #Auth(app)
+
+    # routes
     app.register_blueprint(ui.blueprint)
     app.register_blueprint(dissemination.blueprint)
     app.register_blueprint(src.blueprint)
     app.register_blueprint(redirects.blueprint)
     app.register_blueprint(unimplemented.blueprint)
+
+    # commands
+    app.register_blueprint(invalidate.bp)
+
     s3.init_app(app)
 
     app.jinja_env.trim_blocks = True

--- a/browse/services/database/__init__.py
+++ b/browse/services/database/__init__.py
@@ -3,12 +3,10 @@
 
 import ipaddress
 from datetime import date, datetime
-from logging import Logger
 from typing import Any, Callable, List, Mapping, Optional, Tuple
 
 from flask import current_app
 
-from arxiv.base import logging
 from arxiv.base.globals import get_application_config
 from dateutil.tz import gettz, tzutc
 from sqlalchemy import asc, desc, not_

--- a/poetry.lock
+++ b/poetry.lock
@@ -177,8 +177,8 @@ files = [
 lazy-object-proxy = ">=1.4.0"
 typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 wrapt = [
-    {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
     {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
+    {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
 ]
 
 [[package]]
@@ -936,12 +936,12 @@ files = [
 google-auth = ">=2.14.1,<3.0dev"
 googleapis-common-protos = ">=1.56.2,<2.0dev"
 grpcio = [
-    {version = ">=1.33.2,<2.0dev", optional = true, markers = "python_version < \"3.11\" and extra == \"grpc\""},
     {version = ">=1.49.1,<2.0dev", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
+    {version = ">=1.33.2,<2.0dev", optional = true, markers = "python_version < \"3.11\" and extra == \"grpc\""},
 ]
 grpcio-status = [
-    {version = ">=1.33.2,<2.0dev", optional = true, markers = "python_version < \"3.11\" and extra == \"grpc\""},
     {version = ">=1.49.1,<2.0dev", optional = true, markers = "python_version >= \"3.11\" and extra == \"grpc\""},
+    {version = ">=1.33.2,<2.0dev", optional = true, markers = "python_version < \"3.11\" and extra == \"grpc\""},
 ]
 protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
 requests = ">=2.18.0,<3.0.0dev"
@@ -989,8 +989,8 @@ files = [
 [package.dependencies]
 google-api-core = {version = ">=1.34.0,<2.0.dev0 || >=2.11.dev0,<3.0.0dev", extras = ["grpc"]}
 proto-plus = [
-    {version = ">=1.22.0,<2.0.0dev", markers = "python_version < \"3.11\""},
     {version = ">=1.22.2,<2.0.0dev", markers = "python_version >= \"3.11\""},
+    {version = ">=1.22.0,<2.0.0dev", markers = "python_version < \"3.11\""},
 ]
 protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
 
@@ -1008,6 +1008,25 @@ files = [
 [package.dependencies]
 googleapis-common-protos = ">=1.56.2,<2.0dev"
 protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
+
+[[package]]
+name = "google-cloud-compute"
+version = "1.14.1"
+description = "Google Cloud Compute API client library"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "google-cloud-compute-1.14.1.tar.gz", hash = "sha256:acd987647d7c826aa97b4418141c740ead5e8811d3349315f2f89a30c01c7f4b"},
+    {file = "google_cloud_compute-1.14.1-py2.py3-none-any.whl", hash = "sha256:b40d6aeeb2c5ce373675c869f1404a1bc19b9763b746ad8f2d91ed1148893d6f"},
+]
+
+[package.dependencies]
+google-api-core = {version = ">=1.34.0,<2.0.dev0 || >=2.11.dev0,<3.0.0dev", extras = ["grpc"]}
+proto-plus = [
+    {version = ">=1.22.2,<2.0.0dev", markers = "python_version >= \"3.11\""},
+    {version = ">=1.22.0,<2.0.0dev", markers = "python_version < \"3.11\""},
+]
+protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
 
 [[package]]
 name = "google-cloud-core"
@@ -1045,8 +1064,8 @@ google-cloud-audit-log = ">=0.1.0,<1.0.0dev"
 google-cloud-core = ">=2.0.0,<3.0.0dev"
 grpc-google-iam-v1 = ">=0.12.4,<1.0.0dev"
 proto-plus = [
-    {version = ">=1.22.0,<2.0.0dev", markers = "python_version < \"3.11\""},
     {version = ">=1.22.2,<2.0.0dev", markers = "python_version >= \"3.11\""},
+    {version = ">=1.22.0,<2.0.0dev", markers = "python_version < \"3.11\""},
 ]
 protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
 
@@ -1085,8 +1104,8 @@ files = [
 [package.dependencies]
 google-api-core = {version = ">=1.34.0,<2.0.dev0 || >=2.11.dev0,<3.0.0dev", extras = ["grpc"]}
 proto-plus = [
-    {version = ">=1.22.0,<2.0.0dev", markers = "python_version < \"3.11\""},
     {version = ">=1.22.2,<2.0.0dev", markers = "python_version >= \"3.11\""},
+    {version = ">=1.22.0,<2.0.0dev", markers = "python_version < \"3.11\""},
 ]
 protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<5.0.0dev"
 
@@ -2255,8 +2274,8 @@ files = [
 astroid = ">=2.15.2,<=2.17.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
-    {version = ">=0.2", markers = "python_version < \"3.11\""},
     {version = ">=0.3.6", markers = "python_version >= \"3.11\""},
+    {version = ">=0.2", markers = "python_version < \"3.11\""},
 ]
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.8"
@@ -2945,4 +2964,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "a0b49fc841f13b13ccb19e9e31a0c59c5ad3d7b60bfa6d4afb3ebafd9ada2ecb"
+content-hash = "046b0e48ff5523bfe89b392bb25a9558463c9fee8e63079a2aa5db7b7c54c1c6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ lxml = "^4.9.2"
 xmltodict = "^0.13.0"
 arxiv-base = {git = "https://github.com/arXiv/arxiv-base.git", rev = "1a6035ab"}
 flask = "~=2.2.2"
+google-cloud-compute = "^1.14.1"
 
 [tool.poetry.dev-dependencies]
 beautifulsoup4 = "*"


### PR DESCRIPTION
Adds a flask cli command  in arxiv-browse as part of the flask app that invalidates PDF paths in the CDN. I did it as part of the flask app since I wanted access to the ORM models.

```

cloud_sql_proxy \
 -instances=arxiv-somenv:us-regionN:arxiv-somenv-repN=tcp:0.0.0.0:1234 &

export BROWSE_SQLALCHEMY_DATABASE_URI=mysql://browse:{IN_SECRETS}@127.0.0.1:1234/arXiv

FLASK_APP=browse.factory:create_web_app flask invalidate invalidate_mailings -v 231009
About to query for 231009
For 231009 found 1230 papers.
2460 paths to invalidate. Two for each paper. One with version and one without.
/pdf/1010.2391.pdf

[... 600 or so lines ...]

/pdf/math/0607294.pdf
/pdf/math/0607294v3.pdf
Starting invalidation of paths in CDN.
Invalidated /pdf/1010.2391.pdf.
Invalidated /pdf/1010.2391v10.pdf.
Invalidated /pdf/1012.3643.pdf.
Invalidated /pdf/1012.3643v1.pdf.
[... 1200 or so lines ...]

```
