### PR TITLE
Arxivce 1715 add surrogate key header to list

### DIFF
--- a/browse/controllers/__init__.py
+++ b/browse/controllers/__init__.py
@@ -3,8 +3,7 @@
 Each controller corresponds to a distinct browse feature with its own
 request handling logic.
 """
-from datetime import timezone, datetime, timedelta
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, List
 from zoneinfo import ZoneInfo
 
 from http import HTTPStatus as status
@@ -51,3 +50,9 @@ def biz_tz() -> ZoneInfo:
         return _arxiv_biz_tz
     else:
         return _arxiv_biz_tz
+
+def add_surrogate_key(headers: Dict[str,str], keys:List[str])-> Dict[str, str]:
+    old_keys=headers.get("Surrogate-Key","")
+    for key in keys:
+        old_keys+=" "+key
+    return{"Surrogate-Key":old_keys.strip()}

--- a/browse/controllers/__init__.py
+++ b/browse/controllers/__init__.py
@@ -52,7 +52,8 @@ def biz_tz() -> ZoneInfo:
         return _arxiv_biz_tz
 
 def add_surrogate_key(headers: Dict[str,str], keys:List[str])-> Dict[str, str]:
-    old_keys=headers.get("Surrogate-Key","")
+    old_keys=f' {headers.get("Surrogate-Key","")} '
     for key in keys:
-        old_keys+=" "+key
+        if f" {key} " not in old_keys:
+            old_keys+=" "+key
     return{"Surrogate-Key":old_keys.strip()}

--- a/browse/controllers/list_page/__init__.py
+++ b/browse/controllers/list_page/__init__.py
@@ -48,6 +48,7 @@ import re
 
 from arxiv.taxonomy.definitions import CATEGORIES, ARCHIVES_SUBSUMED, ARCHIVES
 
+from browse.controllers import add_surrogate_key
 from browse.controllers.abs_page import truncate_author_list_size
 from browse.controllers.list_page.paging import paging
 from arxiv.document.metadata import DocMetadata
@@ -614,9 +615,3 @@ def _expires_headers(listing_resp:
         return {'Expires': str(listing_resp.expires)}
     else:
         return {}
-
-def add_surrogate_key(headers: Dict[str,str], keys:List[str])-> Dict[str, str]:
-    old_keys=headers.get("Surrogate-Key","")
-    for key in keys:
-        old_keys+=" "+key
-    return{"Surrogate-Key":old_keys.strip()}

--- a/browse/controllers/list_page/__init__.py
+++ b/browse/controllers/list_page/__init__.py
@@ -195,6 +195,7 @@ def get_listing(subject_or_category: str,
 
     if time_period == 'new':
         list_type = 'new'
+        response_headers.update(add_surrogate_key(response_headers,["list-new", "announce", f"list-new-{list_ctx_id}"]))
         new_resp: Union[ListingNew, NotModifiedResponse] =\
             listing_service.list_new_articles(list_ctx_id, skipn,
                                               shown, if_mod_since)
@@ -212,6 +213,7 @@ def get_listing(subject_or_category: str,
     elif time_period in ['pastweek', 'recent']:
         # A bit different due to returning days not listings
         list_type = 'recent'
+        response_headers.update(add_surrogate_key(response_headers,["list-recent", "announce", f"list-recent-{list_ctx_id}"]))
         rec_resp = listing_service.list_pastweek_articles(
             list_ctx_id, skipn, shown, if_mod_since)
         response_headers.update(_expires_headers(rec_resp))
@@ -224,6 +226,7 @@ def get_listing(subject_or_category: str,
 
     else:  # current or YYMM or YYYYMM or YY
         yandm = year_month_2_digit(time_period)
+        response_headers.update(add_surrogate_key(response_headers,["list-ym"]))
         if yandm is None:
             raise BadRequest(f"Invalid time period: {time_period}") 
         should_redir, list_year, list_month = yandm
@@ -247,12 +250,17 @@ def get_listing(subject_or_category: str,
             if list_month < 1 or list_month > 12:
                 raise BadRequest(f"Invalid month: {list_month}")
             list_type = 'month'
+            response_headers.update(add_surrogate_key(response_headers,[f"list-{list_year:04d}-{list_month:02d}-{list_ctx_id}"]))
+            if date.today().year==list_year and date.today().month==list_month:
+                response_headers.update(add_surrogate_key(response_headers,["announce"]))
             response_data['list_month'] = str(list_month)
             response_data['list_month_name'] = calendar.month_abbr[list_month]
             resp = listing_service.list_articles_by_month(
                 list_ctx_id, list_year, list_month, skipn, shown, if_mod_since)
         else:
             list_type = 'year'
+            response_headers.update(add_surrogate_key(response_headers,[f"list-{list_year:04d}-{list_ctx_id}"]))
+            response_headers.update(add_surrogate_key(response_headers,["announce"])) if list_year==date.today().year else None
             resp = listing_service.list_articles_by_year(
                 list_ctx_id, list_year, skipn, shown, if_mod_since)
 
@@ -606,3 +614,9 @@ def _expires_headers(listing_resp:
         return {'Expires': str(listing_resp.expires)}
     else:
         return {}
+
+def add_surrogate_key(headers: Dict[str,str], keys:List[str])-> Dict[str, str]:
+    old_keys=headers.get("Surrogate-Key","")
+    for key in keys:
+        old_keys+=" "+key
+    return{"Surrogate-Key":old_keys.strip()}

--- a/browse/routes/ui.py
+++ b/browse/routes/ui.py
@@ -231,6 +231,7 @@ def list_articles(context: str, subcontext: str) -> Response:
     'recent', 'new' or a string of format YYMM.
     """
     response, code, headers = list_page.get_listing(context, subcontext)
