### PR TITLE
Fixes bug with db_abs and withdrawn papers. ARXIVCE-960

### DIFF
--- a/browse/controllers/abs_page.py
+++ b/browse/controllers/abs_page.py
@@ -148,15 +148,16 @@ def get_abs_page(arxiv_id: str) -> Response:
 
         response_data["withdrawn_versions"] = []
         response_data["higher_version_withdrawn"] = False
-        for ver_index in range(0, abs_meta.highest_version()):
-            formats = formats_from_source_type(abs_meta.version_history[ver_index].source_type.code)
-            if len(formats) == 1 and formats[0] == "src":
-                response_data["withdrawn_versions"].append(abs_meta.version_history[ver_index])
-                if not response_data["higher_version_withdrawn"] and ver_index > abs_meta.version - 1:
+        response_data["withdrawn"] = False
+        for ver in abs_meta.version_history:
+            if ver.withdrawn_or_ignore:
+                response_data["withdrawn_versions"].append(ver)
+                if abs_meta.version == ver.version:
+                    response_data["withdrawn"] = True
+                if not response_data["higher_version_withdrawn"] and ver.version > abs_meta.version:
                     response_data["higher_version_withdrawn"] = True
-                    response_data["higher_version_withdrawn_submitter"] = _get_submitter(abs_meta.arxiv_identifier, ver_index+1)
-
-        response_data["withdrawn"] = abs_meta.version_history[abs_meta.version - 1] in response_data["withdrawn_versions"]
+                    response_data["higher_version_withdrawn_submitter"] = _get_submitter(abs_meta.arxiv_identifier,
+                                                                                         ver.version)
 
         _non_critical_abs_data(abs_meta, arxiv_identifier, response_data)
 

--- a/browse/domain/metadata.py
+++ b/browse/domain/metadata.py
@@ -188,6 +188,12 @@ class DocMetadata:
                 f'version_history was not an Iterable for {self.arxiv_id_v}')
         return max(map(lambda ve: ve.version, self.version_history))
 
+    def get_requested_version(self) -> VersionEntry:
+        """Get the version indicated in `self.arxiv_identifier.version`."""
+        ver_obj = self.get_version()
+        if not ver_obj:
+            raise ValueError('{self.arxiv_id} version_history has no version {version}')
+        return ver_obj
 
     def get_version(self, version:Optional[int] = None) -> Optional[VersionEntry]:
         """Gets `VersionEntry` for `version`.

--- a/browse/domain/version.py
+++ b/browse/domain/version.py
@@ -115,6 +115,9 @@ class VersionEntry:
     source_type: SourceType = field(default_factory=SourceType)  # type: ignore
     """Source file type."""
 
+    is_withdrawn: bool = False
+    """Is the version withdrawn."""
+
     @property
-    def is_withdrawn(self) -> bool:
-        return self.source_type.ignore
+    def withdrawn_or_ignore(self) -> bool:
+        return self.source_type.ignore or self.is_withdrawn

--- a/browse/services/dissemination/article_store.py
+++ b/browse/services/dissemination/article_store.py
@@ -216,7 +216,7 @@ class ArticleStore():
         if not version:
             return "VERSION_NOT_FOUND"
 
-        if version.is_withdrawn:
+        if version.withdrawn_or_ignore:
             return "WITHDRAWN"
 
         handler_fn = self.format_handlers[format]
@@ -263,6 +263,9 @@ class ArticleStore():
             A list of format strings.
         """
         formats: List[str] = []
+        version = docmeta.get_requested_version()
+        if version.withdrawn_or_ignore or version.size_kilobytes <= 0:
+            return formats
 
         # first, get possible list of formats based on available source file
         if src_file is None:
@@ -283,8 +286,7 @@ class ArticleStore():
         else:
             # check source type from metadata, with consideration of
             # user format preference and cache
