### PR TITLE
Update cite.py to include arXiv url and doi

### DIFF
--- a/browse/formatting/cite.py
+++ b/browse/formatting/cite.py
@@ -18,7 +18,8 @@ def arxiv_bibtex(docm: DocMetadata) -> str:
     auths = _fmt_author_list(pauths)
 
     pc = docm.primary_category if docm.primary_category else "unknown"
-
+    url = "https://doi.org/" + docm.doi
+    
     return (
         "@misc{" + _txt_id(docm, pauths, year) + ",\n"
         "      title={" + title + "}, \n"
@@ -26,7 +27,9 @@ def arxiv_bibtex(docm: DocMetadata) -> str:
         "      year={" + year + "},\n"
         "      eprint={" + docm.arxiv_id + "},\n"
         "      archivePrefix={arXiv},\n"
-        "      primaryClass={" + str(pc) + "}\n"
+        "      primaryClass={" + str(pc) + "},\n"
+        "      url={" + str(url) + "},\n"
+        "      doi={" + str(docm.doi) + "},\n"
         "}"
     )
 


### PR DESCRIPTION
Many journal bibtex style (.bst) files do not support arXiv IDs. By adding doi and url fields, the preprint bibtex export becomes compatible with these .bst files.
I have not tested these changes since I'd have no idea how to run the flask app. Please make or suggest any edits needed if it doesn't work.