### PR TITLE
Allows src to be a configured independently of ps_cache ARXIVCE-2801

### DIFF
--- a/browse/config.py
+++ b/browse/config.py
@@ -116,11 +116,17 @@ class Settings(arxiv_base.Settings):
     """
 
     ABS_PATH_ROOT: str = "tests/data/abs_files/"
-    """Paths to .abs and source files.
+    """Paths to .abs files.
 
-       This can start with gs:// to use Google Storage."""
-    DOCUMENT_CACHE_PATH: str = "tests/data/cache"
-    """Path to cache directory"""
+    This can start with gs:// to use Google Storage.
+    """
+
+    SOURCE_STORAGE_PREFIX: str = "tests/data/abs_files/"
+    """Paths to source files.
+    
+    This can start with gs:// to use Google Storage. Ex
+    `gs://arxiv-production-data`. Use with `/data/` for a file system.
+    """
 
     DISSEMINATION_STORAGE_PREFIX: str = "./tests/data/abs_files/"
     """Storage prefix to use. Ex gs://arxiv-production-data

--- a/browse/services/dissemination/__init__.py
+++ b/browse/services/dissemination/__init__.py
@@ -9,9 +9,9 @@ import logging
 from browse.services.documents import get_doc_service
 from browse.services.global_object_store import get_global_object_store, one_time_file
 
-logger = logging.getLogger(__name__)
-
 from .article_store import ArticleStore
+
+logger = logging.getLogger(__name__)
 
 _article_store: ArticleStore = None  # type: ignore
 # This works because it is thread safe and not bound to the app context.
@@ -32,9 +32,15 @@ def get_article_store() -> "ArticleStore":
             logger.info("Loading reasons file from %s", config["REASONS_FILE_PATH"])
             reason_file = one_time_file(config["REASONS_FILE_PATH"])
 
+        if config["SOURCE_STORAGE_PREFIX"] == config["DISSEMINATION_STORAGE_PREFIX"]:
+            src_os = dsp_os
+        else:
+            src_os = get_global_object_store(config["SOURCE_STORAGE_PREFIX"], "_source_store")
+
         _article_store = ArticleStore(
             get_doc_service(),
             dsp_os,
+            src_os,
             get_global_object_store(config["GENPDF_API_STORAGE_PREFIX"], "_genpdf_store"),
             get_global_object_store(config["LATEXML_BUCKET"], "_latexml_store"),
             get_reasons_data(reason_file),


### PR DESCRIPTION
Warning: this requires a configuration change to add `SOURCE_STORAGE_PREFIX` 

Previously the DISSEMINATION_STORAGE_PREFIX was the prefix for both ps_cache and source. This needed to be split out to allow them to be independent when they are not stored in the same place.