+    headers.update(list_page.add_surrogate_key(headers,["list"]))
     if code == status.OK:
         #if subcontext not in ["new", "recent", "pastweek"]:
             #response=_add_year_url_alert(response)

--- a/browse/routes/ui.py
+++ b/browse/routes/ui.py
@@ -29,6 +29,7 @@ from browse.controllers import (
     prevnext,
     stats_page,
     tb_page,
+    add_surrogate_key
 )
 from browse.controllers.openurl_cookie import make_openurl_cookie, get_openurl_page
 from browse.controllers.cookies import get_cookies_page, cookies_to_set
@@ -231,7 +232,7 @@ def list_articles(context: str, subcontext: str) -> Response:
     'recent', 'new' or a string of format YYMM.
     """
     response, code, headers = list_page.get_listing(context, subcontext)
-    headers.update(list_page.add_surrogate_key(headers,["list"]))
+    headers.update(add_surrogate_key(headers,["list"]))
     if code == status.OK:
         #if subcontext not in ["new", "recent", "pastweek"]:
             #response=_add_year_url_alert(response)

--- a/browse/services/listing/__init__.py
+++ b/browse/services/listing/__init__.py
@@ -2,7 +2,8 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 from time import mktime
 from typing import Any, List, Literal, Optional, Tuple, Union, cast
 from wsgiref.handlers import format_date_time
@@ -293,9 +294,8 @@ def gen_expires() -> str:
        What is optimal value for the expires value? Next publish?
        RFC 1123 format ex 'Wed, 21 Oct 2015 07:28:00 GMT'
     """
-    now = datetime.now()
-    future = timedelta(days=1)
-    expire = now + future
-    stamp = mktime(expire.timetuple())
-    expires = format_date_time(stamp)
+    now=datetime.now().astimezone(ZoneInfo("US/Eastern"))
+    midnight=now.replace(hour=0, minute=0, second=0, microsecond=0)
+    expire = midnight + timedelta(days=1)
+    expires = format_date_time(expire.timestamp())
     return expires

--- a/tests/listings/test_list_page.py
+++ b/tests/listings/test_list_page.py
@@ -1,5 +1,6 @@
 import pytest
 import re
+from datetime import date
 from unittest.mock import MagicMock
 
 from browse.services.listing import NotModifiedResponse, get_listing_service
@@ -835,4 +836,47 @@ def test_no_listings_recent(client_with_db_listings):
     assert rv.text.count("Mon, 31 Jan 2011") == 2
     assert rv.text.count("Fri, 28 Jan 2011") == 2
 
+
+def test_surrogate_keys(client_with_db_listings):
+    client=client_with_db_listings
+
+    rv = client.get("/list/math/recent?skip=4")
+    head=rv.headers["Surrogate-Key"]
+    assert "list" in head
+    assert "list-recent" in head
+    assert "announce" in head
+    assert "list-recent-math" in head
+
+    rv = client.get("/list/cs.SY/new")
+    head=rv.headers["Surrogate-Key"]
+    assert "list" in head
+    assert "list-new" in head
+    assert "announce" in head
+    assert "list-new-eess.SY" in head
+    
+    rv = client.get("/list/solv-int/0506")
+    head=rv.headers["Surrogate-Key"]
+    assert "list" in head
+    assert "list-ym" in head
+    assert "announce"  not in head
+    assert "list-2005-06-nlin.SI" in head
+
+    rv = client.get("/list/astro-ph/05")
+    head=rv.headers["Surrogate-Key"]
+    assert "list" in head
+    assert "list-ym" in head
+    assert "announce"  not in head
+    assert "list-2005-astro-ph" in head
+
+    rv = client.get(f"/list/astro-ph/{date.today().year-2000:02d}")
+    head=rv.headers["Surrogate-Key"]
+    assert "list" in head
+    assert "list-ym" in head
+    assert "announce" in head
+
+    rv = client.get(f"/list/astro-ph/current")
+    head=rv.headers["Surrogate-Key"]
+    assert "list" in head
+    assert "list-ym" in head
+    assert "announce" in head
 


### PR DESCRIPTION
fastly can use surrogate keys to purge specific sections of the cache