### PR TITLE
Graceful latexml DB down, part 1

### DIFF
--- a/tests/test_latexml_graceful.py
+++ b/tests/test_latexml_graceful.py
@@ -1,0 +1,10 @@
+def test_html_fail_graceful(dbclient, mocker):
+    """Test arxiv-browse graceful handling of latexml db down.
+
+    https://arxiv-org.atlassian.net/browse/ARXIVCE-2433"""
+    from pg8000.exceptions import  InterfaceError
+    fn = mocker.patch('browse.services.database._inside_get_latexml_publish_dt')
+    fn.side_effect = InterfaceError('network error')
+
+    rt = dbclient.get('/abs/0906.2112')
+    assert rt.status_code == 200


### PR DESCRIPTION
Adds a `ignore_errors` arg to `db_handle_error` decorator that we wrap many db calls with to have uniform error handling.

Sets `ignore_errors` to `True` on latexml DB calls. This should reduce cases where latexml DB down causes the service to error out.

This PR can be deployed immediately. An additional change in arxiv-base to handle the rollback is still needed to complete the graceful latexml DB down feature. It would be ideal if we could set arxiv-browse so it does not try to roll anything back since it is read only.

ARXIVCE-2433