### PR TITLE
Set /pdf requests per node 8 to 4, adds retry.

### DIFF
--- a/script/sync_prod_to_gcp/sync_published_to_gcp.py
+++ b/script/sync_prod_to_gcp/sync_published_to_gcp.py
@@ -69,19 +69,7 @@ class Overloaded503Exception(Exception):
     pass
 
 
-class WaitTimeout(Exception):
-    """The wait for the PDF to show up in /cache/ps_cache greater than PDF_WAIT_SEC."""
-    pass
-
-
-class NoPdfFile(Exception):
-    """Raised when the PDF is not in /cache/ps_cache"""
-    pass
-
-
-PDF_RETRY_EXCEPTIONS = [Overloaded503Exception, WaitTimeout, NoPdfFile,
-                        requests.exceptions.ConnectionError,
-                        requests.exceptions.Timeout]
+PDF_RETRY_EXCEPTIONS = [Overloaded503Exception, requests.exceptions.ConnectionError, requests.exceptions.Timeout]
 CATEGORY = "category"
 
 GS_BUCKET = 'arxiv-production-data'


### PR DESCRIPTION
This:
1. decreases the concurrent per webnode /pdf  requests from 8 to 4 
2. adds retry to /pdf reqeusts 
3. adds retry to upload to GS
4. increases the wait time for a pdf to be built from 3 minutes to 5 minutes.
5. Adds a log msg on successful GET /pdf

Both retry's use the default settings: initial delay of 1 sec, max delay of 60 sec, multiplier of 2 and a timeout of 120 sec.  

The docs say timeout is "Timeout: the maximum duration of time after which a certain operation must terminate (successfully or with an error). The countdown begins right after an operation was started. For example, if an operation was started at 09:24:00 with timeout of 75 seconds, it must terminate no later than 09:25:15."

