### PR TITLE
Keep ar5iv_0.7.4.css asset until we regenerate all HTML

### DIFF
--- a/browse/static/css/ar5iv_0.7.4.min.css
+++ b/browse/static/css/ar5iv_0.7.4.min.css
@@ -1,0 +1,2048 @@
+/**
+ * Minified by jsDelivr using clean-css v5.2.4.
+ * Original file: /gh/dginev/ar5iv-css@0.7.4/css/ar5iv.css
+ *
+ * Do NOT use SRI with dynamically generated files! More information: https://www.jsdelivr.com/using-sri-with-dynamic-files
+ */
+ :root,
+ [data-theme=light] {
+     --main-width: 52rem;
+     --main-width-margin: 54rem;
+     --headings-font-family: "Noto Sans", sans-serif;
+     --text-font-family: "Noto Serif", serif;
+     --math-font-family: "STIX Two Math", "Cambria Math", "Noto Serif", serif;
+     --math-caligraphic-font-family: "Lucida Calligraphy", "Zapf Chancery", "URW Chancery L";
+     --code-font-family: "Noto Sans Mono", monospace;
+     --background-color: white;
+     --text-color: #292929;
+     --border-color: #292929;
+     --border-light-color: grey;
+     --image-color: black;
+     --image-background-color: white;
+     --link-text-color: #212121;
+     --email-link-color: #026ecb;
+     --note-mark-color: #026ecb;
+     --note-highlight-color: #ffffd4;
+     --info-text-color: #01719d;
+     --warning-text-color: #d09e05;
+     --error-text-color: #D8000C;
+     --fatal-text-color: #D8000C;
+     --index-ref-color: #026ecb
+ }
+ 
+ [data-theme=dark] {
+     --background-color: #0d1117;
+     --text-color: #c9d1d9;
+     --link-text-color: #c9d1d9;
+     --border-color: white;
+     --border-light-color: #d4d4d4;
+     --note-mark-color: #daa002;
+     --note-highlight-color: rgb(35, 29, 2);
+     --email-link-color: darkcyan;
+     --error-text-color: #d52f36;
+     --fatal-text-color: #d52f36;
+     --index-ref-color: darkcyan;
+     --image-color: black;
+     --image-background-color: white
+ }
+ 
+ [data-theme=dark] img,
+ svg {
+     filter: brightness(.8) contrast(1.2);
+     background-color: #fff;
+     color: #000
+ }
+ 
+ [data-theme=light] img,
+ svg {
+     filter: none;
+     background-color: #fff;
+     color: #000
+ }
+ 
+ body {
+     margin: 0;
+     height: 100%;
+     width: 100%;
+     color: var(--text-color);
+     background-color: var(--background-color)
+ }
+ 
+ @media only screen and (max-width:95.99rem) {
+     body {
+         overflow-x: scroll
+     }
+ }
+ 
+ @media only screen and (min-width:96rem) {
+     body {
+         overflow-x: hidden
+     }
+ 
+     .ltx_page_content {
+         width: 100%
+     }
+ }
+ 
+ .ltx_page_main {
+     width: 100%
+ }
+ 
+ .ltx_page_content {
+     margin: 6rem 1rem;
+     font-size: 1rem;
+     font-weight: 300;
+     clear: both
+ }
+ 
+ .ltx_page_header {
+     border-bottom: .1em solid;
+     margin-bottom: .5em
+ }
+ 
+ .ltx_page_footer {
+     clear: both;
+     text-align: right;
+     width: auto;
+     margin: auto;
+     border-top: .1em solid;
+     max-width: var(--main-width)
+ }
+ 
+ .ltx_page_logo {
+     font-family: var(--text-font-family);
+     font-size: 1rem;
+     text-align: right;
+     padding: .5rem
+ }
+ 
+ .ltx_page_logo>a {
+     border-bottom: .063rem dotted var(--link-text-color);
+     color: var(--link-text-color);
+     text-decoration: none;
+     overflow-wrap: break-word
+ }
+ 
+ .ltx_page_content:after,
+ .ltx_page_footer:after,
+ .ltx_page_header:after {
+     content: ".";
+     display: block;
+     height: 0;
+     clear: both;
+     visibility: hidden
+ }
+ 
+ .ltx_page_footer:before {
+     content: ".";
+     display: block;
+     height: 0;
+     clear: both;
+     visibility: hidden
+ }
+ 
+ .ltx_document {
+     margin: auto;
+     max-width: var(--main-width);
+     margin-top: 2rem;
+     text-rendering: optimizeLegibility
+ }
+ 
+ .ltx_abstract .ltx_p,
+ .ltx_acknowledgements,
+ .ltx_para {
+     font-family: var(--text-font-family);
+     text-align: justify;
+     text-justify: inter-word;
+     hyphens: auto;
+     line-height: 1.5rem;
+     margin-bottom: 1.5rem
+ }
+ 
+ .ltx_figure+.ltx_para,
+ .ltx_flex_figure+.ltx_para {
+     clear: both
+ }
+ 
+ .ltx_p {
+     line-height: 1.5rem;
+     text-indent: 0;
+     white-space: normal;
+     margin-top: 0
+ }
+ 
+ .ltx_text {
+     font-family: var(--text-font-family);
+     word-wrap: break-word
+ }
+ 
+ .ltx_tag .ltx_text {
+     font-family: inherit
+ }
+ 
+ .ltx_indent>.ltx_p:first-child {
+     text-indent: 2em !important
+ }
+ 
+ .ltx_noindent>.ltx_p:first-child {
+     text-indent: 0 !important
+ }
+ 
+ .ltx_pagination.ltx_role_newpage {
+     margin-top: 2rem;
+     display: block
+ }
+ 
+ math,
+ mjx-container {
+     font-family: var(--math-font-family);
+     word-wrap: break-word;
+     white-space: nowrap
+ }
+ 
+ mtd {
+     padding: .1rem
+ }
+ 
+ .ltx_markedasmath {
+     white-space: nowrap
+ }
+ 
+ .ltx_ref {
+     border-bottom: .063rem dotted var(--link-text-color);
+     color: var(--link-text-color);
+     text-decoration: none;
+     overflow-wrap: break-word
+ }
+ 
+ .ltx_ref>.ltx_graphics {
+     border-bottom: none;
+     display: inline
+ }
+ 
+ .ltx_cite {
+     font-style: normal
+ }
+ 
+ .ltx_cite+.ltx_cite {
+     padding-left: .2rem
+ }
+ 
+ .ltx_td .ltx_cite {
+     white-space: pre-wrap
+ }
+ 
+ .ltx_cite .ltx_font_italic {
+     font-style: normal
+ }
+ 
+ .ltx_cite>.ltx_ref {
+     white-space: nowrap;
+     display: inline-block;
+     line-height: 1.4rem;
+     text-indent: 0
+ }
+ 
+ article>div:not(.ltx_minipage)>img:first-of-type {
+     max-width: 30rem;
+     width: auto;
+     height: auto
+ }
+ 
+ .ltx_title.ltx_title_document {
+     font-weight: 400;
+     font-size: 1.7rem !important;
+     margin-top: 1rem;
+     margin-bottom: 1.5rem;
+     text-align: center
+ }
+ 
+ .ltx_subtitle {
+     font-family: var(--headings-font-family);
+     font-style: italic;
+     font-size: 1.3rem;
+     margin-top: 1rem;
+     margin-bottom: 1.5rem;
+     text-align: center
+ }
+ 
+ .ltx_subtitle .ltx_text {
+     font-family: inherit
+ }
+ 
+ .ltx_authors {
+     display: flex;
+     flex-flow: row wrap;
+     width: auto;
+     justify-content: center;
+     align-items: center;
+     object-fit: contain;
+     margin-top: .75rem;
+     margin-bottom: .75rem;
+     text-align: center
+ }
+ 
+ span.ltx_personname {
+     font-family: var(--text-font-family);
+     font-size: 1rem;
+     display: inline-block;
+     overflow-wrap: break-word;
+     min-width: 14rem
+ }
+ 
+ span.ltx_personname span:first {
+     font-size: 1.5rem
+ }
+ 
+ span.ltx_personname br.ltx_break {
+     margin-top: .25rem
+ }
+ 
+ span.ltx_personname>br.ltx_break+span {
+     display: inline-block;
+     padding-top: .75em
+ }
+ 
+ span.ltx_personname>.ltx_break+.ltx_break {
+     display: none
+ }
+ 
+ .ltx_para>.ltx_break:first-child:last-child {
+     display: none
+ }
+ 
+ .ltx_creator {
+     flex: 1 1 0px;
+     max-width: 100%;
+     padding: .5rem;
+     overflow-wrap: break-word
+ }
+ 
+ .ltx_creator br.ltx_break {
+     flex-basis: 100%;
+     height: 0
+ }
+ 
+ .ltx_author_after,
+ .ltx_author_before {
+     display: none
+ }
+ 
+ .ltx_dates {
+     margin-top: 0;
+     margin-bottom: 1rem;
+     text-align: center;
+     font-family: var(--text-font-family)
+ }
+ 
+ .ltx_role_author+.ltx_role_author {
+     margin-left: 2rem
+ }
+ 
+ .ltx_affiliation_country,
+ .ltx_affiliation_department,
+ .ltx_affiliation_institution {
+     margin-left: .25rem;
+     margin-right: .25rem;
+     white-space: nowrap
+ }
+ 
+ span.ltx_role_affiliation:not(.ltx_note)+span.ltx_role_affiliation:not(.ltx_note),
+ span.ltx_role_orcid+span.ltx_role_affiliation:not(.ltx_note) {
+     margin-top: .5rem;
+     display: block
+ }
+ 
+ div.ltx_keywords:empty:before {
+     content: "Keywords: ";
+     font-weight: 700
+ }
+ 
+ .ltx_classification,
+ .ltx_keywords {
+     margin-bottom: 1.5rem;
+     font-size: 1rem;
+     font-family: var(--text-font-family);
+     font-weight: 400
+ }
+ 
+ .ltx_title.ltx_title_classification,
+ .ltx_title.ltx_title_keywords {
+     display: inline;
+     font-size: 1rem;
+     font-weight: 700;
+     font-style: normal
+ }
+ 
+ .ltx_title>br.ltx_break {
+     display: none
+ }
+ 
+ .ltx_date {
+     font-family: var(--text-font-family);
+     text-align: center;
+     font-size: 120%;
+     margin: .5em 0 .5em 0
+ }
+ 
+ .ltx_note {
+     position: relative;
+     text-align: justify;
+     text-justify: inter-word;
+     hyphens: auto;
+     word-spacing: -0.05rem;
+     font-style: normal;
+     font-size: .85em
+ }
+ 
+ .ltx_note+.ltx_note {
+     padding-left: .2rem
+ }
+ 
+ .ltx_note_outer {
+     font-size: .85rem
+ }
+ 
+ .ltx_note>.ltx_note_mark {
+     position: relative;
+     top: -.2em;
+     max-height: 2rem;
+     font-size: .85em;
+     color: var(--note-mark-color)
+ }
+ 
+ .ltx_note_content {
+     display: block;
+     opacity: 100;
+     padding-top: .5rem;
+     padding-bottom: .5rem;
+     margin: .6rem;
+     font-family: var(--text-font-family);
+     line-height: 1.5rem;
+     overflow-wrap: break-word
+ }
+ 
+ .ltx_author_notes {
+     display: block;
+     opacity: 100;
+     min-width: 20rem;
+     margin-top: .5rem;
+     margin-bottom: 2rem;
+     font-family: var(--text-font-family);
+     font-size: .9rem;
+     padding: .2rem
+ }
+ 
+ @media only screen and (max-width:46rem) {
+     .ltx_note_outer {
+         width: 20rem
+     }
+ }
+ 
+ @media only screen and (min-width:46.01rem) and (max-width:51.99rem) {
+     .ltx_note_outer {
+         width: 46rem
+     }
+ }
+ 
+ @media only screen and (min-width:52rem) and (max-width:95.99rem) {
+     .ltx_note_outer {
+         width: 50rem
+     }
+ }
+ 
+ @media only screen and (min-width:96rem) and (max-width:108.99rem) {
+     .ltx_note_outer {
+         width: 20rem;
+         margin-right: -24rem
+     }
+ }
+ 
+ @media only screen and (min-width:109rem) {
+     .ltx_note_outer {
+         width: 27rem;
+         margin-right: -31rem
+     }
+ }
+ 
+ @media only screen and (max-width:95.99rem) {
+     .ltx_note_outer {
+         display: none;
+         opacity: 0
+     }
+ 
+     .ltx_note_content {
+         overflow-wrap: break-word;
+         width: 90%
+     }
+ 
+     .ltx_note:not(.ltx_note_frontmatter):not(.ltx_role_affiliationmark):not(.ltx_role_footnotemark):active>.ltx_note_outer,
+     .ltx_note:not(.ltx_note_frontmatter):not(.ltx_role_affiliationmark):not(.ltx_role_footnotemark):hover>.ltx_note_outer {
+         display: block;
+         opacity: 100;
+         z-index: 100;
+         position: absolute;
+         top: 0;
+         margin: auto;
+         padding: 2rem;
+         background-color: var(--background-color);
+         border-width: .1rem 0;
+         border-bottom: double;
+         border-top: double
+     }
+ 
+     .ltx_note.ltx_note_frontmatter {
+         display: block;
+         opacity: 100;
+         opacity: inherit;
+         text-align: left
+     }
+ 
+     .ltx_note.ltx_note_frontmatter>.ltx_note_mark {
+         display: none;
+         opacity: 0
+     }
+ 
+     .ltx_note.ltx_note_frontmatter .ltx_note_outer {
+         display: block;
+         opacity: 100;
+         opacity: inherit
+     }
+ 
+     .ltx_note.ltx_note_frontmatter .ltx_note_content {
+         border: none;
+         margin-left: 0
+     }
+ 
+     .ltx_note.ltx_note_frontmatter .ltx_note_content>.ltx_note_mark {
+         display: inline
+     }
+ 
+     .ltx_authors>.ltx_note .ltx_note_mark {
+         display: none;
+         opacity: 0
+     }
+ }
+ 
+ @media only screen and (min-width:96rem) {
+     .ltx_note_outer {
+         display: block;
+         opacity: 100;
+         position: relative;
+         clear: both;
+         float: right;
+         padding-bottom: 2rem;
+         padding-right: 2rem
+     }
+ 
+     .ltx_note_content {
+         border-style: double none none none;
+         border-width: .1rem 0
+     }
+ 
+     .ltx_note_content>.ltx_note_mark {
+         display: block;
+         opacity: 100;
+         margin-top: -1.8rem
+     }
+ 
+     .ltx_author_notes>.ltx_note>.ltx_note_mark:hover+.ltx_note_outer .ltx_note_content,
+     .ltx_author_notes>span>.ltx_note>.ltx_note_mark:hover+.ltx_note_outer .ltx_note_content,
+     .ltx_note>.ltx_note_mark:active+.ltx_note_outer .ltx_note_content,
+     .ltx_note>.ltx_note_mark:hover+.ltx_note_outer .ltx_note_content,
+     .ltx_title.ltx_title_document>.ltx_role_affiliation>.ltx_note_mark:active+.ltx_note_outer .ltx_note_content,
+     .ltx_title.ltx_title_document>.ltx_role_affiliation>.ltx_note_mark:hover+.ltx_note_outer .ltx_note_content {
+         background-color: var(--note-highlight-color);
+         z-index: 100
+     }
+ 
+     .ltx_title.ltx_title_document .ltx_note_outer {
+         display: block;
+         opacity: 100
+     }
+ 
+     .ltx_title.ltx_title_document .ltx_note_type {
+         display: none;
+         opacity: 0
+     }
+ 
+     .ltx_author_notes>.ltx_note .ltx_note_outer,
+     .ltx_author_notes>span>.ltx_note .ltx_note_outer,
+     .ltx_role_affiliation>.ltx_note_outer,
+     .ltx_td .ltx_note_outer,
+     .ltx_th .ltx_note_outer,
+     figcaption .ltx_note_outer,
+     td .ltx_note_outer,
+     th .ltx_note_outer {
+         display: none;
+         opacity: 0
+     }
+ 
+     figcaption .ltx_note_content,
+     td .ltx_note_content,
+     th .ltx_note_content {
+         font-weight: 400;
+         overflow-wrap: break-word;
+         width: 90%
+     }
+ 
+     .ltx_td .ltx_note:active>.ltx_note_outer,
+     .ltx_td .ltx_note:hover>.ltx_note_outer,
+     .ltx_th .ltx_note:active>.ltx_note_outer,
+     .ltx_th .ltx_note:hover>.ltx_note_outer,
+     figcaption .ltx_note:active>.ltx_note_outer,
+     figcaption .ltx_note:hover>.ltx_note_outer,
+     td .ltx_note:active>.ltx_note_outer,
+     td .ltx_note:hover>.ltx_note_outer,
+     th .ltx_note:active>.ltx_note_outer,
+     th .ltx_note:hover>.ltx_note_outer {
+         display: block;
+         opacity: 100;
+         z-index: 100;
+         position: absolute;
+         top: 0;
+         margin: auto;
+         padding: 2rem;
+         background-color: var(--background-color);
+         border-width: .1rem 0;
+         border-bottom: double;
+         border-top: double
+     }
+ 
+     .ltx_author_notes>.ltx_note>.ltx_note_mark:hover+.ltx_note_outer,
+     .ltx_author_notes>span>.ltx_note>.ltx_note_mark:hover+.ltx_note_outer,
+     .ltx_personname .ltx_role_footnote>.ltx_note_mark:active+.ltx_note_outer,
+     .ltx_personname .ltx_role_footnote>.ltx_note_mark:hover+.ltx_note_outer,
+     .ltx_role_affiliation>.ltx_note_mark:active+.ltx_note_outer,
+     .ltx_role_affiliation>.ltx_note_mark:hover+.ltx_note_outer {
+         display: block;
+         opacity: 100;
+         z-index: 100;
+         position: absolute;
+         left: 0
+     }
+ 
+     .ltx_personname .ltx_role_footnote .ltx_note_outer {
+         display: none;
+         opacity: 0
+     }
+ 
+     .ltx_note.ltx_role_footnotetext .ltx_note_outer {
+         position: absolute;
+         left: var(--main-width-margin)
+     }
+ 
+     .ltx_note.ltx_role_footnotetext:nth-of-type(2) .ltx_note_outer {
+         top: 8rem
+     }
+ 
+     .ltx_note.ltx_role_footnotetext:nth-of-type(3) .ltx_note_outer {
+         top: 16rem
+     }
+ 
+     .ltx_note.ltx_role_footnotetext:nth-of-type(4) .ltx_note_outer {
+         top: 24rem
+     }
+ 
+     .ltx_note.ltx_role_footnotetext:nth-of-type(5) .ltx_note_outer {
+         top: 32rem
+     }
+ 
+     .ltx_note.ltx_role_footnotetext:nth-of-type(6) .ltx_note_outer {
+         top: 40rem
+     }
+ 
+     .ltx_note.ltx_role_footnotetext:nth-of-type(7) .ltx_note_outer {
+         top: 48rem
+     }
+ 
+     .ltx_note.ltx_role_footnotetext:nth-of-type(8) .ltx_note_outer {
+         top: 56rem
+     }
+ 
+     .ltx_abstract>.ltx_note>.ltx_note_mark,
+     .ltx_author_notes>.ltx_note>.ltx_note_outer .ltx_note_mark,
+     .ltx_author_notes>span>.ltx_note>.ltx_note_outer .ltx_note_mark,
+     .ltx_document>.ltx_note:not(.ltx_role_footnotetext)>.ltx_note_outer>.ltx_note_content>.ltx_note_mark,
+     .ltx_document>.ltx_note>.ltx_note_mark,
+     .ltx_note.ltx_note_frontmatter>.ltx_note_mark,
+     .ltx_note.ltx_note_frontmatter>.ltx_note_outer>.ltx_note_content>.ltx_note_mark,
+     .ltx_title_document>.ltx_note>.ltx_note_mark {
+         display: none;
+         opacity: 0
+     }
+ 
+     .ltx_note.ltx_note_frontmatter .ltx_note_content {
+         border: none;
+         margin-bottom: 0;
+         padding-bottom: 0;
+         margin-top: 0;
+         padding-top: 0
+     }
+ 
+     .ltx_note.ltx_note_frontmatter>.ltx_note_outer {
+         margin-bottom: 0;
+         padding-bottom: 0
+     }
+ }
+ 
+ .ltx_note.ltx_role_footnotetext .ltx_note_type {
+     display: none;
+     opacity: 0
+ }
+ 
+ .ltx_note.ltx_role_affiliationmark>.ltx_note_mark,
+ .ltx_note.ltx_role_footnotemark>.ltx_note_mark {
+     color: var(--text-color)
+ }
+ 
+ .ltx_note.ltx_role_affiliationmark>.ltx_note_outer,
+ .ltx_note.ltx_role_footnotemark>.ltx_note_outer {
+     display: none !important;
+     opacity: 0 !important
+ }
+ 
+ .ltx_title {
+     font-size: 100%;
+     font-weight: 400;
+     font-family: var(--headings-font-family)
+ }
+ 
+ .ltx_abstract {
+     margin-top: 4rem;
+     margin-bottom: 2rem
+ }
+ 
+ .ltx_TOC>h6,
+ .ltx_title_abstract {
+     margin-top: 0;
+     margin-bottom: 1.5rem;
+     padding-top: 0;
+     color: var(--link-text-color);
+     text-decoration: none;
+     font-size: 1.4rem;
+     font-weight: 700;
+     font-family: var(--headings-font-family);
+     line-height: 1.15rem;
+     box-sizing: border-box;
+     list-style: none
+ }
+ 
+ .ltx_abstract p:first-of-type {
+     text-indent: 0
+ }
+ 
+ .ltx_role_dedicatory {
+     font-size: 100%;
+     font-style: italic;
+     text-align: center;
+     margin: 1em
+ }
+ 
+ .ltx_role_email {
+     display: block
+ }
+ 
+ .ltx_role_email>a {
+     color: var(--email-link-color);
+     text-decoration: none
+ }
+ 
+ .ltx_TOC {
+     margin-top: 2rem;
+     margin-bottom: 2rem
+ }
+ 
+ ul.ltx_toclist {
+     padding-left: 2.5rem
+ }
+ 
+ ul.ltx_toclist>.ltx_tocentry:first-of-type {
+     margin-top: .3rem
+ }
+ 
+ .ltx_TOC>ul.ltx_toclist {
+     padding-left: 0
+ }
+ 
+ .ltx_TOC>.ltx_toclist>.ltx_tocentry {
+     list-style-type: none;
+     margin-bottom: 1.3rem
+ }
+ 
+ .ltx_tocentry {
+     list-style-type: none;
+     margin-bottom: .5rem
+ }
+ 
+ .ltx_TOC>.ltx_toclist>.ltx_tocentry>a.ltx_ref {
+     display: inline-block;
+     border-bottom: none;
+     font-weight: 700;
+     margin-bottom: .5em
+ }
+ 
+ .ltx_tocentry_chapter>.ltx_ref>.ltx_ref_title>.ltx_tag,
+ .ltx_tocentry_part>.ltx_ref>.ltx_ref_title>.ltx_tag,
+ .ltx_tocentry_section>.ltx_ref>.ltx_ref_title>.ltx_tag {
+     margin-right: 1rem;
+     display: inline-block;
+     min-width: 1.5rem
+ }
+ 
+ .ltx_toclist_part>.ltx_tocentry_chapter>.ltx_ref>.ltx_ref_title>.ltx_tag {
+     min-width: .5rem
+ }
+ 
+ .ltx_tocentry_chapter .ltx_tocentry_section>.ltx_ref>.ltx_ref_title,
+ .ltx_tocentry_part .ltx_tocentry_chapter>.ltx_ref,
+ .ltx_tocentry_subsection>.ltx_ref>.ltx_ref_title {
+     font-family: var(--text-font-family)
+ }
+ 
+ .ltx_tocentry_chapter .ltx_tocentry_section>.ltx_ref,
+ .ltx_tocentry_part .ltx_tocentry_chapter>.ltx_ref,
+ .ltx_tocentry_subsection>.ltx_ref,
+ .ltx_tocentry_subsubsection>.ltx_ref {
+     border-bottom: none
+ }
+ 
+ .ltx_tocentry_chapter .ltx_tocentry_section>.ltx_ref>.ltx_ref_title>.ltx_tag_ref,
+ .ltx_tocentry_part .ltx_tocentry_chapter>.ltx_ref>.ltx_ref_title>.ltx_tag_ref,
+ .ltx_tocentry_subsection>.ltx_ref>.ltx_ref_title>.ltx_tag_ref,
+ .ltx_tocentry_subsubsection>.ltx_ref>.ltx_ref_title>.ltx_tag_ref {
+     border-bottom: .063rem dotted var(--link-text-color);
+     width: min-content;
+     display: inline-block;
+     line-height: 1.1rem;
+     margin-right: .3rem
+ }
+ 
+ .ltx_tag_appendix,
+ .ltx_tag_chapter,
+ .ltx_tag_part,
+ .ltx_tag_section,
+ .ltx_tag_subsection,
+ .ltx_tag_subsubsection {
+     display: inline-block;
+     padding-right: 1rem;
+     min-width: 1.33em
+ }
+ 
+ .ltx_tag_figure,
+ .ltx_tag_table {
+     display: inline-block;
+     padding-right: .2rem;
+     min-width: 1.33em
+ }
+ 
+ .ltx_title_chapter,
+ .ltx_title_part {
+     font-size: 1.6rem;
+     font-weight: 700;
+     margin-bottom: 1.5rem
+ }
+ 
+ .ltx_title_acknowledgements,
+ .ltx_title_appendix,
+ .ltx_title_bibliography,
+ .ltx_title_index,
+ .ltx_title_section,
+ span.ltx_font_bold>.ltx_break:last-child {
+     font-size: 1.4rem;
+     font-weight: 700;
+     margin-bottom: 1.5rem
+ }
+ 
+ span.ltx_font_bold>.ltx_break:last-child {
+     margin-top: 2rem
+ }
+ 
+ .ltx_title_subsection {
+     font-size: 1.2rem;
+     font-weight: 700;
+     margin-bottom: 1rem
+ }
+ 
+ .ltx_title_subsubsection {
+     font-size: 1rem;
+     font-weight: 700;
+     margin-bottom: 1rem
+ }
+ 
+ .ltx_title_paragraph {
+     font-size: 1rem;
+     font-weight: 700;
+     margin-right: 1rem;
+     margin-bottom: .5rem
+ }
+ 
+ .ltx_title_subparagraph {
+     font-size: 1rem;
+     font-weight: 700;
+     display: inline;
+     margin: 0 1rem 0 2rem
+ }
+ 
+ .ltx_section .ltx_subparagraph>.ltx_para:first-of-type>.ltx_p {
+     text-indent: 2rem
+ }
+ 
+ .ltx_runin {
+     display: inline
+ }
+ 
+ .ltx_runin:after {
+     content: " "
+ }
+ 
+ .ltx_runin+.ltx_para,
+ .ltx_runin+.ltx_para p,
+ .ltx_runin+p {
+     display: inline
+ }
+ 
+ .ltx_outdent {
+     margin-left: -2em
+ }
+ 
+ .ltx_chapter,
+ .ltx_part {
+     margin-bottom: 5rem
+ }
+ 
+ .ltx_bibliography,
+ .ltx_section {
+     margin-bottom: 2.5rem
+ }
+ 
+ .ltx_subsection {
+     margin-bottom: 2rem
+ }
+ 
+ .ltx_subsubsection {
+     margin-bottom: .5rem
+ }
+ 
+ .ltx_section .ltx_para:first-of-type .ltx_p:first-of-type {
+     text-indent: 0
+ }
+ 
+ .ltx_proof,
+ .ltx_theorem {
+     margin: 2rem 0 1rem 0
+ }
+ 
+ .ltx_item>.ltx_theorem {
+     margin-left: 1em
+ }
+ 
+ .ltx_theorem>.ltx_para {
+     margin-bottom: .5rem
+ }
+ 
+ .ltx_title_proof,
+ .ltx_title_theorem {
+     font-family: var(--headings-font-family);
+     font-size: 1rem;
+     font-weight: 700;
+     display: inline;
+     padding-right: .25em
+ }
+ 
+ .ltx_bibliography dt {
+     margin-right: .5em;
+     float: left
+ }
+ 
+ .ltx_bibliography dd {
+     margin-left: 3em
+ }
+ 
+ .ltx_bibitem {
+     display: table;
+     table-layout: fixed;
+     list-style-type: none;
+     width: 100%;
+     padding-bottom: .75em;
+     font-family: var(--text-font-family)
+ }
+ 
+ .ltx_bibitem .ltx_tag {
+     display: table-cell;
+     position: relative;
+     left: -2.5rem;
+     line-height: 1.5rem;
+     text-align: left;
+     vertical-align: middle;
+     word-break: normal;
+     overflow-wrap: break-word
+ }
+ 
+ @media only screen and (max-width:52rem) {
+     .ltx_bibitem .ltx_tag {
+         width: 26%
+     }
+ }
+ 
+ @media only screen and (min-width:52.01rem) {
+     .ltx_bibitem .ltx_tag {
+         width: 14%
+     }
+ }
+ 
+ .ltx_bibitem .ltx_bibblock {
+     display: inline-block;
+     text-align: left;
+     padding-left: .5em;
+     max-width: 40em;
+     line-height: 1.5rem;
+     vertical-align: middle;
+ }
+ 
+ .ltx_bib_title {
+     font-style: italic;
+ }
+ 
+ .ltx_bib_article .bib-title {
+     font-style: normal !important
+ }
+ 
+ .ltx_bib_journal {
+     font-style: italic
+ }
+ 
+ .ltx_bib_volume {
+     font-weight: 700
+ }
+ 
+ .ltx_tag_bibitem:active~*,
+ .ltx_tag_bibitem:hover~*,
+ .ltx_tag_bibitem~:active,
+ .ltx_tag_bibitem~:hover {
+     background-color: var(--note-highlight-color);
+     z-index: 100
+ }
+ 
+ .ltx_indexlist {
+     columns: 2;
+     -webkit-columns: 2;
+     -moz-columns: 2;
+     list-style-type: none;
+     padding-left: 0
+ }
+ 
+ .ltx_indexentry>.ltx_indexlist {
+     columns: 1;
+     -webkit-columns: 1;
+     -moz-columns: 1;
+     margin: .2rem 1rem 0
+ }
+ 
+ .ltx_indexentry {
+     font-family: var(--text-font-family);
+     font-size: .85rem;
+     padding-bottom: .15rem
+ }
+ 
+ .ltx_indexrefs .ltx_ref {
+     color: var(--index-ref-color);
+     white-space: nowrap
+ }
+ 
+ section.ltx_conversion_report>.ltx_para {
+     background: #f5f5f5;
+     width: var(--main-width);
+     padding: .1rem 1rem .1rem 1rem;
+     border-radius: .8rem;
+     line-height: 1rem;
+     font-family: var(--code-font-family);
+     font-size: .8rem;
+     word-break: break-word
+ }
+ 
+ section.ltx_conversion_report>.ltx_para>.ltx_p {
+     text-align: left;
+     line-height: 1rem
+ }
+ 
+ :not(.ltx_quote)>blockquote.ltx_quote:not(.ltx_epigraph) {
+     border-left: .188rem solid var(--border-color);
+     font-size: 1em;
+     font-style: italic;
+     line-height: 1.5em;
+     margin: 1.1em 0;
+     padding: .5em 2em;
+     position: relative;
+     z-index: 0
+ }
+ 
+ :not(.ltx_quote)>blockquote.ltx_quote:not(.ltx_epigraph):before {
+     content: "";
+     position: absolute;
+     top: 50%;
+     left: -.25rem;
+     height: 2rem;
+     background-color: var(--background-color);
+     width: .25rem;
+     margin-top: -1rem
+ }
+ 
+ :not(.ltx_quote)>blockquote.ltx_quote:not(.ltx_epigraph):after {
+     content: "“";
+     position: absolute;
+     top: 50%;
+     left: -.6rem;
+     color: var(--border-color);
+     font-style: normal;
+     font-size: 1.5rem;
+     line-height: 2rem;
+     text-align: center;
+     width: 1rem;
+     margin-top: -.7rem
+ }
+ 
+ .ltx_quote>.ltx_p:last-child {
+     margin-bottom: 0
+ }
+ 
+ .ltx_quote>.ltx_break:last-child {
+     display: none
+ }
+ 
+ .ltx_quote .ltx_break+.ltx_break+.ltx_break {
+     display: none
+ }
+ 
+ .ltx_quote>.ltx_break:first-child,
+ .ltx_quote>.ltx_break:first-child+.ltx_break,
+ .ltx_quote>.ltx_break:first-child+.ltx_break+.ltx_break {
+     display: none
+ }
+ 
+ blockquote.ltx_epigraph {
+     width: calc(.5*var(--main-width)) !important;
+     margin-left: calc(.45*var(--main-width)) !important
+ }
+ 
+ .ltx_block,
+ .ltx_p,
+ .ltx_para,
+ .ltx_quote {
+     display: block
+ }
+ 
+ .ltx_quote.ltx_innerquote,
+ .ltx_quote.ltx_outerquote {
+     display: inline
+ }
+ 
+ .ltx_align_left {
+     text-align: left
+ }
+ 
+ .ltx_align_right {
+     text-align: right
+ }
+ 
+ .ltx_align_center {
+     text-align: center
+ }
+ 
+ .ltx_align_justify {
+     text-align: justify;
+     text-justify: inter-word;
+     hyphens: auto
+ }
+ 
+ .ltx_align_top {
+     vertical-align: top
+ }
+ 
+ .ltx_align_bottom {
+     vertical-align: bottom
+ }
+ 
+ .ltx_align_middle {
+     vertical-align: middle
+ }
+ 
+ .ltx_align_baseline {
+     vertical-align: baseline
+ }
+ 
+ .ltx_align_floatleft {
+     float: left
+ }
+ 
+ .ltx_align_floatright {
+     float: right
+ }
+ 
+ .ltx_td.ltx_align_center,
+ .ltx_td.ltx_align_left,
+ .ltx_td.ltx_align_right,
+ .ltx_th.ltx_align_center,
+ .ltx_th.ltx_align_left,
+ .ltx_th.ltx_align_right {
+     white-space: nowrap
+ }
+ 
+ .ltx_td.ltx_align_center.ltx_wrap,
+ .ltx_td.ltx_align_justify,
+ .ltx_td.ltx_align_left.ltx_wrap,
+ .ltx_td.ltx_align_right.ltx_wrap,
+ .ltx_th.ltx_align_center.ltx_wrap,
+ .ltx_th.ltx_align_justify,
+ .ltx_th.ltx_align_left.ltx_wrap,
+ .ltx_th.ltx_align_right.ltx_wrap {
+     white-space: normal
+ }
+ 
+ .ltx_graphics {
+     display: block
+ }
+ 
+ @media only screen and (max-width:52rem) {
+     .ltx_graphics {
+         max-width: 95%
+     }
+ }
+ 
+ @media only screen and (min-width:52.01rem) {
+     .ltx_graphics {
+         max-width: var(--main-width)
+     }
+ }
+ 
+ .ltx_caption .ltx_graphics {
+     display: inline-block
+ }
+ 
+ :not(mtext):not(.ltx_flex_cell)>:not(mtext):not(.ltx_flex_cell)>.ltx_img_landscape {
+     max-width: 100%;
+     max-height: calc(var(--main-width)/1.66);
+     width: auto;
+     height: auto
+ }
+ 
+ :not(mtext):not(.ltx_flex_cell)>:not(mtext):not(.ltx_flex_cell)>.ltx_img_portrait {
+     max-height: var(--main-width);
+     max-width: calc(var(--main-width)/1.33);
+     width: auto
+ }
+ 
+ :not(mtext):not(.ltx_flex_cell)>:not(mtext):not(.ltx_flex_cell)>.ltx_img_square {
+     max-height: calc(var(--main-width)/1.33);
+     width: auto
+ }
+ 
+ @media only screen and (max-width:52rem) {
+     :not(mtext):not(.ltx_flex_cell)>:not(mtext):not(.ltx_flex_cell)>.ltx_img_portrait {
+         height: auto
+     }
+ 
+     :not(mtext):not(.ltx_flex_cell)>:not(mtext):not(.ltx_flex_cell)>.ltx_img_square {
+         height: auto
+     }
+ }
+ 
+ :not(.ltx_eqn_cell)>math mtext img.ltx_img_landscape,
+ :not(.ltx_eqn_cell)>math mtext img.ltx_img_portrait,
+ :not(.ltx_eqn_cell)>math mtext img.ltx_img_square,
+ :not(.ltx_eqn_cell)>math mtext object.ltx_img_landscape,
+ :not(.ltx_eqn_cell)>math mtext object.ltx_img_portrait,
+ :not(.ltx_eqn_cell)>math mtext object.ltx_img_square,
+ :not(.ltx_flex_cell):not(.ltx_figure):not(.ltx_transformed_inner):not(.ltx_td):not(.ltx_th)>.ltx_p:not(.ltx_align_center) img.ltx_img_landscape,
+ :not(.ltx_flex_cell):not(.ltx_figure):not(.ltx_transformed_inner):not(.ltx_td):not(.ltx_th)>.ltx_p:not(.ltx_align_center) img.ltx_img_portrait,
+ :not(.ltx_flex_cell):not(.ltx_figure):not(.ltx_transformed_inner):not(.ltx_td):not(.ltx_th)>.ltx_p:not(.ltx_align_center) img.ltx_img_square,
+ :not(.ltx_flex_cell):not(.ltx_figure):not(.ltx_transformed_inner):not(.ltx_td):not(.ltx_th)>.ltx_p:not(.ltx_align_center) object.ltx_img_landscape,
+ :not(.ltx_flex_cell):not(.ltx_figure):not(.ltx_transformed_inner):not(.ltx_td):not(.ltx_th)>.ltx_p:not(.ltx_align_center) object.ltx_img_portrait,
+ :not(.ltx_flex_cell):not(.ltx_figure):not(.ltx_transformed_inner):not(.ltx_td):not(.ltx_th)>.ltx_p:not(.ltx_align_center) object.ltx_img_square {
+     width: 1rem;
+     min-width: 1rem !important;
+     min-height: 1rem !important
+ }
+ 
+ .ltx_markedasmath.ltx_graphics,
+ .ltx_markedasmath>.ltx_graphics,
+ mtext>.ltx_graphics {
+     display: inline;
+     max-width: calc(.9*var(--main-width)) !important
+ }
+ 
+ .ltx_flex_cell .ltx_img_landscape,
+ .ltx_flex_cell .ltx_img_portrait,
+ .ltx_flex_cell .ltx_img_square {
+     width: 100%;
+     height: auto;
+     max-height: var(--main-width)
+ }
+ 
+ .ltx_note_content .ltx_graphics {
+     max-width: 10rem;
+     max-height: 3rem
+ }
+ 
+ .ltx_flex_figure {
+     display: flex;
+     flex-flow: row wrap;
+     width: auto;
+     justify-content: center;
+     align-items: flex-end;
+     object-fit: contain;
+     margin-bottom: 1rem
+ }
+ 
+ .ltx_flex_figure>.ltx_flex_cell>.ltx_figure,
+ .ltx_flex_figure>.ltx_flex_cell>.ltx_float,
+ .ltx_flex_figure>.ltx_flex_cell>.ltx_graphics,
+ .ltx_flex_figure>.ltx_flex_cell>.ltx_graphics.ltx_centering,
+ .ltx_flex_figure>.ltx_flex_cell>.ltx_minipage {
+     margin: .1rem 1px .1rem;
+     width: 100%;
+     max-height: 100%
+ }
+ 
+ .ltx_flex_figure>.ltx_flex_cell>.ltx_inline-block,
+ .ltx_flex_figure>.ltx_flex_cell>.ltx_minipage {
+     width: 100% !important
+ }
+ 
+ @media only screen and (max-width:46rem) {
+     .ltx_flex_figure>.ltx_flex_cell.ltx_flex_size_1 {
+         min-width: 20rem
+     }
+ }
+ 
+ @media only screen and (min-width:46.01rem) {
+     .ltx_flex_figure>.ltx_flex_cell.ltx_flex_size_1 {
+         min-width: 25rem
+     }
+ }
+ 
+ .ltx_flex_figure>.ltx_flex_cell.ltx_flex_size_2 img.ltx_graphics {
+     min-width: 20rem
+ }
+ 
+ .ltx_flex_figure>.ltx_flex_cell.ltx_flex_size_3 img.ltx_graphics {
+     min-width: 15rem
+ }
+ 
+ .ltx_flex_figure>.ltx_flex_cell.ltx_flex_size_4 img.ltx_graphics {
+     min-width: 10rem
+ }
+ 
+ .ltx_flex_figure>.ltx_flex_cell img.ltx_graphics {
+     min-width: 7rem
+ }
+ 
+ .ltx_flex_cell.ltx_flex_size_1,
+ .ltx_flex_cell.ltx_flex_size_1 .ltx_tabular,
+ .ltx_lstlisting.ltx_flex_size_1,
+ .ltx_minipage.ltx_flex_size_1 .ltx_float .ltx_caption,
+ .ltx_table.ltx_flex_size_1 .ltx_caption {
+     max-width: var(--main-width)
+ }
+ 
+ .ltx_flex_figure.ltx_flex_table .ltx_flex_size_2 {
+     max-width: calc(.5*var(--main-width))
+ }
+ 
+ .ltx_flex_cell.ltx_flex_size_2,
+ .ltx_flex_size_2 .ltx_tabular,
+ .ltx_flex_size_2.ltx_tabular,
+ .ltx_lstlisting.ltx_flex_size_2,
+ .ltx_minipage.ltx_flex_size_2 .ltx_float .ltx_caption,
+ .ltx_table.ltx_flex_size_2 .ltx_caption {
+     max-width: calc(.5*var(--main-width))
+ }
+ 
+ .ltx_flex_figure.ltx_flex_table .ltx_flex_size_3 {
+     max-width: calc(.33*var(--main-width))
+ }
+ 
+ .ltx_flex_cell.ltx_flex_size_3,
+ .ltx_flex_size_3 .ltx_tabular,
+ .ltx_flex_size_3.ltx_tabular,
+ .ltx_lstlisting.ltx_flex_size_3,
+ .ltx_minipage.ltx_flex_size_3 .ltx_float .ltx_caption,
+ .ltx_table.ltx_flex_size_3 .ltx_caption {
+     max-width: calc(.33*var(--main-width))
+ }
+ 
+ .ltx_flex_figure.ltx_flex_table .ltx_flex_size_4,
+ .ltx_flex_figure.ltx_flex_table .ltx_flex_size_many {
+     max-width: calc(.25*var(--main-width))
+ }
+ 
+ .ltx_flex_cell.ltx_flex_size_4,
+ .ltx_flex_size_4 .ltx_tabular,
+ .ltx_flex_size_4.ltx_tabular,
+ .ltx_lstlisting.ltx_flex_size_4,
+ .ltx_minipage.ltx_flex_size_4 .ltx_float .ltx_caption,
+ .ltx_table.ltx_flex_size_4 .ltx_caption {
+     max-width: calc(.25*var(--main-width))
+ }
+ 
+ .ltx_flex_figure.ltx_flex_table .ltx_flex_size_many {
+     max-width: calc(.28*var(--main-width))
+ }
+ 
+ .ltx_flex_cell.ltx_flex_size_many,
+ .ltx_flex_size_many .ltx_tabular,
+ .ltx_flex_size_many.ltx_tabular,
+ .ltx_lstlisting.ltx_flex_size_many,
+ .ltx_minipage.ltx_flex_size_many .ltx_float .ltx_caption,
+ .ltx_table.ltx_flex_size_many .ltx_caption {
+     max-width: calc(.25*var(--main-width))
+ }
+ 
+ .ltx_flex_figure .ltx_flex_cell {
+     flex: 1 1 0px;
+     margin: .1rem 1px .1rem
+ }
+ 
+ .ltx_flex_figure .ltx_flex_break {
+     flex-basis: 100%;
+     height: 0
+ }
+ 
+ .ltx_flex_cell>.ltx_figure {
+     margin: 0
+ }
+ 
+ .ltx_flex_figure .ltx_tabular .ltx_td,
+ .ltx_flex_figure .ltx_tabular .ltx_th {
+     padding: .1rem .2rem
+ }
+ 
+ .ltx_figure img {
+     color: var(--image-color);
+     background-color: var(--image-background-color);
+     -webkit-transition: all .2s ease;
+     -moz-transition: all .2s ease;
+     -ms-transition: all .2s ease;
+     -o-transition: all .2s ease;
+     transition: all .2s ease
+ }
+ 
+ .ltx_figure img:active,
+ .ltx_p>img.ltx_graphics:active,
+ .ltx_text>img.ltx_graphics:active {
+     -webkit-transform: scale(1.8);
+     -moz-transform: scale(1.8);
+     -ms-transform: scale(1.8);
+     -o-transform: scale(1.8);
+     transform: scale(1.8);
+     overflow: visible;
+     background-color: #fff
+ }
+ 
+ .ltx_p>img.ltx_graphics {
+     display: inline
+ }
+ 
+ .ltx_para>svg:only-child {
+     margin: auto;
+     display: block;
+     max-width: var(--main-width)
+ }
+ 
+ svg {
+     color: var(--image-color);
+     background-color: var(--image-background-color);
+     z-index: -1
+ }
+ 
+ foreignObject .ltx_text {
+     word-wrap: initial;
+     white-space: nowrap
+ }
+ 
+ .ltx_para>.ltx_tabular {
+     margin-bottom: 1rem
+ }
+ 
+ .ltx_tabular .ltx_tabular {
+     width: 100%
+ }
+ 
+ .ltx_tabular.ltx_tabbing {
+     display: table
+ }
+ 
+ .ltx_inline-para,
+ .ltx_inline-para .ltx_para {
+     display: inline
+ }
+ 
+ .ltx_inline-block,
+ .ltx_inline-block .ltx_para {
+     display: inline-block
+ }
+ 
+ .ltx_inline-block>.ltx_p {
+     width: auto !important
+ }
+ 
+ .ltx_title_document>.ltx_inline-block,
+ .ltx_title_document>.ltx_parbox {
+     width: auto !important
+ }
+ 
+ :not(.ltx_flex_cell)>.ltx_figure,
+ :not(.ltx_flex_cell)>.ltx_table {
+     display: flex;
+     flex-direction: column;
+     align-items: center;
+     text-align: center;
+     margin: 4rem auto 4rem
+ }
+ 
+ .ltx_caption {
+     font-family: var(--text-font-family)
+ }
+ 
+ .ltx_figure .ltx_caption,
+ .ltx_table .ltx_caption {
+     text-align: justify;
+     line-height: 1.5rem;
+     margin-top: 1.5rem;
+     margin-bottom: 1.5rem
+ }
+ 
+ .ltx_flex_figure .ltx_figure .ltx_caption {
+     text-align: center
+ }
+ 
+ .ltx_figure .ltx_parbox,
+ .ltx_table {
+     text-align: justify
+ }
+ 
+ .ltx_parbox {
+     text-indent: 0;
+     display: inline-block
+ }
+ 
+ .ltx_minipage {
+     align-self: normal;
+     display: inline-block
+ }
+ 
+ .ltx_minipage.ltx_align_center {
+     align-self: center
+ }
+ 
+ .ltx_minipage .ltx_float,
+ .ltx_minipage .ltx_float .ltx_caption {
+     display: inline-block
+ }
+ 
+ .ltx_minipage.ltx_align_middle {
+     margin: auto;
+     width: auto !important
+ }
+ 
+ .ltx_minipage>.ltx_graphics {
+     max-width: 100%
+ }
+ 
+ .ltx_listingline {
+     text-align: justify;
+     white-space: nowrap;
+     min-height: 1rem;
+     display: block
+ }
+ 
+ .ltx_listingline .ltx_text {
+     font-size: .7rem !important
+ }
+ 
+ .ltx_listing {
+     display: block;
+     max-width: var(--main-width);
+     margin-bottom: 1rem
+ }
+ 
+ .ltx_listing>.ltx_framed_rectangle {
+     border-style: none
+ }
+ 
+ .ltx_tag_listingline {
+     padding-right: .3rem;
+     border-right: solid;
+     border-width: thin;
+     margin-right: .3rem;
+     text-align: right;
+     width: 1rem;
+     display: inline-block
+ }
+ 
+ .ltx_listing_data {
+     display: none
+ }
+ 
+ .ltx_lstlisting.ltx_text {
+     white-space: break-spaces
+ }
+ 
+ .ltx_float {
+     margin: 3.5rem auto 3.5rem
+ }
+ 
+ .ltx_minipage>.ltx_float {
+     margin: .2rem auto .2rem
+ }
+ 
+ .ltx_float .ltx_caption {
+     text-align: justify;
+     text-justify: inter-word;
+     hyphens: auto;
+     border-top: solid var(--border-color);
+     border-bottom: solid var(--border-color);
+     border-width: .1rem;
+     margin-top: .2rem;
+     margin-bottom: .2rem;
+     padding-top: .2rem;
+     padding-bottom: .2rem
+ }
+ 
+ .ltx_rule {
+     color: var(--border-color);
+     vertical-align: middle;
+     background-color: var(--border-color) !important
+ }
+ 
+ .ltx_transformed_outer {
+     width: auto !important;
+     height: auto !important
+ }
+ 
+ .ltx_figure>.ltx_inline-block>.ltx_transformed_inner,
+ .ltx_figure>.ltx_transformed_outer>.ltx_transformed_inner,
+ .ltx_table>.ltx_inline-block>.ltx_transformed_inner,
+ .ltx_table>.ltx_transformed_outer>.ltx_transformed_inner,
+ .ltx_tr:only-child>.ltx_td:only-child>.ltx_inline-block>.ltx_transformed_inner,
+ .ltx_tr:only-child>.ltx_td:only-child>.ltx_p:only-child>.ltx_inline-block>.ltx_transformed_inner,
+ .ltx_tr:only-child>.ltx_td:only-child>.ltx_p:only-child>.ltx_transformed_outer>.ltx_transformed_inner,
+ .ltx_tr:only-child>.ltx_td:only-child>.ltx_transformed_outer>.ltx_transformed_inner {
+     transform: none !important
+ }
+ 
+ span.ltx_transformed_inner {
+     display: inline-block
+ }
+ 
+ .ltx_transformed_inner>.ltx_p {
+     margin: 0;
+     padding: 0
+ }
+ 
+ .ltx_eqn_cell>.ltx_transformed_outer>.ltx_transformed_inner,
+ .ltx_flex_cell>.ltx_transformed_outer>.ltx_transformed_inner {
+     transform: none !important
+ }
+ 
+ .ltx_phantom {
+     visibility: hidden
+ }
+ 
+ .ltx_font_serif {
+     font-family: var(--text-font-family)
+ }
+ 
+ .ltx_font_sansserif {
+     font-family: var(--headings-font-family)
+ }
+ 
+ .ltx_font_typewriter {
+     font-family: var(--code-font-family)
+ }
+ 
+ .ltx_font_bold {
+     font-weight: 700
+ }
+ 
+ .ltx_font_medium {
+     font-weight: 400
+ }
+ 
+ .ltx_font_italic {
+     font-style: italic;
+     font-variant: discretionary-ligatures
+ }
+ 
+ .ltx_font_upright {
+     font-style: normal;
+     font-variant: normal
+ }
+ 
+ .ltx_font_slanted {
+     font-style: oblique;
+     font-variant: discretionary-ligatures
+ }
+ 
+ .ltx_font_smallcaps {
+     font-variant: small-caps;
+     font-style: normal
+ }
+ 
+ .ltx_font_mathcaligraphic {
+     font-family: var(--math-caligraphic-font-family)
+ }
+ 
+ .ltx_eqn_div {
+     display: block;
+     width: 95%;
+     text-align: center
+ }
+ 
+ .ltx_eqn_table {
+     display: table;
+     width: 100%;
+     border-collapse: collapse;
+     margin: .65rem auto .65rem
+ }
+ 
+ .ltx_eqn_row {
+     display: table-row
+ }
+ 
+ .ltx_eqn_cell {
+     display: table-cell;
+     width: auto;
+     padding-top: .3rem;
+     padding-bottom: .3rem;
+     padding-right: .2rem;
+     padding-left: .2rem
+ }
+ 
+ .ltx_eqn_cell.ltx_eqn_eqno {
+     width: 3em;
+     white-space: nowrap
+ }
+ 
+ .ltx_tag.ltx_tag_equation,
+ .ltx_tag.ltx_tag_equationgroup {
+     font-size: .9em
+ }
+ 
+ table.ltx_eqn_align tr.ltx_equation td.ltx_align_center+td.ltx_align_center,
+ table.ltx_eqn_align tr.ltx_equation td.ltx_align_center+td.ltx_align_right,
+ table.ltx_eqn_align tr.ltx_equation td.ltx_align_left+td.ltx_align_center,
+ table.ltx_eqn_align tr.ltx_equation td.ltx_align_left+td.ltx_align_right {
+     padding-left: 3em
+ }
+ 
+ table.ltx_eqn_eqnarray tr.ltx_eqn_lefteqn+tr td.ltx_align_right {
+     min-width: 2em
+ }
+ 
+ .ltx_eqn_eqno.ltx_align_right .ltx_tag {
+     float: right
+ }
+ 
+ .ltx_eqn_center_padleft,
+ .ltx_eqn_center_padright {
+     width: 50%;
+     min-width: 2em
+ }
+ 
+ .ltx_eqn_left_padleft,
+ .ltx_eqn_right_padright {
+     min-width: 2em
+ }
+ 
+ .ltx_eqn_left_padright,
+ .ltx_eqn_right_padleft {
+     width: 100%
+ }
+ 
+ .ltx_description,
+ .ltx_enumerate,
+ .ltx_itemize {
+     display: block
+ }
+ 
+ .ltx_item>.ltx_para>.ltx_description,
+ .ltx_item>.ltx_para>.ltx_enumerate,
+ .ltx_item>.ltx_para>.ltx_itemize {
+     margin-top: .5rem;
+     margin-left: .5rem
+ }
+ 
+ .ltx_description .ltx_item,
+ .ltx_enumerate .ltx_item,
+ .ltx_itemize .ltx_item {
+     display: list-item
+ }
+ 
+ li.ltx_item>.ltx_tag {
+     display: inline;
+     margin-left: -2.5rem;
+     padding-right: .5rem;
+     text-align: right
+ }
+ 
+ .ltx_item .ltx_tag+.ltx_para,
+ .ltx_item .ltx_tag+.ltx_para .ltx_p {
+     display: inline
+ }
+ 
+ .ltx_item .ltx_para {
+     margin-bottom: 0;
+     display: inline
+ }
+ 
+ .ltx_item+.ltx_item {
+     margin-top: 1em
+ }
+ 
+ dd.ltx_item+dt.ltx_item {
+     margin-top: 0
+ }
+ 
+ dl.ltx_description {
+     list-style-type: none
+ }
+ 
+ dl.ltx_description dt {
+     margin-right: .5em;
+     float: left;
+     font-weight: 700;
+     font-size: 95%
+ }
+ 
+ dl.ltx_description dd.ltx_item {
+     margin-left: 3em;
+     text-indent: 0
+ }
+ 
+ dl.ltx_description dl.ltx_description dd {
+     margin-left: 3em;
+     margin-bottom: .75em
+ }
+ 
+ .ltx_table .ltx_description,
+ .ltx_table .ltx_enumerate,
+ .ltx_table .ltx_itemize {
+     text-align: justify;
+     text-justify: inter-word;
+     hyphens: auto;
+     font-family: var(--text-font-family);
+     line-height: 1.5rem
+ }
+ 
+ .ltx_tabular {
+     display: inline-table;
+     border-collapse: collapse
+ }
+ 
+ .ltx_tabular.ltx_centering {
+     display: table;
+     margin-left: auto;
+     margin-right: auto
+ }
+ 
+ .ltx_graphics.ltx_centering,
+ .ltx_picture.ltx_centering {
+     margin-left: auto;
+     margin-right: auto;
+     text-align: center
+ }
+ 
+ .ltx_picture.ltx_centering {
+     vertical-align: middle
+ }
+ 
+ .ltx_tbody,
+ .ltx_tfoot,
+ .ltx_thead {
+     display: table-row-group
+ }
+ 
+ .ltx_tr {
+     display: table-row
+ }
+ 
+ .ltx_td,
+ .ltx_th {
+     display: table-cell
+ }
+ 
+ .ltx_framed {
+     border: .063rem solid var(--border-color)
+ }
+ 
+ .ltx_tabular .ltx_td,
+ .ltx_tabular .ltx_th {
+     padding: .1em .5em;
+     max-width: var(--main-width);
+     word-wrap: break-word;
+     white-space: normal
+ }
+ 
+ .ltx_tabular .ltx_th.ltx_th_column {
+     white-space: nowrap
+ }
+ 
+ .ltx_border_t {
+     border-top: .063rem solid var(--border-color)
+ }
+ 
+ .ltx_border_r {
+     border-right: .063rem solid var(--border-color)
+ }
+ 
+ .ltx_border_b {
+     border-bottom: .063rem solid var(--border-color)
+ }
+ 
+ .ltx_border_l {
+     border-left: .063rem solid var(--border-color)
+ }
+ 
+ .ltx_border_tt {
+     border-top: .188rem double var(--border-color)
+ }
+ 
+ .ltx_border_rr {
+     border-right: .188rem double var(--border-color)
+ }
+ 
+ .ltx_border_bb {
+     border-bottom: .188rem double var(--border-color)
+ }
+ 
+ .ltx_border_ll {
+     border-left: .188rem double var(--border-color)
+ }
+ 
+ .ltx_border_T {
+     border-top: .063rem solid var(--border-light-color)
+ }
+ 
+ .ltx_border_R {
+     border-right: .063rem solid var(--border-light-color)
+ }
+ 
+ .ltx_border_B {
+     border-bottom: .063rem solid var(--border-light-color)
+ }
+ 
+ .ltx_border_L {
+     border-left: .063rem solid var(--border-light-color)
+ }
+ 
+ .ltx_framed_bottom:not(:empty),
+ .ltx_framed_left:not(:empty),
+ .ltx_framed_rectangle:not(:empty),
+ .ltx_framed_right:not(:empty),
+ .ltx_framed_top:not(:empty),
+ .ltx_framed_topbottom:not(:empty),
+ .ltx_framed_underline:not(:empty) {
+     display: inline-block
+ }
+ 
+ .ltx_framed_rectangle {
+     border-style: solid;
+     border-width: .063rem;
+     padding-left: .3rem;
+     padding-right: .3rem
+ }
+ 
+ .ltx_framed_top {
+     border-top-style: solid;
+     border-top-width: .063rem
+ }
+ 
+ .ltx_framed_left {
+     border-left-style: solid;
+     border-left-width: .063rem
+ }
+ 
+ .ltx_framed_right {
+     border-right-style: solid;
+     border-right-width: .063rem
+ }
+ 
+ .ltx_framed_bottom,
+ .ltx_framed_underline {
+     border-bottom-style: solid;
+     border-bottom-width: .063rem
+ }
+ 
+ .ltx_framed_topbottom {
+     border-top-style: solid;
+     border-top-width: .063rem;
+     border-bottom-style: solid;
+     border-bottom-width: .063rem
+ }
+ 
+ .ltx_framed_leftright {
+     border-left-style: solid;
+     border-left-width: .063rem;
+     border-right-style: solid;
+     border-right-width: .063rem
+ }
+ 
+ .ltx_verbatim {
+     text-align: left;
+     font-size: 90%
+ }
+ 
+ .ltx_tag_note {
+     display: none
+ }
+ 
+ .ltx_ERROR,
+ .ltx_FATAL,
+ .ltx_INFO,
+ .ltx_WARNING {
+     text-align: left;
+     display: inline
+ }
+ 
+ .ltx_INFO {
+     color: var(--info-text-color)
+ }
+ 
+ .ltx_WARNING {
+     color: var(--warning-text-color)
+ }
+ 
+ .ltx_ERROR {
+     font-weight: 400;
+     color: var(--error-text-color)
+ }
+ 
+ .ltx_FATAL {
+     font-weight: 400;
+     color: var(--fatal-text-color)
+ }
+ 
+ .ltx_rdf {
+     display: none
+ }
+ 
+ .ltx_missing,
+ .ltx_nounicode {
+     color: var(--error-text-color)
+ }
+ 
+ .ltx_missing_label {
+     color: var(--warning-text-color)
+ }
+ 
+ merror.ltx_ERROR {
+     font-size: .75rem;
+     background-color: var(--background-color)
+ }
+ 
+ mjx-merror {
+     background-color: var(--background-color) !important
+ }
+ 
+ /*# sourceMappingURL=/sm/e4b1c02825ec8521f7b23a50602819ffb5e41a95c8a3b268c1e80f8203ab4536.map */


### PR DESCRIPTION
As I discovered today, `0.7.4` is hardcoded in early-2024 conversions, such as [this one](https://arxiv.org/html/2401.01544v1).

Returning it for a little while longer.