### PR TITLE
ARXIVCE-928 switch header from XHTML to HTML5

### DIFF
--- a/browse/templates/base.html
+++ b/browse/templates/base.html
@@ -1,9 +1,8 @@
 {%- import 'base/macros.html' as base_macros -%}
 {%- import 'user_banner.html' as user_banner -%}
 {%- set rd_int = request_datetime.strftime("%Y%m%d%H%M")|int -%}
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 
 <head>
   {%- block head -%}


### PR DESCRIPTION
The main switch is easy, if the HTML5 direction has strong support today.

There are other helpful [validator warnings and errors](https://validator.nu/?doc=https%3A%2F%2Farxiv.org), which could be addressed if there's interest.