### PR TITLE
removes hiring messages

### DIFF
--- a/browse/templates/base.html
+++ b/browse/templates/base.html
@@ -35,7 +35,7 @@
           <a href="https://www.cornell.edu/"><img src="{{ url_for('static', filename='images/icons/cu/cornell-reduced-white-SMALL.svg') }}" alt="Cornell University" /></a>
         </div>
 
-        {%- if rd_int >= 202310120100 and rd_int <= 202311150100 -%}
+        {%- if rd_int >= 202310120100 and rd_int <= 202310220100 -%}
         <div class="column banner-minimal">
           <p><a href="https://cornell.wd1.myworkdayjobs.com/en-US/CornellCareerPage/job/arXiv-Production-Editor--Cornell-Tech--NYC-_WDR-00040646">We are hiring</a></p>
         </div>

--- a/browse/templates/home/special-message.html
+++ b/browse/templates/home/special-message.html
@@ -11,7 +11,7 @@
   <p><a href="https://blog.arxiv.org/">Latest news</a></p>
 </div>
 
-{%- if rd_int >= 202310120100 and rd_int <= 202311150100 -%}
+{%- if rd_int >= 202310120100 and rd_int <= 202310220100 -%}
 <div class="message-special column">
   <span class="label">arXiv is hiring!</span>
   <p>We are looking for a full time Production Editor to join arXiv staff.</p>


### PR DESCRIPTION
Enough recipients have applied for the editorial role and it is time to take down the hiring links from the homepage and header. This PR modifies the display date for the hiring messages to end yesterday 10/22. 