### PR TITLE
Removes click through links.

### DIFF
--- a/browse/factory.py
+++ b/browse/factory.py
@@ -7,7 +7,7 @@ import logging
 from flask.logging import default_handler
 
 from arxiv.base import Base
-from arxiv.base.urls import canonical_url, clickthrough_url, urlizer
+from arxiv.base.urls import canonical_url, urlizer
 from arxiv.base.filters import tidy_filesize
 from flask import Flask
 from flask_s3 import FlaskS3
@@ -67,7 +67,6 @@ def create_web_app(**kwargs) -> Flask: # type: ignore
 
     app.jinja_env.filters['entity_to_utf'] = entity_to_utf
 
-    app.jinja_env.filters['clickthrough_url_for'] = clickthrough_url
     app.jinja_env.filters['show_email_hash'] = \
         partial(generate_show_email_hash,
                 secret=settings.SHOW_EMAIL_SECRET.get_secret_value())  # pylint: disable=E1101

--- a/browse/routes/ui.py
+++ b/browse/routes/ui.py
@@ -203,6 +203,10 @@ def trackback(arxiv_id: str) -> Union[str, Response]:
 @blueprint.route("ct")
 def clickthrough() -> Response:
     """Generate redirect for clickthrough links."""
+    # Phasing out clickthrough and just supporting until all the links are gone.
+    if datetime.now().year > 2024:
+        raise NotFound
+
     if 'url' in request.args and 'v' in request.args:
         sec = current_app.config["CLICKTHROUGH_SECRET"].get_secret_value()
         if is_hash_valid(sec, request.args.get('url'), request.args.get('v')):

--- a/browse/templates/abs/bookmarking.html
+++ b/browse/templates/abs/bookmarking.html
@@ -2,12 +2,12 @@
   <div><h3>Bookmark</h3></div>
   {%- set absUrl = canonical_url( abs_meta.arxiv_id ) -%}
   {%- set title = abs_meta.title -%}
-  <a class="abs-button abs-button-grey abs-button-small" href="{{ ('http://www.bibsonomy.org/BibtexHandler?requTask=upload&url=' + absUrl + '&description=' + title) | clickthrough_url_for }}"
+  <a class="abs-button abs-button-grey abs-button-small" href="{{ ('http://www.bibsonomy.org/BibtexHandler?requTask=upload&url=' + absUrl + '&description=' + title) }}"
      title="Bookmark on BibSonomy">
     <img src="{{ url_for('static', filename='images/icons/social/bibsonomy.png') }}"
          alt="BibSonomy logo"/>
   </a>
-  <a class="abs-button abs-button-grey abs-button-small" href="{{('https://reddit.com/submit?url=' + absUrl + '&title=' + title) | clickthrough_url_for}}"
+  <a class="abs-button abs-button-grey abs-button-small" href="{{('https://reddit.com/submit?url=' + absUrl + '&title=' + title)}}"
      title="Bookmark on Reddit">
     <img src="{{ url_for('static', filename='images/icons/social/reddit.png') }}"
          alt="Reddit logo"/>


### PR DESCRIPTION
Removes click through links.

Sets /ct to phase out in 2025 so as to not cause problems with any existing links.
