### PR TITLE
Don't send html sourced papers to genpdf

### DIFF
--- a/browse/controllers/files/dissemination.py
+++ b/browse/controllers/files/dissemination.py
@@ -19,7 +19,7 @@ from arxiv.files import FileObj, FileTransform
 from browse.services.html_processing import post_process_html
 from browse.services.dissemination import get_article_store
 from browse.services.dissemination.article_store import (
-    Acceptable_Format_Requests, CannotBuildPdf, Deleted)
+    Acceptable_Format_Requests, KnownReason, Deleted)
 
 from flask import Response, abort, make_response, render_template, request, current_app, stream_with_context
 from flask_rangerequest import RangeRequest
@@ -166,7 +166,7 @@ def get_dissemination_resp(format: Acceptable_Format_Requests,
         return no_html(arxiv_id)
     elif isinstance(item, Deleted):
         return bad_id(arxiv_id, item.msg)
-    elif isinstance(item, CannotBuildPdf):
+    elif isinstance(item, KnownReason):
         return cannot_build_pdf(arxiv_id, item.msg, item.fmt)
 
     file, docmeta, version = item

--- a/browse/services/dissemination/article_store.py
+++ b/browse/services/dissemination/article_store.py
@@ -357,7 +357,7 @@ class ArticleStore:
 
     def _pdf(self, arxiv_id: Identifier, docmeta: DocMetadata, version: VersionEntry) -> FormatHandlerReturn:
         """Handles getting the `FielObj` for a PDF request."""
-        if version.source_flag.cannot_pdf:
+        if version.source_flag.cannot_pdf or version.source_format == "html":
             return "NOT_PDF"
 
         ps_cache_pdf = self.cache_store.to_obj(ps_cache_pdf_path(arxiv_id, version.version))


### PR DESCRIPTION
Browse was asking genpdf for the PDF for papers with html source. This PR stops that.

This has nothing to do with the latexml HTML.