### PR TITLE
Changes file download caching

### DIFF
--- a/browse/controllers/__init__.py
+++ b/browse/controllers/__init__.py
@@ -3,6 +3,7 @@
 Each controller corresponds to a distinct browse feature with its own
 request handling logic.
 """
+from datetime import timezone, datetime, timedelta
 from typing import Any, Dict, Optional, Tuple
 from zoneinfo import ZoneInfo
 
@@ -50,3 +51,21 @@ def biz_tz() -> ZoneInfo:
         return _arxiv_biz_tz
     else:
         return _arxiv_biz_tz
+
+
+def next_publish(now: Optional[datetime] = None) -> datetime:
+    """Guesses the next publish but knows nothing about holidays.
+
+    Returns a `datetime` with a `timezone` from `biz_tz()`."""
+    if now is None:
+        now = datetime.now(tz=biz_tz())
+
+    if now.weekday() == 4:
+        return (now + timedelta(days=2)).replace(hour=20)
+    if now.weekday() == 5:
+        return (now + timedelta(days=2)).replace(hour=20)
+
+    if now.hour > 21:
+        return next_publish((now + timedelta(days=1)).replace(hour=12))
+    else:
+        return now.replace(hour=20)

--- a/browse/services/next_published.py
+++ b/browse/services/next_published.py
@@ -1,27 +1,3 @@
-from datetime import datetime, timedelta
-from typing import Optional
 
 
-def next_publish(now: Optional[datetime] = None) -> datetime:
-    """Guesses the next publish but knows nothing about holidays.
 
-    This is a conservative approch. If this is used for Expires
-    headers should never cache when the contents were updated due to publish. It will
-    cache less then optimal when there is a holiday and nothing could
-    have been updated.
-    """
-    if now is None:
-        now = datetime.now()
-
-    if now.weekday() == 4:
-        return (now + timedelta(days=2)).replace(hour=20)
-    if now.weekday() == 5:
-        return (now + timedelta(days=2)).replace(hour=20)
-
-    if now.hour > 20 and now.hour < 21:
-        # It's around publish time, PDF might change, really short
-        return now.replace(minute=now.minute + 5)
-    elif now.hour > 21:
-        return next_publish((now + timedelta(days=1)).replace(hour=12))
-    else:
-        return now.replace(hour=20)

--- a/tests/dissemination/test_no_source.py
+++ b/tests/dissemination/test_no_source.py
@@ -2,7 +2,7 @@ def test_no_source(client_with_test_fs, mocker):
     resp = client_with_test_fs.get("/pdf/1208.9998.pdf")
     assert resp.status_code == 404
     assert "1208.9998" in resp.text
-    assert resp.headers.get('Expires', None)
+    assert resp.headers.get('Expires', None) or resp.headers.get('Cache-Control', None)
 
     resp = client_with_test_fs.get("/pdf/1208.9998v1.pdf")
     assert resp.status_code == 404
@@ -12,5 +12,4 @@ def test_no_source(client_with_test_fs, mocker):
     resp = client_with_test_fs.get("/pdf/1208.9998v2.pdf")
     assert resp.status_code == 404
     assert "1208.9998v2" in resp.text
-    assert resp.headers.get('Cache-Control', None) is None
-    assert resp.headers.get('Expires', None) is not None
+    assert resp.headers.get('Cache-Control', None)


### PR DESCRIPTION
Sets `Cache-Control` to max-age of either 15 for un-versioned requests or 30 minutes for versioned requests.

Removes `Expires` header. This was based on the publish time and often was too far in the future to pick up changes like latexml or added DOIs.