### PR TITLE
adds minimal banner and homepage block for prod editor role

### DIFF
--- a/browse/templates/base.html
+++ b/browse/templates/base.html
@@ -34,12 +34,17 @@
         <div class="column" id="cu-logo">
           <a href="https://www.cornell.edu/"><img src="{{ url_for('static', filename='images/icons/cu/cornell-reduced-white-SMALL.svg') }}" alt="Cornell University" /></a>
         </div>
-        {%- if config["BROWSE_MINIMAL_BANNER_ENABLED"] and rd_int >= 202310010100 and rd_int <= 202312300100 -%}
-        <div class="column">
-            <a href="https://info.arxiv.org/help/cloud.html"><span style="color:white;text-decoration-line:underline;">
-                Served from the cloud
-            </span></a>
-            <!--<p><a href="https://info.arxiv.org/hiring/">We are hiring</a></p> --!>
+
+        {%- if rd_int >= 202310120100 and rd_int <= 202311150100 -%}
+        <div class="column banner-minimal">
+          <p><a href="https://cornell.wd1.myworkdayjobs.com/en-US/CornellCareerPage/job/arXiv-Production-Editor--Cornell-Tech--NYC-_WDR-00040646">We are hiring</a></p>
+        </div>
+        {%- endif -%}
+
+
+        {%- if config["BROWSE_MINIMAL_BANNER_ENABLED"] and rd_int >= 202310010100 and rd_int <= 202310010100 -%}
+        <div class="column banner-minimal">
+            <p><a href="https://info.arxiv.org/help/cloud.html">Served from the cloud</a></p>
         </div>
         {%- endif -%}
 

--- a/browse/templates/base.html
+++ b/browse/templates/base.html
@@ -42,9 +42,11 @@
         {%- endif -%}
 
 
-        {%- if config["BROWSE_MINIMAL_BANNER_ENABLED"] and rd_int >= 202310010100 and rd_int <= 202310010100 -%}
-        <div class="column banner-minimal">
-            <p><a href="https://info.arxiv.org/help/cloud.html">Served from the cloud</a></p>
+        {%- if config["BROWSE_MINIMAL_BANNER_ENABLED"] and rd_int >= 202310010100 and rd_int <= 202312300100 -%}
+        <div class="column">
+            <a href="https://info.arxiv.org/help/cloud.html"><span style="color:white;text-decoration-line:underline;">
+                Served from the cloud
+            </span></a>
         </div>
         {%- endif -%}
 

--- a/browse/templates/base.html
+++ b/browse/templates/base.html
@@ -41,7 +41,6 @@
         </div>
         {%- endif -%}
 
-
         {%- if config["BROWSE_MINIMAL_BANNER_ENABLED"] and rd_int >= 202310010100 and rd_int <= 202312300100 -%}
         <div class="column">
             <a href="https://info.arxiv.org/help/cloud.html"><span style="color:white;text-decoration-line:underline;">

--- a/browse/templates/home/special-message.html
+++ b/browse/templates/home/special-message.html
@@ -1,29 +1,21 @@
 {#- Special messages appear in a column to the side of the website intro/news section,
   each in their own column. Always apply the style "message-special" to the column.
   You can also apply the style "dark" to override the red styles and add a message with a black background instead.
-  There should can be just one, never more than two. -#}
+  There can be just one, never more than two. -#}
 
 {%- set rd_int = request_datetime.strftime("%Y%m%d%H%M")|int -%}
 
 <div class="message-special dark column">
   <span class="label">arXiv News</span>
-  <p><a href="https://blog.arxiv.org/">Visit our blog for the latest news</a></p>
+  <p>Stay up to date with what is happening at arXiv on our blog.</p>
+  <p><a href="https://blog.arxiv.org/">Latest news</a></p>
 </div>
 
-{%- if rd_int >= 202305010100 and rd_int <= 202307170100 -%}
-<div class="message-special dark column">
-  <span class="label">arXiv News</span>
-  <h2>TeX Live 2023 Upgrade</h2>
-  <p>Beginning on Monday May 22, 2023 all new submissions and replacements will process under TeX Live 2023. <a href="https://blog.arxiv.org/2023/05/12/tex-live-2023-upgrade-to-occur-may-22nd-2023/">Learn More</a></p>
-  <p><a href="https://blog.arxiv.org/">Visit blog for all news</a></p>
-</div>
-{%- endif -%}
-
-{%- if rd_int >= 202305010100 and rd_int <= 202307170100 -%}
+{%- if rd_int >= 202310120100 and rd_int <= 202311150100 -%}
 <div class="message-special column">
   <span class="label">arXiv is hiring!</span>
-  <p>We are looking for a community engagement manager, several software developers, a project manager, and a documentation manager/tech writer.</p>
-  <p><a href="https://info.arxiv.org/hiring/">View open roles</a></p>
+  <p>We are looking for a full time Production Editor to join arXiv staff.</p>
+  <p><a href="https://cornell.wd1.myworkdayjobs.com/en-US/CornellCareerPage/job/arXiv-Production-Editor--Cornell-Tech--NYC-_WDR-00040646">View role</a></p>
 </div>
 {%- endif -%}
 


### PR DESCRIPTION
This PR adds two notices related to the open role for Production Editor: 
- A minimal banner in the header
- and a homepage block

Reviewers: please double check the start and end dates set for these banners to appear: 
if rd_int >= 202310120100 and rd_int <= 202311150100
so from 10/12 at 1:00am to 11/15 at 1:00am.

Also, please double check that the url I am linking to is the one we want to use: [workday job page](https://cornell.wd1.myworkdayjobs.com/en-US/CornellCareerPage/job/arXiv-Production-Editor--Cornell-Tech--NYC-_WDR-00040646)

See screenshot:
![Screen Shot 2023-10-12 at 10 21 23 AM](https://github.com/arXiv/arxiv-browse/assets/56078140/7772d8fc-7e73-4869-b9a1-ed2cbb62747b)
