### PR TITLE
Gets integration tests passing

### DIFF
--- a/browse/controllers/files/__init__.py
+++ b/browse/controllers/files/__init__.py
@@ -129,5 +129,5 @@ def bad_id(arxiv_id: Union[Identifier,str], err_msg: str) -> Response:
 
 def cannot_build_pdf(arxiv_id: Identifier, msg: str) -> Response:
     return make_response(render_template("dissemination/cannot_build_pdf.html",
-                                         err_msg=msg,
+                                         msg=msg,
                                          arxiv_id=arxiv_id), 404, {})

--- a/browse/controllers/files/__init__.py
+++ b/browse/controllers/files/__init__.py
@@ -100,7 +100,7 @@ def unavailable(arxiv_id: Identifier) -> Response:
 
 
 def not_pdf(arxiv_id: Identifier) -> Response:
-    return make_response(render_template("dissemination/unavailable.html",
+    return make_response(render_template("dissemination/not_pdf.html",
                                          arxiv_id=arxiv_id), 404, {})
 
 

--- a/browse/controllers/files/dissemination.py
+++ b/browse/controllers/files/dissemination.py
@@ -162,7 +162,6 @@ def get_dissemination_resp(format: Acceptable_Format_Requests,
     elif item == "WITHDRAWN" or item == "NO_SOURCE":
         return withdrawn(arxiv_id, arxiv_id.has_version)
     elif item == "UNAVAILABLE":
-        breakpoint()
         return unavailable(arxiv_id)
     elif item == "NOT_PDF":
         return not_pdf(arxiv_id)

--- a/browse/controllers/files/dissemination.py
+++ b/browse/controllers/files/dissemination.py
@@ -154,12 +154,13 @@ def get_dissemination_resp(format: Acceptable_Format_Requests,
     except IdentifierException as ex:
         return bad_id(arxiv_id_str, str(ex))
     item = get_article_store().dissemination(format, arxiv_id)
-    logger. debug(f"dissemination_for_id(%s) was %s", arxiv_id.idv, item)
+    logger.debug(f"dissemination (%s) was %s", arxiv_id.idv, item)
     if not item or item == "VERSION_NOT_FOUND" or item == "ARTICLE_NOT_FOUND":
         return not_found(arxiv_id)
     elif item == "WITHDRAWN" or item == "NO_SOURCE":
         return withdrawn(arxiv_id, arxiv_id.has_version)
     elif item == "UNAVAILABLE":
+        breakpoint()
         return unavailable(arxiv_id)
     elif item == "NOT_PDF":
         return not_pdf(arxiv_id)

--- a/browse/services/dissemination/article_store.py
+++ b/browse/services/dissemination/article_store.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 import requests
 
 from arxiv.identifier import Identifier
-from arxiv.legacy.papers.dissemination.reasons import FORMATS
+from arxiv.legacy.papers.dissemination.reasons import FORMATS, reasons
 from arxiv.document.metadata import DocMetadata, VersionEntry
 from arxiv.document.exceptions import (
     AbsDeletedException, AbsNotFoundException, AbsVersionNotFoundException)
@@ -107,9 +107,6 @@ def _is_deleted(id: str) -> Optional[str]:
         return DELETED_PAPERS.get(id, None)
 
 
-def _unset_reasons(str: str, fmt:FORMATS) -> Optional[str]:
-    pass
-
 def from_genpdf_location(location: str) -> typing.Tuple[str, str]:
     """Translates the genpdf-api redirect location for the genpdf object store.
     returns the bucket name and key as a tuple if it is a gcp bucket.
@@ -136,7 +133,7 @@ class ArticleStore():
                  metaservice: DocMetadataService,
                  objstore: ObjectStore,
                  genpdf_store: ObjectStore,
-                 reasons: Callable[[str, FORMATS], Optional[str]] = _unset_reasons,
+                 reasons: Callable[[str, FORMATS], Optional[str]] = reasons,
                  is_deleted: Callable[[str], Optional[str]] = _is_deleted
                  ):
         self.metadataservice = metaservice

--- a/browse/services/dissemination/article_store.py
+++ b/browse/services/dissemination/article_store.py
@@ -318,7 +318,7 @@ class ArticleStore():
 
     def _pdf(self, arxiv_id: Identifier, docmeta: DocMetadata, version: VersionEntry) -> FormatHandlerReturn:
         """Handles getting the `FielObj` for a PDF request."""
-        if version.source_flag.cannot_pdf:
+        if version.source_flag.cannot_pdf or version.source_format == 'html':
             return "NOT_PDF"
 
         res = self.reasons(arxiv_id.idv, 'pdf')

--- a/browse/templates/dissemination/bad_id.html
+++ b/browse/templates/dissemination/bad_id.html
@@ -1,4 +1,4 @@
-{% extends "base/base.html" %}
+{% extends "base.html" %}
 
 {# This is the template that gets shown when the client provides
 something that is not a valid ID. #}

--- a/browse/templates/dissemination/cannot_build_pdf.html
+++ b/browse/templates/dissemination/cannot_build_pdf.html
@@ -1,4 +1,4 @@
-{% extends "base/base.html" %}
+{% extends "base.html" %}
 
 {%- block content -%}
 <h1>PDF unavailable ...</h1>

--- a/browse/templates/dissemination/cannot_build_pdf.html
+++ b/browse/templates/dissemination/cannot_build_pdf.html
@@ -1,21 +1,19 @@
 {% extends "base.html" %}
 
 {%- block content -%}
-<h1>PDF unavailable ...</h1>
+<h1>PDF unavailable</h1>
 
-<p>Our <b>automated</b> source to PDF conversion system was unable to produce PDF for the paper:
+<p>Our automated source to PDF conversion system was unable to produce PDF for the paper
   <a href="{{url_for('browse.abstract', arxiv_id=arxiv_id.ids)}}">{{arxiv_id.ids}}</a>.</p>
 
-<p>Incomplete or corrupted files were submitted. This failure can be resolved by replacing missing or corrupted files. The reason for failure is recorded as:<br />
-  <b>{{msg}}</b></p>
+<p>The reason for failure is recorded as: <b>{{msg}}</b>
+</p>
 
-<p>Return to the<a href="{{url_for('browse.abstract', arxiv_id=arxiv_id.ids)}}">abstract</a> for an
-  alternative link to the
-  <a href="{{url_for('src.src', arxiv_id_str=arxiv_id.ids)}}">source</a>, or to find an
-  email address to contact the author.</p>
+<p>Return to the <a href="{{url_for('browse.abstract',
+   arxiv_id=arxiv_id.ids)}}">abstract</a> for an link to
+   the <a href="{{url_for('src.src', arxiv_id_str=arxiv_id.ids)}}">source</a> or
+   to find an email address to contact the author.</p>
 
 <p>For help regarding the automated source to PDF system,
-  contact <a href="mailto:help@arxiv.org">help@arxiv.org</a>,
-  remembering to specify the problematic archive and paper number.</p>
-
+  contact <a href="mailto:help@arxiv.org">help@arxiv.org</a>.</p>
 {%- endblock -%}

--- a/browse/templates/dissemination/multiple_files.html
+++ b/browse/templates/dissemination/multiple_files.html
@@ -1,4 +1,4 @@
-{% extends "base/base.html" %}
+{% extends "base.html" %}
 
 {%- block title -%}{{arxiv_id.ids}}{%- endblock -%}
 

--- a/browse/templates/dissemination/no_html.html
+++ b/browse/templates/dissemination/no_html.html
@@ -1,4 +1,4 @@
-{% extends "base/base.html" %}
+{% extends "base.html" %}
 
 {# This is when an html version is unavailable for some reason, 
     either we havent converted the latex or failed to, or its another type of document that isnt latex or native html #}

--- a/browse/templates/dissemination/not_found.html
+++ b/browse/templates/dissemination/not_found.html
@@ -1,4 +1,4 @@
-{% extends "base/base.html" %}
+{% extends "base.html" %}
 
 {# This is when the arxiv ID from the client is valid but the article
 or version does not exist. #}

--- a/browse/templates/dissemination/not_pdf.html
+++ b/browse/templates/dissemination/not_pdf.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{# This is the template that gets shown when the paper and version
+exists, but the source is not PDF and the source cannot build a PDF. Ex HTML source #}
+
+{%- block content -%}
+<h1>{{arxiv_id.ids}} does not build PDF</h1>
+<p>
+  The source for the paper
+  <a href="{{url_for('browse.abstract', arxiv_id=arxiv_id.ids)}}">{{arxiv_id.id}}</a>
+  cannot built to a PDF by our systems.
+</p>
+{%- endblock -%}

--- a/browse/templates/dissemination/unavailable.html
+++ b/browse/templates/dissemination/unavailable.html
@@ -1,10 +1,13 @@
-{% extends "base/base.html" %}
+{% extends "base.html" %}
 
 {# This is the template that gets shown when the paper and version
-exists, but there is no file like a PDF. This is an error condition that should
-not happen but needs to be covered. #}
+exists, but there is no file like a PDF. This can happen when the source is
+HTML. #}
 
 {%- block content -%}
 <h1>file unavailable</h1>
-<p>Our automated source to PDF conversion system has failed to produce PDF for the paper {{arxiv_id.ids}}.</p>
+<p>
+  Our automated source to PDF conversion system has failed to produce PDF for the paper
+  <a href="{{url_for('browse.abstract', arxiv_id=arxiv_id.id)}}">{{arxiv_id.id}}</a>.
+</p>
 {%- endblock -%}

--- a/browse/templates/dissemination/withdrawn.html
+++ b/browse/templates/dissemination/withdrawn.html
@@ -1,4 +1,4 @@
-{% extends "base/base.html" %}
+{% extends "base.html" %}
 
 {%- block title -%}No file for {{arxiv_id.ids}}{%- endblock -%}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,6 +203,8 @@ Mark integration tests like this:
 @pytest.mark.integration
 def test_something():
   ...
+
+Run this with: `HOST=https://browse.dev.arxiv.org pytset --runintegration tests/dissemination/test_integration.py`
 """
 
 def pytest_addoption(parser):

--- a/tests/dissemination/test_integration.py
+++ b/tests/dissemination/test_integration.py
@@ -334,7 +334,7 @@ def test_withdrawn(host):
 
 @pytest.mark.integration
 def test_html_src(host):
-    """Submissions with HTML source"""
+    """Submissions with HTML source."""
     # legacy returns 200 with msg: "Unavailable, The author has provided no source to generate PDF, and no PDF."
     resp = requests.get(f"{host}/pdf/cond-mat/9906075v1")
     assert resp.status_code == 404

--- a/tests/dissemination/test_integration.py
+++ b/tests/dissemination/test_integration.py
@@ -348,30 +348,30 @@ def test_html_src(host):
 @pytest.mark.integration
 def test_reasons(host):
     """Paper in reasons"""
-    msg = "submitter supplied incomplete or corrupted files"
+    msg = b"Incomplete or corrupted files"
     resp = requests.get(f"{host}/pdf/1808.02949v1")
     assert resp.status_code == 404
-    assert msg in resp.text
+    assert msg in resp.content
 
     resp = requests.get(f"{host}/pdf/1310.4962")
     assert resp.status_code == 404
-    assert msg in resp.text
+    assert msg in resp.content
     resp = requests.get(f"{host}/pdf/1310.4962v1")
     assert resp.status_code == 404
-    assert msg in resp.text
+    assert msg in resp.content
     resp = requests.get(f"{host}/pdf/1310.4962v2")
     assert resp.status_code == 404
-    assert msg in resp.text
+    assert msg in resp.content
 
     resp = requests.get(f"{host}/pdf/physics/0411006")
     assert resp.status_code == 404
-    assert msg in resp.text
+    assert msg in resp.content
     resp = requests.get(f"{host}/pdf/physics/0411006")
     assert resp.status_code == 404
-    assert msg in resp.text
+    assert msg in resp.content
     resp = requests.get(f"{host}/pdf/physics/0411006")
     assert resp.status_code == 404
-    assert msg in resp.text
+    assert msg in resp.content
 
 
 @pytest.mark.integration


### PR DESCRIPTION
The integration tests can be run with `HOST=https://browse.dev.arxiv.org pytest --runintegration tests`

Or if you have a local set that points to GCP: `HOST=http://localhost:8080 pytest --runintegration tests`

This gets those tests to all pass. It also adds back in the use of the REASONS for PDFs that have known reasons why they don't build. That should be moved to arxiv-base. 