### PR TITLE
ScienceCast filter update

### DIFF
--- a/browse/services/audio.py
+++ b/browse/services/audio.py
@@ -40,13 +40,19 @@ def check_scienceCast(metadata: DocMetadata) -> AudioLink:
     scienceCast_cats=["astro-ph.HE"]
     not_available=AudioLink(service=AudioProvider.SCIENCECAST,
                 url=None,
-                not_available_reason=f"This paper's area is not yet supported for this paper. Sciencecast currently only supports categories {', '.join(scienceCast_cats)} for papers announced after {scienceCast_start.strftime('%Y-%m-%d')}")
+                not_available_reason=f"Not yet supported for this paper. " \
+            "Sciencecast currently only supports papers " \
+            "in categories {', '.join(scienceCast_cats)} " \
+            "and announced after {scienceCast_start.strftime('%Y-%m-%d')}" \
+            "and with tex source.")
 
     if not metadata.primary_category or metadata.arxiv_identifier.year is None or metadata.arxiv_identifier.month is None:
         return not_available
 
     paper_month=datetime(year=metadata.arxiv_identifier.year, month=metadata.arxiv_identifier.month, day=2)
-    if paper_month>scienceCast_start and metadata.primary_category.id in scienceCast_cats:
+    if (paper_month>scienceCast_start
+        and metadata.primary_category.id in scienceCast_cats
+        and metadata.source_format in ['tex', 'pdftex']):
         return AudioLink(service=AudioProvider.SCIENCECAST,
                     url=f"https://sciencecast.org/papers/{DOI_PREFIX}/arXiv.{metadata.arxiv_identifier.id}",
                     )

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,92 +1,32 @@
-
-from unittest.mock import MagicMock
+import pytest
 from arxiv.identifier import Identifier
 from browse.services.audio import check_scienceCast, get_audio_urls, has_audio, AudioProvider
 
-def test_check_scienceCast_valid():
-    """Test valid metadata that should return a ScienceCast URL."""
-    metadata = MagicMock()
-    metadata.arxiv_identifier= Identifier("2501.12345")
-    metadata.primary_category.id = "astro-ph.HE"
 
-    result = check_scienceCast(metadata)
-    assert result.url is not None
-    assert "sciencecast.org" in result.url
-    assert result.service == AudioProvider.SCIENCECAST
+tests = [
+    ("check_scienceCast_valid", Identifier("2501.12345"), "astro-ph.HE", "tex", True),
+    ("check_scienceCast_valid", Identifier("2501.12345"), "astro-ph.HE", "pdftex", True),
+    ("check_scienceCast_wrong_format", Identifier("2501.12345"), "astro-ph.HE", "html", False),
+    ("check_scienceCast_wrong_format", Identifier("2501.12345"), "astro-ph.HE", "pdf", False),
+    ("check_scienceCast_old_paper", Identifier("2001.12345"), "astro-ph.HE", "tex", False),
+    ("check_scienceCast_wrong_category", Identifier("2501.12345"), "quant-ph", "tex", False),
+    ("check_scienceCast_missing_category", Identifier("2501.12345"), None, "tex", False),
+    ("check_scienceCast_missing_category_2", Identifier("2501.12345"), "", "tex", False),
+]
 
-def test_check_scienceCast_old_paper():
-    """Test old paper that should return 'not available'."""
-    metadata = MagicMock()
-    metadata.arxiv_identifier= Identifier("2301.12345")
-    metadata.primary_category.id = "astro-ph.HE"
-
-    result = check_scienceCast(metadata)
-    assert result.url is None
-    assert "not yet supported" in result.not_available_reason
-
-def test_check_scienceCast_wrong_category():
-    """Test paper in wrong category that should return 'not available'."""
-    metadata = MagicMock()
-    metadata.arxiv_identifier= Identifier("2501.12345")
-    metadata.primary_category.id = "cs.AI"  
-
-    result = check_scienceCast(metadata)
-    assert result.url is None
-    assert "not yet supported" in result.not_available_reason
-
-def test_check_scienceCast_missing_category():
-    """Test missing primary_category should return 'not available'."""
-    metadata = MagicMock()
-    metadata.arxiv_identifier= Identifier("2501.12345")
-    metadata.primary_category = None  # Missing primary_category
-
-    result = check_scienceCast(metadata)
-    assert result.url is None
-    assert "not yet supported" in result.not_available_reason
-
-def test_check_scienceCast_missing_year_month():
-    """Test missing year/month should return 'not available'."""
-    metadata = MagicMock()
-    metadata.arxiv_identifier.year = None
-    metadata.arxiv_identifier.month = None
-    metadata.arxiv_identifier.id = "2501.55555"
-    metadata.primary_category.id = "astro-ph.HE"
-
-    result = check_scienceCast(metadata)
-    assert result.url is None
-    assert "not yet supported" in result.not_available_reason
-
-def test_get_audio_urls_valid():
-    """Test that get_audio_urls correctly includes the ScienceCast URL."""
-    metadata = MagicMock()
-    metadata.arxiv_identifier= Identifier("2501.12345")
-    metadata.primary_category.id = "astro-ph.HE"
+@pytest.mark.parametrize("desc, paperid, category, src_format, has_audio", tests)
+def test_sciencecast_conditions(mocker, desc, paperid, category, src_format, has_audio):
+    """Test metadata and if it returns a ScienceCast URL."""
+    metadata = mocker.MagicMock()
+    metadata.arxiv_identifier = paperid
+    metadata.primary_category.id = category
+    metadata.source_format = src_format
 
     result = get_audio_urls(metadata)
-    assert AudioProvider.SCIENCECAST in result
-    assert result[AudioProvider.SCIENCECAST].url is not None
-
-def test_get_audio_urls_not_available():
-    """Test get_audio_urls when the paper doesn't qualify (should return 'not available')."""
-    metadata = MagicMock()
-    metadata.arxiv_identifier= Identifier("2301.12345")
-    metadata.primary_category.id = "astro-ph.HE"
-
-    result = get_audio_urls(metadata)
-    assert AudioProvider.SCIENCECAST in result
-    assert result[AudioProvider.SCIENCECAST].url is None
-    assert "not yet supported" in result[AudioProvider.SCIENCECAST].not_available_reason
-
-def test_has_audio_valid():
-    """Test has_audio should return True for valid metadata."""
-    metadata = MagicMock()
-    metadata.arxiv_identifier= Identifier("2501.12345")
-    metadata.primary_category.id = "astro-ph.HE"
-    assert has_audio(metadata) is True
-
-def test_has_audio_no_audio():
-    """Test has_audio should return False when there is no available audio."""
-    metadata = MagicMock()
-    metadata.arxiv_identifier= Identifier("2301.12345")
-    metadata.primary_category.id = "astro-ph.HE"
-    assert has_audio(metadata) is False
+    if has_audio:
+        assert AudioProvider.SCIENCECAST in result
+        assert result[AudioProvider.SCIENCECAST].url is not None
+    else:
+        assert AudioProvider.SCIENCECAST in result
+        assert result[AudioProvider.SCIENCECAST].url is None
+        assert "not yet supported" in result[AudioProvider.SCIENCECAST].not_available_reason.lower()


### PR DESCRIPTION
Per discussion with ScienceCast on 3/6, update the filter on our end to look for submissions with astro-HE as primary, announced since Dec 1 2024, and that are have tex source. 

Minor change from the ticket: it said ", and that are NOT pdf-only. " But I assumed sciencecast cannot handle other strange submissions. Also filtering out HTML, PS and DOCX. 