### PR TITLE
use arxiv-browse asset for bibex.js

### DIFF
--- a/browse/static/js/toggle-labs.js
+++ b/browse/static/js/toggle-labs.js
@@ -28,7 +28,7 @@ $(document).ready(function() {
     "gotitpub": $('#gotitpub-toggle').data('script-url'),
     "alphaxiv": $('#alphaxiv-toggle').data('script-url'),
     "bibex": {
-      "url": "https://static.arxiv.org/js/bibex/bibex.js?20241202",
+      "url": $('#bibex-toggle').data('script-url'),
       "container": "#bib-main"
     },
     "core-recommender": {

--- a/browse/templates/abs/labs_tabs.html
+++ b/browse/templates/abs/labs_tabs.html
@@ -22,7 +22,8 @@
         <div class="columns is-mobile lab-row">
           <div class="column lab-switch">
             <label class="switch">
-              <input id="bibex-toggle" type="checkbox" class="lab-toggle">
+              <input id="bibex-toggle" type="checkbox" class="lab-toggle"
+                     data-script-url="{{ url_for('static', filename='bibex/bibex.js') }}?20241202">
               <span class="slider"></span>
               <span class="is-sr-only">Bibliographic Explorer Toggle</span>
             </label>


### PR DESCRIPTION
Moving to a bibex.js served by the arxiv-browse service, away from `static.arxiv.org`

In the interest of continuing the migration away from AWS, and more uniformity with the other Labs JS assets.