### PR TITLE
reject custom show values

### DIFF
--- a/browse/controllers/list_page/__init__.py
+++ b/browse/controllers/list_page/__init__.py
@@ -181,13 +181,17 @@ def get_listing(subject_or_category: str,
     else:
         skipn = int(skip)
 
-    if not show or not show.isdigit():
+    if show:
+        if show.isdigit() and int(show) in show_values:
+            shown=int(show)
+        else:
+            raise BadRequest(f"Invalid show value. Valid values: {', '.join(map(str, show_values))}")
+    else:
         if time_period == 'new':
             shown = max_show
         else:
             shown = default_show
-    else:
-        shown = max(min(int(show), max_show), min_show)
+
 
     if_mod_since = request.headers.get('If-Modified-Since', None)
 

--- a/browse/templates/list/list_macros.html
+++ b/browse/templates/list/list_macros.html
@@ -36,7 +36,7 @@
     <dd>
       <div class='meta'>
         <div class='list-title mathjax'><span class='descriptor'>Title:</span>
-          {{article.title}}
+          {{article.title|tex2utf}}
         </div>
         <div class='list-authors'>
           {{- do_author_list( article ) -}}

--- a/tests/listings/db/test_db_listing.py
+++ b/tests/listings/db/test_db_listing.py
@@ -36,12 +36,6 @@ SAMPLE_METADATA1=Metadata(
     is_withdrawn = 0
 )
 
-def test_bad_parameters(client_with_db_listings):
-    client = client_with_db_listings
-    rv = client.get("/list/math.MP/recent?show=0")
-    assert rv.status_code == 200
-    rv = client.get("/list/math.MP/recent?skip=9000")
-    assert rv.status_code == 200
 
 def test_list_dl_links(client_with_db_listings):
     client = client_with_db_listings

--- a/tests/listings/db/test_db_listing_recent.py
+++ b/tests/listings/db/test_db_listing_recent.py
@@ -155,7 +155,8 @@ def test_recent_pagination(app_with_db):
 @mock.patch.object(list_page, 'min_show', 1)
 def test_recent_listing_page_pagination(client_with_db_listings):
     client = client_with_db_listings
-    rv = client.get("/list/math/recent?show=1")
+    with mock.patch("browse.controllers.list_page.show_values", [1, 25, 50, 100, 250, 500, 1000, 2000]):
+        rv = client.get("/list/math/recent?show=1")
     assert rv.status_code == 200
     text = rv.text
     assert "Thu, 3 Feb 2011 (showing first 1 of 2 entries )" in text
@@ -171,7 +172,7 @@ def test_recent_listing_page_pagination(client_with_db_listings):
 
 def test_minimum_show(client_with_db_listings):
     client = client_with_db_listings
-    rv = client.get("/list/math/recent?show=1")
+    rv = client.get("/list/math/recent?show=25")
     assert rv.status_code == 200
     text = rv.text
     assert "Thu, 3 Feb 2011 (showing 2 of 2 entries )" in text
@@ -181,7 +182,8 @@ def test_minimum_show(client_with_db_listings):
 @mock.patch.object(list_page, 'min_show', 1)
 def test_recent_page_links( client_with_db_listings):
     client = client_with_db_listings
-    rv = client.get("/list/math/recent?show=2")
+    with mock.patch("browse.controllers.list_page.show_values", [2, 25, 50, 100, 250, 500, 1000, 2000]):
+        rv = client.get("/list/math/recent?show=2")
     assert rv.status_code == 200
     text = rv.text
     assert '<a href="/list/math/recent?skip=4&amp;show=2">\n          Fri, 28 Jan 2011\n        </a>' in text
@@ -189,12 +191,14 @@ def test_recent_page_links( client_with_db_listings):
     assert '<a href="/list/math/recent?skip=2&amp;show=2">\n          Wed, 2 Feb 2011\n        </a>' in text
     assert '<a href="/list/math/recent?skip=0&amp;show=2">\n          Thu, 3 Feb 2011\n        </a>' in text
 
-def test_minimum_pagination( client_with_db_listings):
+def test_bad_pagination( client_with_db_listings):
     client = client_with_db_listings
     rv = client.get("/list/math/recent?show=2")
-    assert rv.status_code == 200
-    text = rv.text
-    assert '<a href="/list/math/recent?skip=4&amp;show=25">\n          Fri, 28 Jan 2011\n        </a>' in text
-    assert '<a href="/list/math/recent?skip=3&amp;show=25">\n          Tue, 1 Feb 2011\n        </a>' in text
-    assert '<a href="/list/math/recent?skip=2&amp;show=25">\n          Wed, 2 Feb 2011\n        </a>' in text
-    assert '<a href="/list/math/recent?skip=0&amp;show=25">\n          Thu, 3 Feb 2011\n        </a>' in text
+    assert rv.status_code == 400
+    assert 'Invalid show value.' in rv.text
+    rv = client.get("/list/math/recent?show=3000")
+    assert rv.status_code == 400
+    assert 'Invalid show value.' in rv.text
+    rv = client.get("/list/math/recent?show=247")
+    assert rv.status_code == 400
+    assert 'Invalid show value.' in rv.text

--- a/tests/listings/test_list_page.py
+++ b/tests/listings/test_list_page.py
@@ -446,8 +446,6 @@ def test_paging_all(client_with_fake_listings):
 
 def test_odd_requests(client_with_fake_listings):
     client = client_with_fake_listings
-    rv = client.get("/list/hep-ph/2009-01?skip=925&show=1000000")
-    assert rv.status_code == 200
 
     rv = client.get("/list/hep-ph/bogusTimePeriod")
     assert rv.status_code != 200
@@ -823,7 +821,8 @@ def test_no_listings_recent(client_with_db_listings):
     assert rv.text.count("Fri, 28 Jan 2011") == 2
 
     #sections farther ahead not shown
-    rv = client.get("/list/physics/recent?show=1")
+    with mock.patch("browse.controllers.list_page.show_values", [1, 25, 50, 100, 250, 500, 1000, 2000]):
+        rv = client.get("/list/physics/recent?show=1")
     assert rv.status_code == 200
     assert rv.text.count(expected_string) == 2
     assert rv.text.count("Thu, 3 Feb 2011") == 2


### PR DESCRIPTION
for the list pages only show values that our page specifies will be supported. This should discourage robots collecting the list pages at show=5 and help with cacheing