### PR TITLE
Fixes DOI URLs with < or > on /abs arxivce-1373

### DIFF
--- a/browse/config.py
+++ b/browse/config.py
@@ -140,9 +140,9 @@ class Settings(arxiv_base.Settings):
     """
 
     ARXIV_LOG_DATA_INCONSTANCY_ERRORS: bool = True
-    """It to log error messages during a PDF or other dat request when a paper's metadata does
-    not match what is on the filesystem for data. Ex. a paper version is source type pdf only
-    but there is no pdf file."""
+    """It to log error messages during a PDF or other data request when a paper's metadata does
+    not match what is on the data filesystem. Ex. a paper version is source type PDF-only
+    but there is no src PDF file."""
 
     """========================= End of Services ========================="""
 

--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -354,7 +354,7 @@
           <td class="tablecell label">
             <abbr title="Digital Object Identifier">Related DOI</abbr>:
           </td>
-          <td class="tablecell doi">{{ doi|escape|abs_doi_to_urls|safe }}
+          <td class="tablecell doi">{{ doi|abs_doi_to_urls|safe }}
 
             <!-- accessible tooltip example -->
             <div class="button-and-tooltip">

--- a/tests/test_doi.py
+++ b/tests/test_doi.py
@@ -8,43 +8,20 @@ from app import app
 from arxiv.license import ASSUMED_LICENSE_URI
 
 
-@unittest.skip('We will move this test and any required test data to arxiv-base in the near future')
-class DoiTest(unittest.TestCase):
+def test_doi_9503001(client_with_test_fs):
+    # test for ARXIVNG-1201, messed up doi text and href
+    rv = client_with_test_fs.get('/abs/ao-sci/9503001')
+    #self.assertEqual(rv.status_code, 200)
+    assert rv.status_code == 200
+    html = BeautifulSoup(rv.data.decode('utf-8'), 'html.parser')
 
-    def setUp(self):
-        app.testing = True
-        app.config['APPLICATION_ROOT'] = ''
-        self.app = app.test_client()
+    doi_a = html.find('td', 'doi').find('a')
+    assert doi_a and (doi_a.text ==
+                     '10.1175/1520-0469(1996)053<0946:ASTFHH>2.0.CO;2',
+                     'DOI links should deal with strange characters with no problems')
 
-    def test_doi_9503001(self):
-        # test for ARXIVNG-1201, messed up doi text and href
-        rv = self.app.get('/abs/ao-sci/9503001')
-        self.assertEqual(rv.status_code, 200)
-        html = BeautifulSoup(rv.data.decode('utf-8'), 'html.parser')
-        self.assertIsNotNone(html)
+    assert doi_a['href']
+    parsed_url = urlparse(doi_a['href'])
 
-        doi_a = html.find('td', 'msc_classes').find('a')
-        self.assertIsNotNone(doi_a)
-        self.assertEqual(doi_a.text,
-                         '10.1175/1520-0469(1996)053<0946:ASTFHH>2.0.CO;2',
-                         'DOI links should deal with strange characters with no problems')
-
-        self.assertIsNotNone(doi_a['href'])
-        parsed_url = urlparse(doi_a['href'])
-        self.assertIsNotNone(parsed_url)
-
-        self.assertEqual(parsed_url.path, '/ct', 'href should be to arXiv /ct')
-        qs = parse_qs(parsed_url.query)
-        self.assertIsNotNone(qs)
-
-        self.assertTrue('v' in qs, 'query to /ct must have v parameter')
-        self.assertTrue('url' in qs, 'query to /ct must have parameter url')
-
-        doiurl = urlparse(unquote(qs['url'][0]))
-        self.assertIsNotNone(doiurl,
-                             'url query part should deurlencode to a URL')
-
-        self.assertEqual(doiurl.netloc, 'dx.doi.org',
-                         'decoded URL from CT should have DOI resolver hostname')
-        self.assertEqual(doiurl.path, '/10.1175/1520-0469(1996)053<0946:ASTFHH>2.0.CO',
-                         'path of doi.org URL should be to expected DOI')
+    assert parsed_url.netloc == 'doi.org' # decoded URL from CT should have DOI resolver hostname
+    assert unquote(parsed_url.path) == '/10.1175/1520-0469(1996)053<0946:ASTFHH>2.0.CO;2' # path of doi.org URL should be to expected DOI


### PR DESCRIPTION
Removes `escape` since the DOI is transformed with urllib.parse.quote() which urlencodes < and >.