### PR TITLE
Temp 2 digit year listings

### DIFF
--- a/browse/controllers/list_page/__init__.py
+++ b/browse/controllers/list_page/__init__.py
@@ -129,7 +129,6 @@ def get_listing(subject_or_category: str,
     show
        Number of articles to show
     """
-    
     skip = skip or request.args.get('skip', '0')
     show = show or request.args.get('show', '')
     if request.args.get('archive', None) is not None:
@@ -138,7 +137,8 @@ def get_listing(subject_or_category: str,
         time_period = request.args.get('year')  # type: ignore
         month = request.args.get('month', None)
         if month and month != 'all':
-            time_period = time_period + "-"+request.args.get('month')  # type: ignore
+            #time_period = time_period + "-"+request.args.get('month')  # type: ignore
+            time_period = time_period +month  
 
 
     if (
@@ -327,12 +327,15 @@ def year_month_2_digit(tp: str)->Optional[Tuple[bool, int, Optional[int]]]:
     
     if len(tp) == 2:  
         year=int(tp) +1900
-        if year<1990:
+        if year<=1990:
             year+=100
         return False, year, None
     
-    if len(tp) == 4:  
-        return False, int(tp), None
+    if len(tp) == 4:
+        year=int(tp[0:2]) +1900
+        if year<1990:
+            year+=100  
+        return False, year, int(tp[2:])
     
     else:
         return None

--- a/browse/controllers/list_page/__init__.py
+++ b/browse/controllers/list_page/__init__.py
@@ -222,7 +222,7 @@ def get_listing(subject_or_category: str,
         response_data.update(sub_sections_for_recent(rec_resp, skipn, shown))
 
     else:  # current or YYMM or YYYYMM or YY
-        yandm = year_month(time_period)
+        yandm = year_month_2_digit(time_period)
         if yandm is None:
             raise BadRequest(f"Invalid time period: {time_period}") 
         should_redir, list_year, list_month = yandm
@@ -320,6 +320,22 @@ def get_listing(subject_or_category: str,
 
     return response_data, status.OK, response_headers
 
+def year_month_2_digit(tp: str)->Optional[Tuple[bool, int, Optional[int]]]:
+    if tp == "current":
+        day = date.today()
+        return False, day.year, day.month
+    
+    if len(tp) == 2:  
+        year=int(tp) +1900
+        if year<1990:
+            year+=100
+        return False, year, None
+    
+    if len(tp) == 4:  
+        return False, int(tp), None
+    
+    else:
+        return None
 
 def year_month(tp: str)->Optional[Tuple[bool, int, Optional[int]]]:
     """Gets the year and month from the time_period parameter. The boolean is if a redirect needs to be sent"""

--- a/browse/routes/ui.py
+++ b/browse/routes/ui.py
@@ -232,8 +232,9 @@ def list_articles(context: str, subcontext: str) -> Response:
     """
     response, code, headers = list_page.get_listing(context, subcontext)
     if code == status.OK:
-        if subcontext not in ["new", "recent", "pastweek"]:
-            response=_add_year_url_alert(response)
+        #if subcontext not in ["new", "recent", "pastweek"]:
+            #response=_add_year_url_alert(response)
+
         # TODO if it is a HEAD request we don't want to render the template
         return render_template(response["template"], **response), code, headers  # type: ignore
     elif code == status.MOVED_PERMANENTLY:

--- a/browse/templates/list/month.html
+++ b/browse/templates/list/month.html
@@ -2,7 +2,7 @@
 {% import "alert_macro.html" as alert with context %}
 
 {% block list_index %}
-{{alert.alert(alert_title, alert_content)}}
+{#{alert.alert(alert_title, alert_content)}#}
 
 <h2>Authors and titles for {{pubmonth.strftime('%B %Y')}} </h2>
 {% endblock %}

--- a/browse/templates/list/year.html
+++ b/browse/templates/list/year.html
@@ -2,7 +2,7 @@
 {% import "alert_macro.html" as alert with context %}
 
 {% block list_index %}
-{{alert.alert(alert_title, alert_content)}}
+{#{alert.alert(alert_title, alert_content)}#}
 
 <h2>Authors and titles for {{pubmonth.strftime('%Y')}} </h2>
 {% endblock %}

--- a/tests/listings/db/test_db_listing_month_year.py
+++ b/tests/listings/db/test_db_listing_month_year.py
@@ -170,7 +170,7 @@ def test_listings_for_year(app_with_db):
 def test_month_listing_page( client_with_db_listings):
     client = client_with_db_listings
 
-    rv = client.get("/list/chao-dyn/1995-10")
+    rv = client.get("/list/chao-dyn/9510")
     assert rv.status_code == 200
     text = rv.text
     #page formatting
@@ -186,7 +186,7 @@ def test_year_listing_page( client_with_db_listings):
     client = client_with_db_listings
 
     #two digit year
-    rv = client.get("/list/chao-dyn/1995")
+    rv = client.get("/list/chao-dyn/95")
     assert rv.status_code == 200
     text = rv.text
     #page formatting

--- a/tests/listings/test_fake_list.py
+++ b/tests/listings/test_fake_list.py
@@ -1,12 +1,12 @@
 import pytest
 
 def test_basic_lists(client_with_fake_listings):
-    rv = client_with_fake_listings.get('/list/hep-ph/2009-01')
+    rv = client_with_fake_listings.get('/list/hep-ph/0901')
     assert rv.status_code == 200
 
 
 def test_listing_expires_headers(client_with_fake_listings):
-    rv = client_with_fake_listings.get('/list/hep-ph/2009-01')
+    rv = client_with_fake_listings.get('/list/hep-ph/0901')
     assert rv.status_code == 200
 
     pytest.skip('expires is not yet implemented')

--- a/tests/listings/test_list_page.py
+++ b/tests/listings/test_list_page.py
@@ -101,8 +101,8 @@ def test_basic_lists_errors(client_with_fake_listings):
     rv = client.get("/list/math/90")  # year 2090, will need to revise after 2090
     assert rv.status_code == 404
 
-    rv = client.get("/list/math/80") #arxiv wasnt around yet 
-    assert rv.status_code == 400
+   # rv = client.get("/list/math/80") #arxiv wasnt around yet 
+    #assert rv.status_code == 400
 
     rv = client.get("/list/math/80") #redirected to 2080 which is in future 
     assert rv.status_code == 404
@@ -677,13 +677,13 @@ def test_invalid_archive_years(client_with_test_fs):
     client = client_with_test_fs
 
     #started in 1996
-    rv = client.get("/year/physics/94")
+    rv = client.get("/year/physics/1994")
     assert rv.status_code == 400
     text=rv.text
     assert 'Invalid year' in text
 
     #ended in 1997
-    rv = client.get("/year/funct-an/98")
+    rv = client.get("/year/funct-an/1998")
     assert rv.status_code == 400
     text=rv.text
     assert 'Invalid year' in text
@@ -691,11 +691,11 @@ def test_invalid_archive_years(client_with_test_fs):
 
 def test_year_archive_with_end_date(client_with_test_fs):
     client = client_with_test_fs
-    rv = client.get("/year/funct-an/96")
+    rv = client.get("/year/funct-an/1996")
     assert rv.status_code == 200
     text=rv.text
-    assert '<a href="/year/funct-an/97">97</a>' in text
-    assert '<a href="/year/funct-an/98">98</a>' not in text
+    assert '<a href="/year/funct-an/1997">1997</a>' in text
+    assert '<a href="/year/funct-an/1998">1998</a>' not in text
 
 def test_listing_page_subsumed_archive( client_with_test_fs):
     client = client_with_test_fs
@@ -715,6 +715,7 @@ def test_listing_page_subsumed_archive( client_with_test_fs):
     assert "Algebraic Geometry" in text
     assert "math.AG" in text
 
+@pytest.mark.skip(reason="Currently using 2 digit year")
 def test_YY_redirect(client_with_db_listings):
     client = client_with_db_listings
     rv = client.get("/list/math-ph/03", follow_redirects=False)
@@ -725,6 +726,7 @@ def test_YY_redirect(client_with_db_listings):
     assert rv.status_code == 200
     assert "titles for 2003" in rv.text
     
+@pytest.mark.skip(reason="Currently using 2 digit year")
 def test_YYYYMM_redirect(client_with_db_listings):
     client = client_with_db_listings
     rv = client.get("/list/math-ph/200301", follow_redirects=False)
@@ -736,6 +738,7 @@ def test_YYYYMM_redirect(client_with_db_listings):
     assert "titles for January 2003" in rv.text
     
 # YYYY-M
+@pytest.mark.skip(reason="Currently using 2 digit year")
 def test_YYYY_M_redirect(client_with_db_listings):
     client = client_with_db_listings
     rv = client.get("/list/math-ph/031", follow_redirects=False)

--- a/tests/listings/test_list_page.py
+++ b/tests/listings/test_list_page.py
@@ -8,7 +8,7 @@ from bs4 import BeautifulSoup
 
 def test_basic_lists(client_with_fake_listings):
     client = client_with_fake_listings
-    rv = client.get("/list/hep-ph/2009-01")
+    rv = client.get("/list/hep-ph/0901")
     assert rv.status_code == 200
     assert rv.headers.get("Expires", None) != None
 
@@ -32,76 +32,76 @@ def test_basic_lists(client_with_fake_listings):
     assert rv.status_code == 200
     assert rv.headers.get("Expires", None) != None
 
-    rv = client.get("/list/hep-ph/2009-01?skip=925&show=25")
+    rv = client.get("/list/hep-ph/0901?skip=925&show=25")
     assert rv.status_code == 200
     assert rv.headers.get("Expires", None) != None
 
-    rv = client.get("/list/astro-ph/2004")
+    rv = client.get("/list/astro-ph/04")
     assert rv.status_code == 200
     assert rv.headers.get("Expires", None) != None
 
-    rv = client.get("/list/math/1992")
+    rv = client.get("/list/math/92")
     assert rv.status_code == 200
     assert rv.headers.get("Expires", None) != None
 
-    rv = client.get("/list/math/1992-01")
+    rv = client.get("/list/math/9201")
     assert rv.status_code == 200
 
-    rv = client.get("/list/math/2001-01")
+    rv = client.get("/list/math/0101")
     assert rv.status_code == 200
 
-    rv = client.get("/list/math/2001-02")
+    rv = client.get("/list/math/0102")
     assert rv.status_code == 200
 
-    rv = client.get("/list/math/2001-03")
+    rv = client.get("/list/math/0103")
     assert rv.status_code == 200
 
-    rv = client.get("/list/math/2001-04")
+    rv = client.get("/list/math/0104")
     assert rv.status_code == 200
 
-    rv = client.get("/list/math/2001-05")
+    rv = client.get("/list/math/0105")
     assert rv.status_code == 200
 
-    rv = client.get("/list/math/2001-06")
+    rv = client.get("/list/math/0106")
     assert rv.status_code == 200
 
-    rv = client.get("/list/math/2001-07")
+    rv = client.get("/list/math/0107")
     assert rv.status_code == 200
 
-    rv = client.get("/list/math/2001-08")
+    rv = client.get("/list/math/0108")
     assert rv.status_code == 200
 
-    rv = client.get("/list/math/2001-09")
+    rv = client.get("/list/math/0109")
     assert rv.status_code == 200
 
-    rv = client.get("/list/math/2001-10")
+    rv = client.get("/list/math/0110")
     assert rv.status_code == 200
 
-    rv = client.get("/list/math/2001-11")
+    rv = client.get("/list/math/0111")
     assert rv.status_code == 200
 
-    rv = client.get("/list/math/2001-12")
+    rv = client.get("/list/math/0112")
     assert rv.status_code == 200
 
-    rv = client.get("/list/math/2001")
+    rv = client.get("/list/math/01")
     assert rv.status_code == 200
 
-    rv = client.get("/list/math/2018")
+    rv = client.get("/list/math/18")
     assert rv.status_code == 200
 
-    rv = client.get("/list/math/2020")  # year 2020
+    rv = client.get("/list/math/20")  # year 2020
     assert rv.status_code == 200
 
-    rv = client.get("/list/math/2001-01")
+    rv = client.get("/list/math/0101")
     assert rv.status_code == 200
 
 def test_basic_lists_errors(client_with_fake_listings):
     client = client_with_fake_listings
 
-    rv = client.get("/list/math/2090")  # year 2090, will need to revise after 2090
+    rv = client.get("/list/math/90")  # year 2090, will need to revise after 2090
     assert rv.status_code == 404
 
-    rv = client.get("/list/math/1980") #arxiv wasnt around yet 
+    rv = client.get("/list/math/80") #arxiv wasnt around yet 
     assert rv.status_code == 400
 
     rv = client.get("/list/math/80") #redirected to 2080 which is in future 
@@ -119,7 +119,7 @@ def test_basic_lists_errors(client_with_fake_listings):
 
 def test_listing_authors(client_with_fake_listings):
     client = client_with_fake_listings
-    rv = client.get("/list/hep-ph/2009-01")
+    rv = client.get("/list/hep-ph/0901")
     assert rv.status_code == 200
     text = rv.data.decode("utf-8")
     au = "Eqab M. Rabei"
@@ -148,7 +148,7 @@ def test_listing_authors(client_with_fake_listings):
 
 def test_paging_first(client_with_fake_listings):
     client = client_with_fake_listings
-    rv = client.get("/list/hep-ph/2009-01")
+    rv = client.get("/list/hep-ph/0901")
     assert rv.status_code == 200
 
     rvdata = rv.data.decode("utf-8")
@@ -191,7 +191,7 @@ def test_paging_first(client_with_fake_listings):
 
 def test_paging_second(client_with_fake_listings):
     client = client_with_fake_listings
-    rv = client.get("/list/hep-ph/2009-01?skip=25&show=25")
+    rv = client.get("/list/hep-ph/0901?skip=25&show=25")
     assert rv.status_code == 200
 
     rvdata = rv.data.decode("utf-8")
@@ -237,7 +237,7 @@ def test_paging_second(client_with_fake_listings):
 
 def test_paging_middle(client_with_fake_listings):
     client = client_with_fake_listings
-    rv = client.get("/list/hep-ph/2009-01?skip=175&show=25")
+    rv = client.get("/list/hep-ph/0901?skip=175&show=25")
     assert rv.status_code == 200
 
     rvdata = rv.data.decode("utf-8")
@@ -295,7 +295,7 @@ def test_paging_middle(client_with_fake_listings):
 
 def test_paging_last(client_with_fake_listings):
     client = client_with_fake_listings
-    rv = client.get("/list/hep-ph/2009-01?skip=1000&show=25")
+    rv = client.get("/list/hep-ph/0901?skip=1000&show=25")
     assert rv.status_code == 200
 
     rvdata = rv.data.decode("utf-8")
@@ -337,7 +337,7 @@ def test_paging_last(client_with_fake_listings):
 
 def test_paging_penultimate(client_with_fake_listings):
     client = client_with_fake_listings
-    rv = client.get("/list/hep-ph/2009-01?skip=975&show=25")
+    rv = client.get("/list/hep-ph/0901?skip=975&show=25")
     assert rv.status_code == 200
 
     rvdata = rv.data.decode("utf-8")
@@ -383,7 +383,7 @@ def test_paging_penultimate(client_with_fake_listings):
 
 def test_paging_925(client_with_fake_listings):
     client = client_with_fake_listings
-    rv = client.get("/list/hep-ph/2009-01?skip=925&show=25")
+    rv = client.get("/list/hep-ph/0901?skip=925&show=25")
     assert rv.status_code == 200
 
     rvdata = rv.data.decode("utf-8")
@@ -434,7 +434,7 @@ def test_paging_925(client_with_fake_listings):
 
 def test_odd_requests(client_with_fake_listings):
     client = client_with_fake_listings
-    rv = client.get("/list/hep-ph/2009-01?skip=925&show=1000000")
+    rv = client.get("/list/hep-ph/0901?skip=925&show=1000000")
     assert rv.status_code == 200
 
     rv = client.get("/list/hep-ph/bogusTimePeriod")
@@ -443,25 +443,25 @@ def test_odd_requests(client_with_fake_listings):
     rv = client.get("/list/junkarchive")
     assert rv.status_code != 200
 
-    rv = client.get("/list/ao-si/2009-01?skip=925&show=25")
+    rv = client.get("/list/ao-si/0901?skip=925&show=25")
     assert rv.status_code != 200
 
-    rv = client.get("/list/math/2001-00")
+    rv = client.get("/list/math/0100")
     assert rv.status_code != 200
 
-    rv = client.get("/list/math/2001-13")
+    rv = client.get("/list/math/0113")
     assert rv.status_code != 200
 
-    rv = client.get("/list/math/2001-99")
+    rv = client.get("/list/math/0199")
     assert rv.status_code != 200
 
-    rv = client.get("/list/math/2001-99")
+    rv = client.get("/list/math/0199")
     assert rv.status_code != 200
 
     rv = client.get("/list/math/2")
     assert rv.status_code != 200
 
-    rv = client.get("/list/math/2001-999999")
+    rv = client.get("/list/math/01999999")
     assert rv.status_code != 200
 
 
@@ -492,7 +492,7 @@ def test_not_modified_from_listing_service(client_with_fake_listings):
     flservice.list_articles_by_month = MagicMock(
         return_value=NotModifiedResponse(True, "Wed, 21 Oct 2015 07:28:00 GMT")
     )
-    rv = client.get("/list/hep-ph/2018-01")
+    rv = client.get("/list/hep-ph/1801")
     assert (
         rv.status_code == 304
     )  # '/list controller should return 304 when service indicates not-modified'
@@ -500,7 +500,7 @@ def test_not_modified_from_listing_service(client_with_fake_listings):
     flservice.list_articles_by_year = MagicMock(
         return_value=NotModifiedResponse(True, "Wed, 21 Oct 2015 07:28:00 GMT")
     )
-    rv = client.get("/list/hep-ph/2018")
+    rv = client.get("/list/hep-ph/18")
     assert (
         rv.status_code == 304
     )  # '/list controller should return 304 when service indicates not-modified'
@@ -508,10 +508,10 @@ def test_not_modified_from_listing_service(client_with_fake_listings):
 
 def test_list_called_from_archive(client_with_fake_listings):
     client = client_with_fake_listings
-    rv = client.get("/list/?archive=hep-ph&year=2008&month=03&submit=Go")
+    rv = client.get("/list/?archive=hep-ph&year=08&month=03&submit=Go")
     assert rv.status_code == 200
 
-    rv = client.get("/list/?archive=hep-ph&year=2008&month=all&submit=Go")
+    rv = client.get("/list/?archive=hep-ph&year=08&month=all&submit=Go")
     assert rv.status_code == 200
 
 
@@ -525,7 +525,7 @@ def test_astro_ph_months(client_with_test_fs, abs_path):
             year+=100
         month=file.stem[2:4]
         name=f"{year}-{month}"
-        rv = client.get(f"/list/astro-ph/{name}")
+        rv = client.get(f"/list/astro-ph/{file.stem[0:4]}")
         assert rv.status_code == 200
 
 
@@ -667,7 +667,7 @@ def test_abs_in_new_listing(client_with_test_fs):
 
 def test_math_ph_9701(client_with_test_fs):
     client = client_with_test_fs
-    rv = client.get("/list/math-ph/1997-01")
+    rv = client.get("/list/math-ph/9701")
     assert rv.status_code == 200
     text = rv.text
     assert "On Exact Solutions" in text
@@ -677,13 +677,13 @@ def test_invalid_archive_years(client_with_test_fs):
     client = client_with_test_fs
 
     #started in 1996
-    rv = client.get("/year/physics/1994")
+    rv = client.get("/year/physics/94")
     assert rv.status_code == 400
     text=rv.text
     assert 'Invalid year' in text
 
     #ended in 1997
-    rv = client.get("/year/funct-an/1998")
+    rv = client.get("/year/funct-an/98")
     assert rv.status_code == 400
     text=rv.text
     assert 'Invalid year' in text
@@ -691,11 +691,11 @@ def test_invalid_archive_years(client_with_test_fs):
 
 def test_year_archive_with_end_date(client_with_test_fs):
     client = client_with_test_fs
-    rv = client.get("/year/funct-an/1996")
+    rv = client.get("/year/funct-an/96")
     assert rv.status_code == 200
     text=rv.text
-    assert '<a href="/year/funct-an/1997">1997</a>' in text
-    assert '<a href="/year/funct-an/1998">1998</a>' not in text
+    assert '<a href="/year/funct-an/97">97</a>' in text
+    assert '<a href="/year/funct-an/98">98</a>' not in text
 
 def test_listing_page_subsumed_archive( client_with_test_fs):
     client = client_with_test_fs
@@ -709,7 +709,7 @@ def test_listing_page_subsumed_archive( client_with_test_fs):
     text = rv.text
     assert "Algebraic Geometry" in text
     assert "math.AG" in text
-    rv = client.get("/list/alg-geom/2021-03")
+    rv = client.get("/list/alg-geom/2103")
     assert rv.status_code == 200
     text = rv.text
     assert "Algebraic Geometry" in text
@@ -729,7 +729,7 @@ def test_YYYYMM_redirect(client_with_db_listings):
     client = client_with_db_listings
     rv = client.get("/list/math-ph/200301", follow_redirects=False)
     assert rv.status_code == 301
-    assert rv.headers["Location"]== "/list/math-ph/2003-01"
+    assert rv.headers["Location"]== "/list/math-ph/0301"
 
     rv = client.get("/list/math-ph/200301", follow_redirects=True)
     assert rv.status_code == 200
@@ -738,22 +738,22 @@ def test_YYYYMM_redirect(client_with_db_listings):
 # YYYY-M
 def test_YYYY_M_redirect(client_with_db_listings):
     client = client_with_db_listings
-    rv = client.get("/list/math-ph/2003-1", follow_redirects=False)
+    rv = client.get("/list/math-ph/031", follow_redirects=False)
     assert rv.status_code == 301
-    assert rv.headers["Location"]== "/list/math-ph/2003-01"
+    assert rv.headers["Location"]== "/list/math-ph/0301"
 
-    rv = client.get("/list/math-ph/2003-1", follow_redirects=True)
+    rv = client.get("/list/math-ph/031", follow_redirects=True)
     assert rv.status_code == 200
     assert "titles for January 2003" in rv.text
 
 def test_basic_no_listings(client_with_db_listings):
     client = client_with_db_listings
     #month
-    rv = client.get("/list/hep-lat/2024-01")
+    rv = client.get("/list/hep-lat/2401")
     assert rv.status_code == 200
     assert "No updates for this time period." in rv.text
     #year
-    rv = client.get("/list/hep-lat/2024")
+    rv = client.get("/list/hep-lat/24")
     assert rv.status_code == 200
     assert "No updates for this time period." in rv.text
     #current


### PR DESCRIPTION
Potential pause to the 4 digit year url change until we are confident GCP listings will be kept up. There was a convenient place to bandaid the /list path but not the /year path so the plan would be just to deploy /list until we are confident it is good to go then we can revert this change and also deploy /year

Changed here:
-Band-Aid time period processing function that expects 2 digit years and never redirects
-use 2 digit urls to run listing tests
-skip the specific redirect test
-disable the url change alert