### PR TITLE
Adds handling of ids like arxiv:astro-ph/011202 AH-86565

### DIFF
--- a/browse/domain/identifier.py
+++ b/browse/domain/identifier.py
@@ -58,10 +58,16 @@ class Identifier:
         self.month: Optional[int] = None
         self.is_old_id: Optional[bool] = None
         self.extra: Optional[str] = None
+        self.arxiv_prefix: bool = False
+        """Set to `True` if id like arxiv:astro-ph/011202. This was an acceptable old id format."""
 
         if self.ids in taxonomy.definitions.ARCHIVES:
             raise IdentifierIsArchiveException(
                 taxonomy.definitions.ARCHIVES[self.ids]['name'])
+
+        if self.ids.startswith("arxiv:"):
+            self.arxiv_prefix = True
+            arxiv_id = arxiv_id.removeprefix("arxiv:")
 
         for subtup in SUBSTITUTIONS:
             arxiv_id = re.sub(subtup[0],
@@ -219,4 +225,4 @@ class Identifier:
             return False
         if len(idin) > 200:
             return False
-        return bool(re.match(re.compile(r"^[./0-9a-zA-Z-]{8}"), idin))
+        return bool(re.match(re.compile(r"^[./0-9a-zA-Z:-]{8}"), idin))

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -655,7 +655,13 @@ class BrowseTest(unittest.TestCase):
 
 
     def test_bad_data(self):
-        """Test where v2 is withdrawn but then there is a non-withdrawn v3."""
+        """Test strange data."""
         rv = self.client.get('/abs/gr-qc/۹۷۰۶123')
         self.assertNotEqual(rv.status_code, 200)
         self.assertNotEqual(rv.status_code, 500)
+
+    def test_old_id_format(self):
+        """Test the old "arxiv:astro-ph/001201" style ID."""
+        rv = self.client.get("/abs/arxiv:physics/9707012")
+        self.assertEqual(rv.status_code, 301)
+        self.assertEqual(rv.headers['Location'], "/abs/physics/9707012")


### PR DESCRIPTION
Adds handling of https://arxiv.org/abs/arxiv:ID that is used in old papers. 

This was part of the apache config pre-fastly.

https://arxiv-org.atlassian.net/browse/AH-86565
