### PR TITLE
ARXIVCE-2997 also set canonical URL header for latexml-based HTML assets

### DIFF
--- a/browse/controllers/files/dissemination.py
+++ b/browse/controllers/files/dissemination.py
@@ -196,6 +196,8 @@ def _html_response(file_list: Union[List[FileObj],FileObj],
     elif isinstance(file_list, FileObj): #converted via latexml
         resp= default_resp_fn(file_list, arxiv_id, docmeta, version)
         resp.headers=add_surrogate_key(resp.headers,["html-latexml"])
+        if _is_html_name(file_list):
+            resp.headers["Link"] = f"<https://arxiv.org/html/{arxiv_id.id}>; rel='canonical'"
     else:
         # Not a data error since a non-html-source paper might legitimately not have a latexml HTML
         resp= unavailable(arxiv_id)


### PR DESCRIPTION
Follow-up to #819 which had a routing oversight and only handled one of the HTML dissemination paths.