### PR TITLE
Increases cache-control max age for files

### DIFF
--- a/browse/controllers/__init__.py
+++ b/browse/controllers/__init__.py
@@ -51,21 +51,3 @@ def biz_tz() -> ZoneInfo:
         return _arxiv_biz_tz
     else:
         return _arxiv_biz_tz
-
-
-def next_publish(now: Optional[datetime] = None) -> datetime:
-    """Guesses the next publish but knows nothing about holidays.
-
-    Returns a `datetime` with a `timezone` from `biz_tz()`."""
-    if now is None:
-        now = datetime.now(tz=biz_tz())
-
-    if now.weekday() == 4:
-        return (now + timedelta(days=2)).replace(hour=20)
-    if now.weekday() == 5:
-        return (now + timedelta(days=2)).replace(hour=20)
-
-    if now.hour > 21:
-        return next_publish((now + timedelta(days=1)).replace(hour=12))
-    else:
-        return now.replace(hour=20)

--- a/browse/controllers/files/__init__.py
+++ b/browse/controllers/files/__init__.py
@@ -10,8 +10,27 @@ from arxiv.files import FileObj
 
 
 BUFFER_SIZE = 1024 * 4
+
 CACHE_AGE_SEC_VERSIONED = 60 * 60 * 24 * 7
+"""cache-control max-age for versioned requests.
+
+An example of a versioned request: /pdf/0202.12345v1
+
+This is set long since changes to old versions are infrequent. When old papers
+change, right after the announce process there is a call to purge the paper's
+related URLs from the fastly cache.
+
+"""
+
 CACHE_AGE_SEC_UNVERSIONED = 60 * 60 * 24
+"""cache-control max-age for unversioned requests.
+
+An example of an unversioned request: /pdf/0202.12345
+
+These can change during the next publish. Right after the announce process,
+replacements have all their related URLs invalidated.
+
+"""
 
 def maxage(versioned: bool=False) -> str:
     """Returns a "max-age=N" `str` for use with "Cache-Control".

--- a/browse/controllers/files/__init__.py
+++ b/browse/controllers/files/__init__.py
@@ -10,6 +10,8 @@ from arxiv.files import FileObj
 
 
 BUFFER_SIZE = 1024 * 4
+CACHE_AGE_SEC_VERSIONED = 60 * 60 * 24 * 7
+CACHE_AGE_SEC_UNVERSIONED = 60 * 60 * 24
 
 def maxage(versioned: bool=False) -> str:
     """Returns a "max-age=N" `str` for use with "Cache-Control".
@@ -19,7 +21,7 @@ def maxage(versioned: bool=False) -> str:
 
     versioned: if the request was for a versioned paper or the current version.
     """
-    return f'max-age={60 * 30}' if versioned else f'max-age={60 * 15}'  # sec
+    return f'max-age={CACHE_AGE_SEC_VERSIONED}' if versioned else f'max-age={CACHE_AGE_SEC_UNVERSIONED}'  # sec
 
 
 def add_time_headers(resp: Response, file: FileObj, arxiv_id: Identifier) -> None:

--- a/browse/controllers/files/ancillary_files.py
+++ b/browse/controllers/files/ancillary_files.py
@@ -12,7 +12,7 @@ from browse.services.documents import get_doc_service
 from arxiv.files import FileObj
 from arxiv.files import FileFromTar
 
-from . import last_modified, add_time_headers, add_mimetype
+from . import last_modified, add_time_headers, add_mimetype, CACHE_AGE_SEC_VERSIONED, CACHE_AGE_SEC_UNVERSIONED
 
 
 def get_extracted_src_file_resp(arxiv_id_str: str,
@@ -39,12 +39,13 @@ def get_extracted_src_file_resp(arxiv_id_str: str,
     doc = get_doc_service().get_abs(arxiv_id)
 
     ver = doc.get_version()
+    cache_sec = CACHE_AGE_SEC_VERSIONED if arxiv_id.has_version else CACHE_AGE_SEC_UNVERSIONED
     if mode == 'anc' and ver is not None \
        and not ver.source_flag.includes_ancillary_files:
         return make_response(
             render_template("src/anc_not_found.html",
                             reason=f"No ancillary files for {arxiv_id.idv}"),
-            404, {'Cache-Control': f"max-age={60*60}"})
+            404, {'Cache-Control': f"max-age={cache_sec}"})
 
     dis_res = get_article_store().dissemination('e-print', arxiv_id, doc)
 
@@ -63,7 +64,7 @@ def get_extracted_src_file_resp(arxiv_id_str: str,
         return make_response(
             render_template("src/anc_not_found.html",
                             reason=f"File not in ancillary files for {arxiv_id.idv}"),
-            404, {"ETag": src_file.etag})
+            404, {"ETag": src_file.etag, "Cache-Control": f"max-age={cache_sec}"})
 
     """RangeRequest does a seek and that seems odd with gzip and tarfile but both of
     those support seek."""


### PR DESCRIPTION
`Requests` for versioned files get the max-age set to 7 days and unversioned requests for one day.