### PR TITLE
Adds canonical link header for /pdf

### DIFF
--- a/browse/controllers/files/dissemination.py
+++ b/browse/controllers/files/dissemination.py
@@ -110,6 +110,7 @@ def pdf_resp_fn(file: FileObj,
     resp = default_resp_fn(file, arxiv_id, docmeta, version)
     filename = f"{arxiv_id.filename}v{version.version}.pdf"
     resp.headers["Content-Disposition"] = f"inline; filename=\"{filename}\""
+    resp.headers["Link"] = f"<https://arxiv.org/pdf/{arxiv_id.id}>; rel='canonical'"
     if arxiv_id.has_version: 
         resp.headers=add_surrogate_key(resp.headers,["pdf",f"pdf-{arxiv_id.idv}"])
     else:

--- a/browse/routes/dissemination.py
+++ b/browse/routes/dissemination.py
@@ -57,6 +57,9 @@ def pdf(arxiv_id: str, archive=None):  # type: ignore
 
     Does a 404 if the key for the ID does not exist on the bucket.
     """
+
+    if request.query_string: # redirect to strip off any useless query strings
+        return redirect(url_for('.pdf', arxiv_id=arxiv_id, archive=archive, _external=True), 301)
     return get_pdf_resp(arxiv_id, archive)
 
 

--- a/browse/routes/dissemination.py
+++ b/browse/routes/dissemination.py
@@ -59,14 +59,6 @@ def pdf(arxiv_id: str, archive=None):  # type: ignore
     """
     return get_pdf_resp(arxiv_id, archive)
 
-@blueprint.route("/pdf_test/<string:archive>/<string:arxiv_id>.pdf", methods=['GET', 'HEAD'])
-@blueprint.route("/pdf_test/<string:arxiv_id>.pdf", methods=['GET', 'HEAD'])
-def pdf_test(arxiv_id: str, archive=None):  # type: ignore
-    """Path to test pdf via fastly.
-
-    Can be removed when no longer needed."""
-    return get_dissemination_resp(fileformat.pdf, arxiv_id, archive)
-
 
 @blueprint.route("/format/<string:archive>/<string:arxiv_id>", methods=['GET', 'HEAD'])
 @blueprint.route("/format/<string:arxiv_id>", methods=['GET', 'HEAD'])

--- a/tests/dissemination/test_pdf.py
+++ b/tests/dissemination/test_pdf.py
@@ -8,9 +8,23 @@ def test_pdf_headers(client_with_test_fs):
     assert "pdf-cs/0011004v" not in head
     assert "paper-id-cs/0011004" in head
 
+    assert rv.headers["Link"] == "<https://arxiv.org/pdf/cs/0011004>; rel='canonical'"
+
     rv=client_with_test_fs.head("/pdf/cs/0011004v1")
     head=rv.headers["Surrogate-Key"]
     assert " pdf " in " "+head+" "
     assert "pdf-cs/0011004-current" not in head
     assert "pdf-cs/0011004v1" in head
     assert "paper-id-cs/0011004" in head
+
+    assert rv.headers["Link"] == "<https://arxiv.org/pdf/cs/0011004>; rel='canonical'", "should not have version"
+
+
+def test_pdf_redirect(client_with_test_fs):
+    rv=client_with_test_fs.head("/pdf/cs/0011004v1?crazy_query_string=notgood")
+    assert rv.status_code == 301
+    assert rv.headers["Location"] == "http://localhost/pdf/cs/0011004v1"
+
+    rv = client_with_test_fs.head("/pdf/2201.0001?crazy_query_string=notgood")
+    assert rv.status_code == 301
+    assert rv.headers["Location"] == "http://localhost/pdf/2201.0001"


### PR DESCRIPTION
Adds Link header for /pdf that points to the versionless /pdf. 

The versioned /pdf URLs link to the versionless because we want the most recent version of the PDF to be the search link in search engine results. The versionless returns the most recent version of the PDF.

This also adds a redirect if the /pdf URL has any query string. While this is slightly against the google suggestions, we don't want folks to have to deal with crazy /pdf URLs from outside of arxiv.org.  

/abs already has canonical links in the HTML.

https://arxiv-org.atlassian.net/browse/ARXIVCE-63

https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-header-method