-            version = docmeta.version
-            format_code = docmeta.version_history[version - 1].source_type.code
+            format_code = version.source_type.code
             cached_ps_file = self.dissemination(fileformat.ps, docmeta.arxiv_identifier, docmeta)
             cache_flag = bool(cached_ps_file and isinstance(cached_ps_file, FileObj) \
                 and cached_ps_file.size == 0 \
@@ -323,7 +325,7 @@ class ArticleStore():
             formats.extend(['pdf', src_fmt])
 
         ver = docmeta.get_version()
-        if ver and not ver.is_withdrawn:
+        if ver and not ver.withdrawn_or_ignore:
             formats.append('src')
 
         return formats

--- a/browse/services/documents/db_implementation/db_abs.py
+++ b/browse/services/documents/db_implementation/db_abs.py
@@ -114,13 +114,14 @@ class DbDocMetadataService(DocMetadataService):
 
         for ver in all_versions:
             size_kilobytes = int(ver.source_size / 1024 + .5)
-            # Set UTC timezone
             created_tz = ver.created.replace(tzinfo=tzutc())
             entry = VersionEntry(version=ver.version,
                                  raw='',
                                  size_kilobytes=size_kilobytes,
                                  submitted_date=created_tz,
-                                 source_type=SourceType(ver.source_flags))
+                                 source_type=SourceType(ver.source_flags),
+                                 is_withdrawn=ver.is_withdrawn
+                                 )
             version_history.append(entry)
 
         return to_docmeta(res, version_history, self.business_tz)

--- a/browse/services/documents/fs_implementation/parse_abs.py
+++ b/browse/services/documents/fs_implementation/parse_abs.py
@@ -235,12 +235,14 @@ def _parse_version_entries(arxiv_id: str, version_entry_list: List) \
                 f'Could not parse submitted date {sd} as datetime') from ex
 
         source_type = SourceType(code=date_match.group('source_type'))
+        kb = int(date_match.group('size_kilobytes'))
         ve = VersionEntry(
             raw=date_match.group(0),
             source_type=source_type,
-            size_kilobytes=int(date_match.group('size_kilobytes')),
+            size_kilobytes=kb,
             submitted_date=submitted_date,
-            version=version_count
+            version=version_count,
+            is_withdrawn=kb == 0 or source_type.ignore
         )
         version_entries.append(ve)
 

--- a/browse/templates/abs/extra_services.html
+++ b/browse/templates/abs/extra_services.html
@@ -42,10 +42,10 @@
   </div>
 
   {%- set current = abs_meta.version == abs_meta.version_history[-1].version -%}
-  {%- if format_list|length == 0 or ( not current and format_list|length == 1 and format_list[0] == 'src' ) -%}
-  <li>Unavailable</li>
-  {%- elif withdrawn -%}
+  {%- if withdrawn -%}
   <li>Withdrawn</li>
+  {%- elif format_list|length == 0 or ( not current and format_list|length == 1 and format_list[0] == 'src' ) -%}
+  <li>Unavailable</li>
   {% else %}
     {%- for format in format_list %}
       {%- if format.startswith('pdf') -%}

--- a/tests/test_fs_abs_parser.py
+++ b/tests/test_fs_abs_parser.py
@@ -15,6 +15,7 @@ ABS_FILES = path_of_for_test('data/abs_files')
 
 class TestAbsParser(TestCase):
     """Test  parsing metadata from .abs files."""
+    maxDiff = None
 
     def test_bulk_parsing(self):
         """Parse all nonempty .abs files in test set."""
@@ -67,7 +68,8 @@ class TestAbsParser(TestCase):
                     submitted_date=datetime(2009, 6, 28, 11, 24, 35,
                                             tzinfo=tzutc()),
                     size_kilobytes=17,
-                    source_type=SourceType(code='')
+                    source_type=SourceType(code=''),
+                    is_withdrawn=False
                 ),
                 VersionEntry(
                     version=2,
@@ -76,7 +78,8 @@ class TestAbsParser(TestCase):
                     submitted_date=datetime(2009, 7, 21, 9, 45, 44,
                                             tzinfo=tzutc()),
                     size_kilobytes=17,
-                    source_type=SourceType(code='')
+                    source_type=SourceType(code=''),
+                    is_withdrawn=False
                 ),
                 VersionEntry(
                     version=3,
@@ -85,7 +88,8 @@ class TestAbsParser(TestCase):
                     submitted_date=datetime(2009, 7, 29, 11, 13, 43,
                                             tzinfo=tzutc()),
                     size_kilobytes=17,
-                    source_type=SourceType(code='')
+                    source_type=SourceType(code=''),
+                    is_withdrawn=False
                 )
             ]
         )


### PR DESCRIPTION
The db abs meatadata has the withdrawn status in arXiv_metadata.is_withdrawn and does not seem to indicate it with  source flag "I". 

This may be a divergence of how .abs files and db abs are recorded. This probably goes back to before 2013.