### PR TITLE
Deploying the annual survey via banner

### DIFF
--- a/browse/templates/base.html
+++ b/browse/templates/base.html
@@ -37,7 +37,7 @@
 
         {%- if rd_int >= 202311270100 and rd_int <= 202311290100 -%}
         <div class="column banner-minimal">
-          <p><a href="https://cornell.ca1.qualtrics.com/jfe/form/SV_8wAZvATbZvWU2vc" target="_blank">arXiv annual global survey</a></p>
+          <p><a href="https://cornell.ca1.qualtrics.com/jfe/form/SV_8wAZvATbZvWU2vc" target="_blank">Take the annual global survey</a></p>
         </div>
         {%- endif -%}
 

--- a/browse/templates/base.html
+++ b/browse/templates/base.html
@@ -35,9 +35,9 @@
           <a href="https://www.cornell.edu/"><img src="{{ url_for('static', filename='images/icons/cu/cornell-reduced-white-SMALL.svg') }}" alt="Cornell University" /></a>
         </div>
 
-        {%- if rd_int >= 202310120100 and rd_int <= 202310220100 -%}
+        {%- if rd_int >= 202311270100 and rd_int <= 202311290100 -%}
         <div class="column banner-minimal">
-          <p><a href="https://cornell.wd1.myworkdayjobs.com/en-US/CornellCareerPage/job/arXiv-Production-Editor--Cornell-Tech--NYC-_WDR-00040646">We are hiring</a></p>
+          <p><a href="https://cornell.ca1.qualtrics.com/jfe/form/SV_8wAZvATbZvWU2vc" target="_blank">arXiv annual global survey</a></p>
         </div>
         {%- endif -%}
 

--- a/browse/templates/home/special-message.html
+++ b/browse/templates/home/special-message.html
@@ -11,11 +11,11 @@
   <p><a href="https://blog.arxiv.org/">Latest news</a></p>
 </div>
 
-{%- if rd_int >= 202310120100 and rd_int <= 202310220100 -%}
+{%- if rd_int >= 202311270100 and rd_int <= 202311290100 -%}
 <div class="message-special column">
-  <span class="label">arXiv is hiring!</span>
-  <p>We are looking for a full time Production Editor to join arXiv staff.</p>
-  <p><a href="https://cornell.wd1.myworkdayjobs.com/en-US/CornellCareerPage/job/arXiv-Production-Editor--Cornell-Tech--NYC-_WDR-00040646">View role</a></p>
+  <span class="label">Global survey</span>
+  <p>Each year, arXiv takes the pulse of how we are serving the global community. In just 4 minutes help us understand how you see arXiv.</p>
+  <p><a class="btn-slim" target="_blank" href="https://cornell.ca1.qualtrics.com/jfe/form/SV_8wAZvATbZvWU2vc">Take survey</a></p>
 </div>
 {%- endif -%}
 


### PR DESCRIPTION
This PR adds a minimal header banner and a message block on the homepage linking to the annual brand perception survey. Screenshot is below showing both. 

They are set to display starting at 1:00AM on November 27th, until 1:00AM on November 29th. @cbf66 let's coordinate to make sure this window does not interfere with other planned dev update announcements.

We normally leave the banner up for only 24 hours. This year, I suspect we may need 48 hours to maintain a similar response rate as previous years, for two reasons:
- We are using a more minimal header banner, not the larger one that covers over the normal header. 
- the timing. Post-thanksgiving may get less engagement than previous years when we ran it in October.

![Screen Shot 2023-11-14 at 10 54 41 AM](https://github.com/arXiv/arxiv-browse/assets/56078140/a4446095-3671-4935-8126-4102c791a43b)
