### PR TITLE
change button text for PDF and HTML

### DIFF
--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -887,7 +887,7 @@ p.tagline {
 #abs-outer .leftcolumn {
   margin: 0 0 1em 0;
   padding: 0px;
-  width:calc(100% - 16em);
+  width:calc(100% - 18em);
   float:left;
 }
 #abs-outer .mobile-submission-download {
@@ -897,7 +897,7 @@ p.tagline {
 #abs-outer .extra-services {
   float:right;
   margin:0;
-  width:16em;
+  width:18em;
 }
 #abs-outer .extra-services .bib-sidebar {
   border-left: .35em solid #ddd !important;

--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -184,15 +184,15 @@
   {% set author_list = abs_meta.authors.raw.split(',') %}
   <div id="download-button-info" hidden>
     {%- if author_list|length > 1 -%}
-    Download a PDF of the paper titled {{abs_meta.title}}, by {{author_list[0]}} and {{author_list|length - 1}} other authors
+    View a PDF of the paper titled {{abs_meta.title}}, by {{author_list[0]}} and {{author_list|length - 1}} other authors
     {%- elif author_list|length == 1 -%}
-    Download a PDF of the paper titled {{abs_meta.title}}, by {{author_list[0]}}
+    View a PDF of the paper titled {{abs_meta.title}}, by {{author_list[0]}}
     {%- else -%}
-    Download a PDF of the paper titled {{abs_meta.title}}
+    View a PDF of the paper titled {{abs_meta.title}}
     {%- endif -%}
   </div>
   {% if formats|length > 0 and ('pdf' in formats or 'pdfonly' in formats) %}
-    <a class="mobile-submission-download" href="{{url_for('dissemination.pdf', arxiv_id=requested_id)}}">Download PDF</a>
+    <a class="mobile-submission-download" href="{{url_for('dissemination.pdf', arxiv_id=requested_id)}}">View PDF</a>
     {% if 'latexml' in formats %}
     <a class="mobile-submission-download" href="{{ latexml_url }}">HTML (experimental)</a>
     {% endif %}

--- a/browse/templates/abs/extra_services.html
+++ b/browse/templates/abs/extra_services.html
@@ -33,11 +33,11 @@
   <div id="download-button-info" hidden>
     {% set author_list = abs_meta.authors.raw.split(',') %}
     {%- if author_list|length > 1 -%}
-    Download a PDF of the paper titled {{abs_meta.title}}, by {{author_list[0]}} and {{author_list|length - 1}} other authors
+    View a PDF of the paper titled {{abs_meta.title}}, by {{author_list[0]}} and {{author_list|length - 1}} other authors
     {%- elif author_list|length == 1 -%}
-    Download a PDF of the paper titled {{abs_meta.title}}, by {{author_list[0]}}
+    View a PDF of the paper titled {{abs_meta.title}}, by {{author_list[0]}}
     {%- else -%}
-    Download a PDF of the paper titled {{abs_meta.title}}
+    View a PDF of the paper titled {{abs_meta.title}}
     {%- endif -%}
   </div>
 
@@ -49,7 +49,7 @@
   {% else %}
     {%- for format in format_list %}
       {%- if format.startswith('pdf') -%}
-  <li><a href="{{url_for('dissemination.pdf', arxiv_id=requested_id)}}" aria-describedby="download-button-info" accesskey="f" class="abs-button download-pdf">Download PDF</a></li>
+  <li><a href="{{url_for('dissemination.pdf', arxiv_id=requested_id)}}" aria-describedby="download-button-info" accesskey="f" class="abs-button download-pdf">View PDF</a></li>
       {%- endif -%}
       {%- if format == 'latexml' -%}
   <li><a href="{{ latexml_url }}" class="abs-button" id="latexml-download-link">HTML (experimental)</a></li>


### PR DESCRIPTION
This PR is basically a very minor text change, but I am seeking feedback before it is merged because it is a visual change on abs.

At the NSF meeting we received feedback to change the "Download PDF" button text to "View PDF", and to update the HTML link to match. In order for the HTML text not to wrap to 2 lines I need to widen the sidebar a tad. Here are screenshots on desktop and mobile:

Desktop:
![Screenshot 2024-03-01 at 2 15 50 PM](https://github.com/arXiv/arxiv-browse/assets/56078140/33052453-cd78-4e6d-a7be-48a275cd1057)

Mobile:
![Screenshot 2024-03-01 at 2 18 13 PM](https://github.com/arXiv/arxiv-browse/assets/56078140/7d996a8f-06ac-40fe-af7f-0607e76ba1e5)
