### PR TITLE
Updated text and a link to technical support

### DIFF
--- a/browse/templates/format.html
+++ b/browse/templates/format.html
@@ -122,8 +122,6 @@ otherwise as a <b>PDF</b> file, or a <b>gzipped TeX, DVI, PostScript or HTML</b>
 (<code>Content-Encoding: x-gzip</code>). Your browser may silently uncompress
 after downloading so the files you see saved may appear uncompressed.</p>
 
-<p>Please report any problems to <a href="https://info.arxiv.org/help/contact">arXiv admins</a>, being
-certain to state the paper identifier, explicit options you've selected and that
-you're using $THIS_SITE.</p>
+<p>Please report any problems to <a href="https://arxiv-org.atlassian.net/servicedesk/customer/portal/1">arXiv technical support</a> and include the paper identifier.</p>
 
 {% endblock %}


### PR DESCRIPTION
There is some text that should be updated on this page: [https://arxiv.org/format/2401.08575 ](https://arxiv.org/format/2401.08575)

  Current text: Please report any problems to arXiv admins, being certain to state the paper identifier, explicit options you've selected and that you're using arxiv.org.  

New text: Please report any problems to arXiv user support and include the paper identifier.   (link provided from "arXiv technical support" should go to "https://arxiv-org.atlassian.net/servicedesk/customer/portal/1)

Note - This code needs to be moved to GCP to be deployed. 
@bdc34 @kyokukou - please let me know when I can deploy this. 