### PR TITLE
years_operating now alwasy tries to add just the year of dates

### DIFF
--- a/browse/controllers/years_operating.py
+++ b/browse/controllers/years_operating.py
@@ -17,7 +17,7 @@ def years_operating(archive: Dict[str, Any]) -> List[int]:
     ):
         return []
     start = archive["start_date"].year
-    end = archive.get("end_date", None) or date.today().year
+    end = archive.get("end_date", date.today()).year #end date could be None or a date
     return list(reversed(range(start, end + 1)))
 
 

--- a/tests/test_list_page.py
+++ b/tests/test_list_page.py
@@ -647,3 +647,11 @@ def test_math_ph_9701(client_with_test_fs):
     text = rv.text
     assert "On Exact Solutions" in text
     assert "unknown-id" not in text
+
+def test_year_archive_with_end_date(client_with_test_fs):
+    client = client_with_test_fs
+    rv = client.get("/year/funct-an")
+    assert rv.status_code == 200
+    text=rv.text
+    assert '<a href="/year/funct-an/97">1997</a>' in text
+    assert '<a href="/year/funct-an/98">1998</a>' not in text


### PR DESCRIPTION
fixes a bug for archives that have end years where it would try and add a date and an int together