### PR TITLE
improve prev next context selection

### DIFF
--- a/browse/controllers/abs_page.py
+++ b/browse/controllers/abs_page.py
@@ -305,14 +305,9 @@ def _prevnext_links(
     ):
         context = request.args["context"]
     elif primary_category:
-        pc = primary_category.get_canonical()
-        if not arxiv_identifier.is_old_id:  # new style IDs
-            context = pc.id
-        else:  # Old style id
-            if pc.id in ARCHIVES:
-                context = pc.id
-            else:
-                if arxiv_identifier.archive in ARCHIVES:
+        context = primary_category.get_canonical().id
+    elif arxiv_identifier.is_old_id: 
+        if arxiv_identifier.archive in ARCHIVES: #context from old style id
                     context = arxiv_identifier.archive
 
     response_data["browse_context"] = context

--- a/browse/controllers/abs_page.py
+++ b/browse/controllers/abs_page.py
@@ -305,10 +305,10 @@ def _prevnext_links(
     ):
         context = request.args["context"]
     elif primary_category:
-        context = primary_category.get_canonical().id
+        context = primary_category.canonical_id
     elif arxiv_identifier.is_old_id: 
         if arxiv_identifier.archive in ARCHIVES: #context from old style id
-                    context = arxiv_identifier.archive
+                    context=ARCHIVES[arxiv_identifier.archive].canonical_id
 
     response_data["browse_context"] = context
     response_data["browse_context_previous_url"] = url_for(

--- a/tests/test_browse_links.py
+++ b/tests/test_browse_links.py
@@ -29,7 +29,7 @@ def test_older_id(client_with_test_fs):
 
     current_context = html.find('div', 'current')
     assert current_context is not None
-    assert current_context.text == 'ao-sci'
+    assert current_context.text == 'physics.ao-ph'
 
     pn_div = html.find('div', 'prevnext')
     assert pn_div, 'Should have div.prevnext'
@@ -37,10 +37,10 @@ def test_older_id(client_with_test_fs):
     atags = pn_div.find_all('a')
     assert len(atags) >= 1, 'Shold be at least one <a> tags for prev/next'
 
-    assert pn_div.find_all('a')[0]['title'] == 'previous in ao-sci (accesskey p)', 'Should have previous span.arrow subtags with correct category'
+    assert pn_div.find_all('a')[0]['title'] == 'previous in physics.ao-ph (accesskey p)', 'Should have previous span.arrow subtags with correct category'
 
     switches = html.find_all('div', 'switch')
-    assert len(switches) == 0, 'Should be no other contxt to switch to'
+    assert len(switches) == 0, 'Should be no other context to switch to'
 
 def test_older_id_w_canonical(client_with_test_fs):
     rv = client_with_test_fs.get('/abs/physics/9707012')
@@ -55,12 +55,12 @@ def test_older_id_w_canonical(client_with_test_fs):
     assert pn_div, 'Should have div.prevnext'
 
     atags = pn_div.find_all('a')
-    assert len(atags) >= 1, 'Shold be at least one <a> tags for prev/next'
+    assert len(atags) >= 1, 'Should be at least one <a> tags for prev/next'
 
     assert pn_div.find_all('a')[0]['title'] == 'previous in math-ph (accesskey p)', 'Should have previous span.arrow subtags with correct category'
 
     switches = html.find_all('div', 'switch')
-    assert len(switches) == 0, 'Should be no other contxt to switch to'
+    assert len(switches) == 0, 'Should be no other context to switch to'
 
     other_atags = html.find('div','list').find_all('a')
     assert other_atags


### PR DESCRIPTION
collect context from article primary category when possible. Only use old style id archive as last resort.

Use canonical category names