### PR TITLE
ARXIVCE-2718 Ensure https scheme when using url_for and _external=True

### DIFF
--- a/browse/controllers/list_page/author.py
+++ b/browse/controllers/list_page/author.py
@@ -166,8 +166,8 @@ def _make_json_entry (metadata: DocMetadata) -> Dict[str, str]:
     # TODO: ps format? It doesn't seem like this is possible in the arXiv-NG implementation
     entry['formats'] = {
         'html': metadata.canonical_url(),
-        'pdf': url_for('dissemination.pdf', arxiv_id=metadata.arxiv_id_v, _external=True)
-    }
+        'pdf': url_for('dissemination.pdf', arxiv_id=metadata.arxiv_id_v, _external=True, _scheme='https')
+}
 
     # 'id' field
     # TODO: This seems to be redundant with entry['formats']['html'] right above
@@ -247,7 +247,7 @@ def _add_atom_feed_entry (metadata: DocMetadata, feed: Element, atom2: bool = Fa
 
     SubElement(entry, 'link', attrib={
         'title': 'pdf',
-        'href': url_for('dissemination.pdf', arxiv_id=metadata.arxiv_id_v, _external=True),
+        'href': url_for('dissemination.pdf', arxiv_id=metadata.arxiv_id_v, _external=True, _scheme='https'),
         'rel': 'alternate', 
         'type': 'application/pdf'
     })

--- a/browse/formatting/metatags.py
+++ b/browse/formatting/metatags.py
@@ -75,7 +75,7 @@ def meta_tag_metadata(metadata: DocMetadata, truncate: bool = False) -> List:
     if cod:
         meta_tags.append(_mtag("citation_online_date", cod))
 
-    pdfurl=url_for("dissemination.pdf", arxiv_id=metadata.arxiv_id, _external=True)
+    pdfurl=url_for("dissemination.pdf", arxiv_id=metadata.arxiv_id, _external=True, _scheme='https')
     meta_tags.append(_mtag("citation_pdf_url",pdfurl))
 
     meta_tags.append(_mtag("citation_arxiv_id", str(metadata.arxiv_id)))

--- a/browse/routes/dissemination.py
+++ b/browse/routes/dissemination.py
@@ -38,7 +38,7 @@ def redirect_pdf(arxiv_id: str, archive=None):  # type: ignore
 
     """
     arxiv_id = f"{archive}/{arxiv_id}" if archive else arxiv_id
-    return redirect(url_for('.pdf', arxiv_id=arxiv_id, _external=True), 301)
+    return redirect(url_for('.pdf', arxiv_id=arxiv_id, _external=True, _scheme='https'), 301)
 
 
 @blueprint.route("/pdf/<string:archive>/<string:arxiv_id>", methods=['GET', 'HEAD'])
@@ -59,7 +59,7 @@ def pdf(arxiv_id: str, archive=None):  # type: ignore
     """
 
     if request.query_string: # redirect to strip off any useless query strings
-        return redirect(url_for('.pdf', arxiv_id=arxiv_id, archive=archive, _external=True), 301)
+        return redirect(url_for('.pdf', arxiv_id=arxiv_id, archive=archive, _external=True, _scheme='https'), 301)
     return get_pdf_resp(arxiv_id, archive)
 
 


### PR DESCRIPTION
This is one possible solution to avoiding an http-to-http redirect, as reported in ARXIVCE-2718.

The PR explicitly requests that `url_for` construct `https` URLs, when preparing external/absolute links (as contrasted to internal/relative links).