### PR TITLE
Fixes bug with conference proceedings

### DIFF
--- a/browse/controllers/files/dissemination.py
+++ b/browse/controllers/files/dissemination.py
@@ -24,7 +24,7 @@ from browse.services.dissemination import get_article_store
 from browse.services.dissemination.article_store import (
     Acceptable_Format_Requests, CannotBuildPdf, Deleted)
 
-from flask import Response, abort, make_response, render_template, request, current_app
+from flask import Response, abort, make_response, render_template, request, current_app, stream_with_context
 from flask_rangerequest import RangeRequest
 
 
@@ -69,7 +69,7 @@ def default_resp_fn(format: Optional[FileFormat],
         # Cloud run needs chunked for large responses
         if request.method == "GET":
             # Flask/werkzeug automatically do Transfer-Encoding: chunked for a file
-            resp = make_response(iter(file.open("rb")))
+            resp = make_response(stream_with_context(iter(file.open("rb"))))
             # but the unit test client doesn't do that so we force it for those
             # see https://github.com/pallets/flask/issues/5424
             resp.headers["Transfer-Encoding"] = "chunked"

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -8,7 +8,9 @@ def test_html_paper(client_with_test_fs):
 
     resp = client_with_test_fs.get("/html/2403.10561")
     assert resp.status_code == 200
-    assert "Human-Centric" in resp.data.decode()
+    assert b"Human-Centric" in resp.data
+
+    assert b"LIST:arXiv:2401.00907" in resp.data  # should have at least un-post-processed line
 
 def test_html_paper_multi_files(client_with_test_fs):
     """Test a paper with html source."""


### PR DESCRIPTION
The html_post_process fn subs in ABS and LIST in the html text for actual looked up abs metadata at time of request.

This was broken due to a recent change that moved it to after the app code so the fn was not in flask's request context. 

Calls `html_post_process` wrapped in `flask.stream_with_context` so it can access the metadata service even after the app code has returned.

Adds a test that should ensure that the `html_post_process` is not having errors due to this flask context problem

https://arxiv-org.atlassian.net/browse/AH-93375