### PR TITLE
Early version of a wdr paper did not show download links

### DIFF
--- a/browse/controllers/abs_page.py
+++ b/browse/controllers/abs_page.py
@@ -113,7 +113,7 @@ def get_abs_page(arxiv_id: str) -> Response:
         if redirect:
             return redirect
 
-        abs_meta = get_doc_service().get_abs(arxiv_id)
+        abs_meta = get_doc_service().get_abs(arxiv_identifier)
         not_modified = _check_request_headers(abs_meta, response_data, response_headers)
         if not_modified:
             return {}, status.NOT_MODIFIED, response_headers

--- a/browse/services/documents/db_implementation/convert.py
+++ b/browse/services/documents/db_implementation/convert.py
@@ -10,6 +10,7 @@ from browse.services.documents.base_documents import AbsException
 
 
 def to_docmeta(dbmd: Metadata,
+               identifier: Identifier,
                version_history: List[VersionEntry],
                business_tz: ZoneInfo) -> DocMetadata:
     """Convert a Metadata object from the DB to a DocMetadata object
@@ -19,7 +20,7 @@ def to_docmeta(dbmd: Metadata,
 
     """
     # This is from parse_abs.py
-    arxiv_identifier = Identifier(dbmd.paper_id)
+    arxiv_identifier = identifier
 
     primary_category = None
     secondary_categories = []
@@ -60,7 +61,7 @@ def to_docmeta(dbmd: Metadata,
         abstract=dbmd.abstract,
         arxiv_id=dbmd.paper_id,
         arxiv_id_v=dbmd.paper_id + 'v' + str(dbmd.version),
-        arxiv_identifier = Identifier(dbmd.paper_id),
+        arxiv_identifier = identifier,
         title = dbmd.title,
         modified=modified,
         authors=AuthorList(dbmd.authors),

--- a/browse/services/documents/db_implementation/db_abs.py
+++ b/browse/services/documents/db_implementation/db_abs.py
@@ -52,7 +52,6 @@ class DbDocMetadataService(DocMetadataService):
         if isinstance(arxiv_id, Identifier):
             paper_id = arxiv_id
         else:
-            # TODO Probably doesn't do docmeta.version_history correctly
             paper_id = Identifier(arxiv_id=arxiv_id)
 
         if paper_id.id in DELETED_PAPERS:
@@ -124,7 +123,7 @@ class DbDocMetadataService(DocMetadataService):
                                  )
             version_history.append(entry)
 
-        return to_docmeta(res, version_history, self.business_tz)
+        return to_docmeta(res, identifier, version_history, self.business_tz)
 
     def service_status(self)->List[str]:
         try:


### PR DESCRIPTION
This was probably introduced recently.

The identifier object created by the controler is passed further down so it can be placed on the DocMeta object and then carries the info about the requested version. That is later picked up by the formats function.