### PR TITLE
switch abs link back to yymm which page change isnt deployed

### DIFF
--- a/browse/templates/abs/extra_services.html
+++ b/browse/templates/abs/extra_services.html
@@ -99,7 +99,8 @@
     <span class="is-hidden-mobile"> | </span>
     <a class="abs-button abs-button-grey abs-button-small context-recent" href="{{url_for('.list_articles',context=browse_context, subcontext='recent')}}">recent</a>
     <span class="is-hidden-mobile"> | </span>
-    {%- set yyyymm = '%04d-%02d' % (abs_meta.arxiv_identifier.year, abs_meta.arxiv_identifier.month) -%}
+    {#%- set yyyymm = '%04d-%02d' % (abs_meta.arxiv_identifier.year, abs_meta.arxiv_identifier.month) -%#}
+    {%-set yyyymm= abs_meta.arxiv_identifier.yymm-%}
     <a class="abs-button abs-button-grey abs-button-small context-id" href="{{url_for('.list_articles',context=browse_context, subcontext=yyyymm)}}">
       {{- yyyymm -}}</a>
   </div>

--- a/tests/test_browse_links.py
+++ b/tests/test_browse_links.py
@@ -67,4 +67,4 @@ def test_older_id_w_canonical(client_with_test_fs):
     assert len(other_atags) >= 3, "should be at least 3 a tags in list"
     assert other_atags[0]['href'] == '/list/math-ph/new'
     assert other_atags[1]['href'] == '/list/math-ph/recent'
-    assert other_atags[2]['href'] == '/list/math-ph/1997-07'
+    assert other_atags[2]['href'] == '/list/math-ph/9707'


### PR DESCRIPTION
switching this back to the old url schema while listings arent turned on