### PR TITLE
Change /abs to use etag instead of last-modified

### DIFF
--- a/browse/controllers/abs_page.py
+++ b/browse/controllers/abs_page.py
@@ -3,26 +3,21 @@
 The primary entrypoint to this module is :func:`.get_abs_page`, which
 handles GET requests to the abs endpoint.
 """
-# pylint: disable=raise-missing-from
 
 import re
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urljoin
 
 from http import HTTPStatus as status
 
-from arxiv import taxonomy
-from arxiv.base import logging
-from dateutil import parser
-from dateutil.tz import tzutc
-from flask import request, url_for, current_app
+from flask import request, url_for
 from werkzeug.exceptions import InternalServerError
 
-from browse.controllers import check_supplied_identifier, biz_tz
+from browse.controllers import check_supplied_identifier
 
 from arxiv import taxonomy
-# from arxiv.base import logging
+
+from browse.controllers.response_headers import check_etag_same
 from browse.domain.category import Category
 from browse.domain.identifier import (
     Identifier,
@@ -37,10 +32,8 @@ from browse.services.database import (
     get_dblp_authors,
     get_dblp_listing_path,
     get_trackback_ping_latest_date,
-    get_latexml_publish_dt,
 )
 from browse.services.documents import get_doc_service
-from browse.services.documents.format_codes import formats_from_source_flag
 
 from browse.services.dissemination import get_article_store
 from browse.services.prevnext import prevnext_service
@@ -65,10 +58,7 @@ from browse.formatting.search_authors import (
     queries_for_authors,
     split_long_author_list,
 )
-from browse.controllers.response_headers import (
-    abs_expires_header,
-    mime_header_date
-)
+
 from browse.formatting.metatags import meta_tag_metadata
 
 import logging
@@ -118,9 +108,6 @@ def get_abs_page(arxiv_id: str) -> Response:
             return redirect
 
         abs_meta = get_doc_service().get_abs(arxiv_identifier)
-        not_modified = _check_request_headers(abs_meta, response_data, response_headers)
-        if not_modified:
-            return {}, status.NOT_MODIFIED, response_headers
 
         response_data["requested_id"] = (
             arxiv_identifier.idv
@@ -161,6 +148,7 @@ def get_abs_page(arxiv_id: str) -> Response:
                                                                                          ver.version)
 
         _non_critical_abs_data(abs_meta, arxiv_identifier, response_data)
+        _add_caching_headers(abs_meta, response_headers)
 
     except AbsNotFoundException as ex:
         if (arxiv_identifier.is_old_id
@@ -205,6 +193,9 @@ def get_abs_page(arxiv_id: str) -> Response:
             "help@arxiv.org."
         ) from ex
 
+    if check_etag_same(response_data, response_headers):
+        return {}, status.NOT_MODIFIED, response_headers
+
     return response_data, status.OK, response_headers
 
 
@@ -234,55 +225,12 @@ def _non_critical_abs_data(
         paper_id=abs_meta.arxiv_id
     )
 
+def _add_caching_headers(docmeta: DocMetadata, resp_headers: Dict[str, str]) -> None:
+    resp_headers["Surrogate-Control"] = f"max-age={60*15}"  # caching services may strip this
+    resp_headers["Cache-Control"] = f"max-age={60*15}"
 
-def _check_request_headers(
-    docmeta: DocMetadata, response_data: Dict[str, Any], resp_headers: Dict[str, Any]
-) -> bool:
-    """Check the request headers, update the response headers accordingly."""
-    version = docmeta.get_version()
-    if version:
-        html_updated = get_latexml_publish_dt(docmeta.arxiv_id, version.version) or datetime.min.replace(tzinfo=timezone.utc)
-    else:
-        html_updated = datetime.min.replace(tzinfo=timezone.utc)
-    last_mod_dt: datetime = max(html_updated, docmeta.modified)
-
-    # Latest trackback ping time depends on the database
-    if 'trackback_ping_latest' in response_data \
-       and isinstance(response_data['trackback_ping_latest'], datetime) \
-       and response_data['trackback_ping_latest'] > last_mod_dt:
-        # If there is a more recent trackback ping, use that datetime
-        last_mod_dt = response_data["trackback_ping_latest"]
-
-    resp_headers["Last-Modified"] = mime_header_date(last_mod_dt)
-
-    #resp_headers["Expires"] = abs_expires_header(biz_tz())
-    # Above we had a Expires: based on publish time but admins wanted shorter when
-    # handling service tickets.
-    resp_headers["Surrogate-Control"] = "max-age=3600"  # caching services may strip this
-    resp_headers["Cache-Control"] = "max-age=3600"
-
-    mod_since_dt = _time_header_parse("If-Modified-Since")
-    return bool(mod_since_dt and mod_since_dt.replace(microsecond=0) >= last_mod_dt.replace(microsecond=0))
-
-
-def _time_header_parse(header: str) -> Optional[datetime]:
-    try:
-        dt = parser.parse(str(_get_req_header(header)))
-        if not dt.tzinfo:
-            dt = dt.replace(tzinfo=tzutc())
-        return dt
-    except (ValueError, TypeError, KeyError):
-        pass
-    return None
-
-
-def _get_req_header(header: str) -> Optional[str]:
-    """Gets request header, needs to be case insensative for keys.
-
-    HTTP header keys are case insensitive. RFC 2616
-    """
-    return next((value for key, value in request.headers.items()
-                 if key.lower() == header.lower()), None)
+    # see https://docs.fastly.com/en/guides/working-with-surrogate-keys
+    resp_headers["Surrogate-Key"] = f"abs {docmeta.arxiv_identifier.year:04}{docmeta.arxiv_identifier.month:02}"
 
 
 def _check_legacy_id_params(arxiv_id: str) -> str:

--- a/browse/domain/identifier.py
+++ b/browse/domain/identifier.py
@@ -55,6 +55,7 @@ class Identifier:
         self.archive: Optional[str] = None
         self.filename: Optional[str] = None
         self.year: Optional[int] = None
+        """Four digit year as an `int`."""
         self.month: Optional[int] = None
         self.is_old_id: Optional[bool] = None
         self.extra: Optional[str] = None

--- a/browse/services/database/__init__.py
+++ b/browse/services/database/__init__.py
@@ -2,7 +2,7 @@
 # pylint disable=no-member
 
 import ipaddress
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Any, Callable, List, Mapping, Optional, Tuple
 
 from flask import current_app

--- a/tests/test_304.py
+++ b/tests/test_304.py
@@ -12,39 +12,39 @@ def test_modified(client_with_test_fs):
     rv = client_with_test_fs.get('/abs/0704.0600')
     assert rv.status_code == 200
 
-    last_mod = rv.headers['Last-Modified']
+    last_mod = rv.headers['Etag']
 
     rv = client_with_test_fs.get('/abs/0704.0600',
-                         headers={'If-Modified-Since': last_mod})
+                         headers={'If-None-Match': last_mod})
     assert rv.status_code == 304
 
     rv = client_with_test_fs.get('/abs/0704.0600',
-                         headers={'if-modified-since': last_mod})
+                         headers={'if-none-match': last_mod})
     assert rv.status_code == 304
 
     rv = client_with_test_fs.get('/abs/0704.0600',
-                         headers={'IF-MODIFIED-SINCE': last_mod})
+                         headers={'IF-NONE-MATCH': last_mod})
     assert rv.status_code == 304
 
     rv = client_with_test_fs.get('/abs/0704.0600',
-                         headers={'If-ModiFIED-SiNCE': last_mod})
+                         headers={'If-NoNe-MaTcH': last_mod})
     assert rv.status_code == 304
 
 
-def test_not_modified(client_with_test_fs):
+def test_etag(client_with_test_fs):
     """Test when pages is not modified"""
 
     rv = client_with_test_fs.get('/abs/0704.0600')
     assert rv.status_code == 200
 
-    mod_dt = parser.parse(rv.headers['Last-Modified'])
+    etag =rv.headers['ETag']
 
     rv = client_with_test_fs.get('/abs/0704.0600',
-                         headers={'If-Modified-Since': mime_header_date(mod_dt)})
+                         headers={'If-None-Match': etag})
     assert rv.status_code == 304
 
     rv = client_with_test_fs.get('/abs/0704.0600',
-                         headers={'If-Modified-Since': mime_header_date(mod_dt + timedelta(seconds=-1))})
+                         headers={'If-None-Match': "bogus"+etag})
     assert rv.status_code == 200
 
     rv = client_with_test_fs.get('/abs/0704.0600',

--- a/tests/test_db_abs.py
+++ b/tests/test_db_abs.py
@@ -72,48 +72,28 @@ def test_db_abs_null_source_size(dbclient):
 
 def test_html_conversion_dissemination (dbclient):
     rt = dbclient.get('/abs/0906.2112')
-
     assert rt.status_code == 200
-
-    assert rt.headers['Last-Modified'] == 'Mon, 01 Jan 2024 00:00:00 GMT'
-
     html = BeautifulSoup(rt.data.decode('utf-8'), 'html.parser')
     atag = html.select_one('.extra-services').find('a', {'id': 'latexml-download-link'})
-
     assert atag and atag.text == "HTML (experimental)"
 
-def test_last_modified_old_html_conversion (dbclient):
+def test_old_html_conversion (dbclient):
     rt = dbclient.get('/abs/2310.08262')
-
     assert rt.status_code == 200
-
-    assert rt.headers['Last-Modified'].startswith('Fri, 13 Oct 2023')
-
     html = BeautifulSoup(rt.data.decode('utf-8'), 'html.parser')
     atag = html.select_one('.extra-services').find('a', {'id': 'latexml-download-link'})
-
     assert atag and atag.text == "HTML (experimental)"
 
 def test_last_modified_no_publish_dt (dbclient):
     rt = dbclient.get('/abs/0906.5132')
-
     assert rt.status_code == 200
-
-    assert rt.headers['Last-Modified'].startswith('Thu, 15 Oct 2009')
-
     html = BeautifulSoup(rt.data.decode('utf-8'), 'html.parser')
     atag = html.select_one('.extra-services').find('a', {'id': 'latexml-download-link'})
-
     assert atag and atag.text == "HTML (experimental)"
 
 def test_last_modified_no_html (dbclient):
     rt = dbclient.get('/abs/0906.5504')
-    
     assert rt.status_code == 200
-
-    assert rt.headers['Last-Modified'].startswith('Tue, 13 Oct 2009')
-
     html = BeautifulSoup(rt.data.decode('utf-8'), 'html.parser')
     atag = html.select_one('.extra-services').find('a', {'id': 'latexml-download-link'})
-
     assert atag is None


### PR DESCRIPTION
We lack a good record for all the data sources that makes up the /abs page so last-modified isn't working out.

Go to etag made from a hash of all the data used by the jinja html template. 