### PR TITLE
Restore connected papers functionality and move to bibliographic tab

### DIFF
--- a/browse/static/js/connectedpapers.js
+++ b/browse/static/js/connectedpapers.js
@@ -19,7 +19,7 @@
   $output.html(htmlPrefix + loadingHtml);
 
 
-  const REST_ADDR = 'https://rest.connectedpapers.com/';
+  const REST_ADDR = 'https://rest.prod.connectedpapers.com/';
   const CONNECTED_PAPERS_ADDR = 'https://www.connectedpapers.com/';
   const ARXIV_THUMBNAILS_ADDR = CONNECTED_PAPERS_ADDR + 'arxiv_thumbnails/';
   const NUMBER_OF_THUMBNAILS = 18;

--- a/browse/templates/abs/labs_tabs.html
+++ b/browse/templates/abs/labs_tabs.html
@@ -32,6 +32,23 @@
           </div>
         </div>
         {% endif %}
+        <div class="columns is-mobile lab-row">
+          <div class="column lab-switch">
+            <label class="switch">
+              <input
+                id="connectedpapers-toggle"
+                type="checkbox"
+                class="lab-toggle"
+                data-script-url="{{ url_for('static', filename='js/connectedpapers.js') }}"
+                aria-labelledby="label-for-connected-papers">
+              <span class="slider"></span>
+              <span class="is-sr-only">Connected Papers Toggle</span>
+            </label>
+          </div>
+          <div class="column lab-name">
+            <span id="label-for-connected-papers">Connected Papers</span> <em>(<a href="https://www.connectedpapers.com/about" target="_blank">What is Connected Papers?</a>)</em>
+          </div>
+        </div>
         {%- if rd_int >= 202106171600 -%}
         <div class="columns is-mobile lab-row">
           <div class="column lab-switch">
@@ -70,6 +87,7 @@
         </div>
       </div>
         <div class="labs-content-placeholder labs-display" style="display: none;"></div>
+        <div style="min-height: 15px" id="connectedpapers-output"></div>
         <div style="min-height: 15px" id="litmaps-open-in"></div>
         <div style="min-height: 15px" id="scite-open-in"></div>
     </div>
@@ -248,20 +266,6 @@
           <div class="columns is-mobile lab-row">
             <div class="column lab-switch">
               <label class="switch">
-                <input id="connectedpapers-toggle" type="checkbox" class="lab-toggle"
-                       data-script-url="{{ url_for('static', filename='js/connectedpapers.js') }}"
-                       aria-labelledby="label-for-connected-papers" >
-                <span class="slider"></span>
-                <span class="is-sr-only">Connected Papers Toggle</span>
-              </label>
-            </div>
-            <div class="column lab-name">
-              <span id="label-for-connected-papers">Connected Papers</span> <em>(<a href="https://www.connectedpapers.com/about" target="_blank">What is Connected Papers?</a>)</em>
-            </div>
-          </div>
-          <div class="columns is-mobile lab-row">
-            <div class="column lab-switch">
-              <label class="switch">
                 <input id="core-recommender-toggle" type="checkbox" class="lab-toggle" aria-labelledby="label-for-core">
                 <span class="slider"></span>
                 <span class="is-sr-only">Core recommender toggle</span>
@@ -306,7 +310,6 @@
             <div class="tab-flower" id="tab-topic"><svg id="flower-graph-topic"></svg></div>
           </div>
         </div>
-        <div style="min-height: 15px" id="connectedpapers-output"></div>
         <div id="coreRecommenderOutput"></div>
         <div id="iarxivOutput"></div>
       </div>


### PR DESCRIPTION
Following recent changes to the Connected Papers API, the integration got broken. This is a fix restoring the functionality.
In addition, looking over the various utilities, we have come to the conclusion connected papers fits better in the "Bibliographic and Citation Tools" tab
<img width="734" alt="image" src="https://github.com/user-attachments/assets/0fd97997-b220-4641-811f-260e8e83c926">
