### PR TITLE
Remove DB call from home page

### DIFF
--- a/browse/controllers/home_page.py
+++ b/browse/controllers/home_page.py
@@ -28,10 +28,13 @@ def get_home_page() -> Response:
     """Get the data needed to generated the home page."""
     response_data: Dict[str, Any] = {}
     response_headers: Dict[str, Any] = {}
-    try:
-        response_data['document_count'] = _get_document_count()
-    except Exception as ex:
-        raise InternalServerError from ex
+
+    # We're removing the document count for now until we can
+    # do this without a DB query on each page
+    # try:
+    #     response_data['document_count'] = _get_document_count()
+    # except Exception as ex:
+    #     raise InternalServerError from ex
 
     response_data['groups'] = taxonomy.definitions.GROUPS
     response_data['archives'] = taxonomy.definitions.ARCHIVES_ACTIVE

--- a/browse/templates/home/home.html
+++ b/browse/templates/home/home.html
@@ -12,10 +12,14 @@
 
 <div class="columns">
   <div class="column intro-and-news is-half-desktop">
-    <p class="tagline">arXiv is a free distribution service and an open-access archive for {% if document_count -%}{{ "{:,}".format(document_count) }}{%- endif %}
+    <p class="tagline">arXiv is a free distribution service and an open-access archive for nearly 2.4 million
+      scholarly articles in the fields of physics, mathematics, computer science, quantitative biology, quantitative finance, statistics, electrical engineering and systems science, and economics.
+      Materials on this site are not peer-reviewed by arXiv.
+     </p>
+    <!-- <p class="tagline">arXiv is a free distribution service and an open-access archive for {% if document_count -%}{{ "{:,}".format(document_count) }}{%- endif %}
      scholarly articles in the fields of physics, mathematics, computer science, quantitative biology, quantitative finance, statistics, electrical engineering and systems science, and economics.
      Materials on this site are not peer-reviewed by arXiv.
-    </p>
+    </p> -->
 
     {#-  /multi sends to either search, catchup or form interface based on which button is hit. -#}
     <form name="home-adv-search" class="home-search" action="/multi" method="get" role="search">


### PR DESCRIPTION
A DB query is made while creating our home page solely for the purpose of displaying the current article count, even though we only update the count once a day:

> open-access archive for 2,358,545 scholarly articles in the fields of physics

It turns out that this DB query is fairly expensive. And if anyone uses our home page as a health check, doing one such call per second adds significant load to the db-rep server -- practically a DDOS.

Changing this to a static string for now. Maybe later have this come from a file that we can update once a day after announce time.