### PR TITLE
Adds /pdf_test path for testing fastly+genpdf

### DIFF
--- a/browse/routes/dissemination.py
+++ b/browse/routes/dissemination.py
@@ -46,6 +46,14 @@ def pdf(arxiv_id: str, archive=None):  # type: ignore
     """
     return get_dissemination_resp(fileformat.pdf, arxiv_id, archive)
 
+@blueprint.route("/pdf_test/<string:archive>/<string:arxiv_id>.pdf", methods=['GET', 'HEAD'])
+@blueprint.route("/pdf_test/<string:arxiv_id>.pdf", methods=['GET', 'HEAD'])
+def pdf_test(arxiv_id: str, archive=None):  # type: ignore
+    """Path to test pdf via fastly.
+
+    Can be removed when no longer needed."""
+    return get_dissemination_resp(fileformat.pdf, arxiv_id, archive)
+
 
 @blueprint.route("/format/<string:archive>/<string:arxiv_id>", methods=['GET', 'HEAD'])
 @blueprint.route("/format/<string:arxiv_id>", methods=['GET', 'HEAD'])


### PR DESCRIPTION
This creates a second path for PDF download only for use with testing fastly and genpdf.

Fastly can be left pointing /pdf to CIT and /pdf_test can be pointed at the cloud run arxiv-browse + genpdf.