### PR TITLE
fixes odd display when there is no license image

### DIFF
--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -2196,7 +2196,7 @@ div#long-dc-list {
   padding-top: 0.3em;
 }
 
-.abs-license a {
+.abs-license .has_license {
   display: flex;
   align-items: center;
   gap: 5px;

--- a/browse/templates/abs/extra_services.html
+++ b/browse/templates/abs/extra_services.html
@@ -182,12 +182,12 @@
         {%- if withdrawn -%}
         <div hidden>No license for this version due to withdrawn</div>
         {%- elif abs_meta.license.icon_uri_path -%}
-        <a href="{{abs_meta.license.effective_uri}}" title="Rights to this article">
+        <a href="{{abs_meta.license.effective_uri}}" title="Rights to this article" class="has_license">
           <img alt="license icon" role="presentation" src="https://arxiv.org{{ abs_meta.license.icon_uri_path }}"/>
           <span>view license</span>
         </a>
         {%- else -%}
-        (<a href="{{abs_meta.license.effective_uri}}" title="Rights to this article">view license</a>)
+        <a href="{{abs_meta.license.effective_uri}}" title="Rights to this article">view license</a>
         {%- endif -%}
       </div>
     </div>


### PR DESCRIPTION
This PR fixes a display issue when there is no license image, just a license link.
![Screen Shot 2024-01-17 at 4 22 19 PM](https://github.com/arXiv/arxiv-browse/assets/56078140/5658167e-e479-4a89-a4eb-6440ca1c5209)
