### PR TITLE
changed urls to 2 digit years for CIT compatibility

### DIFF
--- a/browse/controllers/year.py
+++ b/browse/controllers/year.py
@@ -75,7 +75,7 @@ def year_page(archive_id: str, year: Optional[int]) -> Any:
             yymm= f"{str(month_count.year)[2:]}{month_count.month:02}",
             my = date(year=int(month_count.year),month=int(month_count.month), day=1).strftime("%b %Y"),
             url= url_for('browse.list_articles', context=archive_id,
-                         subcontext=f"{month_count.year}{month_count.month:02}"))
+                         subcontext=f"{month_count.year%100}{month_count.month:02}")) #TODO return to 4 digit year when all of listings is running on browse
         for month_count in count_listing.by_month]
 
     response_data: Dict[str, Any] = {
@@ -101,7 +101,7 @@ ASCII_ART_URL_STEP = 100
 def ascii_art_month(archive_id: str, month: MonthCount) -> List[Tuple[str, Optional[str]]]:
     """Make ascii art for a MonthTotal."""
     tot = month.new + month.cross
-    yyyymm = f"{month.year}{month.month:02}"
+    yyyymm = f"{month.year%100}{month.month:02}" #TODO return to 4 digit year when all of listings is running on browse
 
     def _makestep(idx: int) -> Tuple[str, Optional[str]]:
         if idx % ASCII_ART_URL_STEP == 0:

--- a/browse/controllers/year.py
+++ b/browse/controllers/year.py
@@ -75,7 +75,7 @@ def year_page(archive_id: str, year: Optional[int]) -> Any:
             yymm= f"{str(month_count.year)[2:]}{month_count.month:02}",
             my = date(year=int(month_count.year),month=int(month_count.month), day=1).strftime("%b %Y"),
             url= url_for('browse.list_articles', context=archive_id,
-                         subcontext=f"{month_count.year%100}{month_count.month:02}")) #TODO return to 4 digit year when all of listings is running on browse
+                         subcontext=f"{month_count.year%100:02}{month_count.month:02}")) #TODO return to 4 digit year when all of listings is running on browse
         for month_count in count_listing.by_month]
 
     response_data: Dict[str, Any] = {
@@ -101,7 +101,7 @@ ASCII_ART_URL_STEP = 100
 def ascii_art_month(archive_id: str, month: MonthCount) -> List[Tuple[str, Optional[str]]]:
     """Make ascii art for a MonthTotal."""
     tot = month.new + month.cross
-    yyyymm = f"{month.year%100}{month.month:02}" #TODO return to 4 digit year when all of listings is running on browse
+    yyyymm = f"{month.year%100:02}{month.month:02}" #TODO return to 4 digit year when all of listings is running on browse
 
     def _makestep(idx: int) -> Tuple[str, Optional[str]]:
         if idx % ASCII_ART_URL_STEP == 0:

--- a/tests/test_hybrid_listing.py
+++ b/tests/test_hybrid_listing.py
@@ -151,9 +151,9 @@ def test_year_page_hybrid(mock, client_with_hybrid_listings):
     assert '<a href="/year/cond-mat/11">2011</a>' in text
     assert "<p>2009 totals: <b>8 articles</b> + <i>2 cross-lists</i></p>" in text
     assert (
-        "<a href=/list/cond-mat/200911?skip=0>|</a>      <b>2</b> + 0 (Nov 2009)"
+        "<a href=/list/cond-mat/0911?skip=0>|</a>      <b>2</b> + 0 (Nov 2009)"
         in text
-    )
+    ) #TODO change this back to 4 digit year when all of listings is running on browse
     assert '<a href="/year/cond-mat/92">1992</a>' in text
 
     rv = client.get("/year/cs/23")


### PR DESCRIPTION
temporary change to allow year to run while still working with legacy listings. The plan is to change this back once all of browse lsitings is in production