### PR TITLE
sync-to-gcp to have better error messages

### DIFF
--- a/script/sync_prod_to_gcp/README.md
+++ b/script/sync_prod_to_gcp/README.md
@@ -278,3 +278,58 @@ If the events get stuck, someone needs to take a look at the failuer.
 GCP logging gives some clue, and def. you can know the paper ID. 
 Alart is set up on GCP so pay some attention to it.
 
+
+## Deployment
+
+
+0. Check out arxiv-browse repo (or link)
+   at /opt_arxiv/e-prints/arxiv/arxiv-browse
+
+1. Create Log Directory - `/opt_arxiv/e-prints/logs/sync/` with e-prints:e-prints
+    sudo mkdir -p /opt_arxiv/e-prints/logs/sync/
+	sudo chown e-prints:e-prints /opt_arxiv/e-prints/logs/sync/
+
+2. Install stanza pulgin
+    cd /opt_arxiv/e-prints/arxiv/arxiv-browse/script/sync_prod_to_gcp/stanza/plugins
+	sudo install -m 444 arxiv_sync2gcp_log.yaml /opt/observiq/stanza/plugins
+
+3. Add following to /opt/observiq/stanza/config.yaml (adjust leading spaces)
+
+    - type: arxiv_sync2gcp_log
+      log_path: "/opt_arxiv/e-prints/logs/sync/*"
+      output: host_metadata
+
+4. Restart stanza
+
+5. Prepare the credentials to subscribe the pub/sub event and send files to GCP
+
+As e-prints user
+
+get arxiv-production-39d850b0221d.json (ask Brian C or Tai if you don't know where)
+have it ~/arxiv-production-39d850b0221d.json as e-prints user
+
+    cd
+    ls -l arxiv-production-39d850b0221d.json
+    ln -s arxiv-production-cred.json  arxiv-production-39d850b0221d.json
+
+
+6. Install systemd service
+
+    sudo install -m 444 /opt_arxiv/e-prints/arxiv/arxiv-browse/script/sync_prod_to_gcp/resource/systemd/submissions-to-gcp.service /etc/systemd/system
+	sudo systemctl daemon-reload
+	sudo systemctl enable submissions-to-gcp.service
+	sudo systemctl start submissions-to-gcp.service
+
+7. Install /usr/local/bin/arxiv-mail
+
+    sudo install -m 755 -u e-prints /opt_arxiv/e-prints/arxiv/arxiv-browse/script/sync_prod_to_gcp/resources/bin/arxiv-mail /usr/local/bin
+
+8. Install ~e-prints/bin/tex-compilation-problem-notification
+
+    sudo install -m 755 -u e-prints /opt_arxiv/e-prints/arxiv/arxiv-browse/script/sync_prod_to_gcp/resources/bin/tex-compilation-problem-notification ~e-prints/bin
+
+9. Make temp dir 
+
+    mkdir /tmp/sync-to-gcp
+	sudo chown e-prints /tmp/sync-to-gcp
+	

--- a/script/sync_prod_to_gcp/resource/bin/arxiv-mail
+++ b/script/sync_prod_to_gcp/resource/bin/arxiv-mail
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Sending email to non-local MTA. Almost drop in replacement of /usr/bin/mail
+
+This is intended to be on sync node's /us/local/bin/arxiv-mail.
+You can use this for any MTA but YMMV.
+
+"""
+import smtplib
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+import sys
+import os
+
+
+def _send_email(smtp_server, smtp_port, smtp_user, smtp_pass, recipient, sender, subject):
+    sys.exit(0)
+
+def send_email(smtp_server, smtp_port, smtp_user, smtp_pass, recipient, sender, subject):
+    body = sys.stdin.read()
+
+    msg = MIMEMultipart()
+    msg['From'] = sender
+    msg['To'] = recipient
+    msg['Subject'] = subject
+
+    msg.attach(MIMEText(body, 'plain'))
+
+    try:
+        with smtplib.SMTP(smtp_server, smtp_port) as server:
+            server.ehlo()
+            server.starttls()
+            server.ehlo()
+
+            if smtp_user and smtp_pass:
+                server.login(smtp_user, smtp_pass)
+
+            server.sendmail(sender, recipient, msg.as_string())
+
+    except Exception as e:
+        print(str(e))
+        sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Send an email via a specified SMTP server.')
+    parser.add_argument('-t', '--recipient', required=True, help='TO: Recipient email address')
+    parser.add_argument('-f', '--sender', required=True, help='FROM: Sender email address')
+    parser.add_argument('-s', '--subject', required=True, help='Email subject')
+    parser.add_argument('-m', '--smtp_server', required=True, help='SMTP server address')
+    parser.add_argument('-p', '--smtp_port', type=int, default=25, help='SMTP server port (default: 25)')
+    parser.add_argument('-u', '--smtp_user', help='SMTP username for authentication (optional)')
+    parser.add_argument('-w', '--smtp_pass', help='SMTP password for authentication (optional)')
+
+    args = parser.parse_args()
+
+    send_email(
+        smtp_server=args.smtp_server,
+        smtp_port=args.smtp_port,
+        smtp_user=args.smtp_user,
+        smtp_pass=args.smtp_pass,
+        recipient=args.recipient,
+        sender=args.sender,
+        subject=args.subject
+    )

--- a/script/sync_prod_to_gcp/resource/bin/tex-compilation-problem-notification
+++ b/script/sync_prod_to_gcp/resource/bin/tex-compilation-problem-notification
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <paper_id>"
+  exit 1
+fi
+
+PAPER_ID=$1
+MESSAGE=$2
+
+# This is the "TeX compilation is stuck" workflow
+
+WEBHOOK_URL="https://hooks.slack.com/triggers/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"
+
+PAYLOAD=$(jq -n --arg paper_id "$PAPER_ID" --arg message "$MESSAGE" '{paper_id: $paper_id, message: $message}')
+
+curl -X POST -H "Content-Type: application/json" -d "$PAYLOAD" $WEBHOOK_URL
+exit 0

--- a/script/sync_prod_to_gcp/submissions_to_gcp.py
+++ b/script/sync_prod_to_gcp/submissions_to_gcp.py
@@ -756,6 +756,7 @@ class ErrorStateFile:
 
     @property
     def error_state_filename(self):
+        # squish "/" in pater ID.
         return os.path.join(ERROR_STATE_DIR, self.paper_id.replace('/', '__'))
 
     def error_reported(self) -> bool:
@@ -763,10 +764,6 @@ class ErrorStateFile:
 
     def report(self):
         if not os.path.exists(self.error_state_filename):
-            # Double make sure the dir exists.
-            # This gets over the old style paper ID (eg math/000000)
-            #dirname = os.path.dirname(self.error_state_filename)
-            #os.makedirs(dirname, exist_ok=True)
             # touch
             try:
                 with open(self.error_state_filename, "w", encoding="utf-8") as fd:

--- a/script/sync_prod_to_gcp/submissions_to_gcp.py
+++ b/script/sync_prod_to_gcp/submissions_to_gcp.py
@@ -687,7 +687,7 @@ class SubmissionFilesState:
 
     def register_files(self,
                        file_type: str,
-                       files: typing.List[Path] | typing.List[str]) -> None:
+                       files: typing.Union[typing.List[Path], typing.List[str]]) -> None:
         """
         Used for HTML submission. The actual files uploaded to the gcp bucket is unknown until
         webnode untars it. When ensure_html gets the file list, register them for the upload.
@@ -756,13 +756,17 @@ class ErrorStateFile:
 
     @property
     def error_state_filename(self):
-        return os.path.join(ERROR_STATE_DIR, self.paper_id)
+        return os.path.join(ERROR_STATE_DIR, self.paper_id.replace('/', '__'))
 
     def error_reported(self) -> bool:
         return os.path.exists(self.error_state_filename)
 
     def report(self):
         if not os.path.exists(self.error_state_filename):
+            # Double make sure the dir exists.
+            # This gets over the old style paper ID (eg math/000000)
+            #dirname = os.path.dirname(self.error_state_filename)
+            #os.makedirs(dirname, exist_ok=True)
             # touch
             try:
                 with open(self.error_state_filename, "w", encoding="utf-8") as fd:
@@ -997,6 +1001,11 @@ def move_bucket_objects(gs_client, objects: typing.List[(str, str, str)], verdic
     return
 
 
+def list_missing_cit_files(file_state: SubmissionFilesState) -> typing.List[str]:
+    missing_cit_files = [entry["cit"] for entry in file_state.get_expected_files() if not os.path.exists(entry["cit"])]
+    return missing_cit_files
+
+
 def submission_callback(message: Message) -> None:
     """Pub/sub event handler to upload the submission tarball and .abs files to GCP.
 
@@ -1035,8 +1044,16 @@ def submission_callback(message: Message) -> None:
         # sanity check
         raise ValueError
 
+    message_total_seconds = int(message_age.total_seconds())
+    message_hours, message_remainder = divmod(message_total_seconds, 3600)
+    message_minutes, _ = divmod(message_remainder, 60)
+    if message_hours > 0:
+        message_age_text = f"{message_hours} hour{'s' if message_hours != 1 else ''}, {message_minutes} minute{'s' if message_minutes != 1 else ''}"
+    else:
+        message_age_text = f"{message_minutes} minute{'s' if message_minutes != 1 else ''}"
+
     compilation_timeout = int(os.environ.get("TEX_COMPILATION_TIMEOUT_MINUTES", "720"))
-    first_notification_time = int(os.environ.get("TEX_COMPILATION_FAILURE_FIRST_NOTIFICATION_TIME", "30"))
+    first_notification_time = int(os.environ.get("TEX_COMPILATION_FAILURE_FIRST_NOTIFICATION_TIME", "90"))
 
     file_state = submission_message_to_file_state(data, log_extra, ask_webnode=False)
     desired_state = file_state.get_expected_files()
@@ -1070,7 +1087,7 @@ def submission_callback(message: Message) -> None:
     verdict = SyncVerdict()
     try:
         sync_to_gcp(file_state, verdict, log_extra)
-        logger.info("ack message: %s", file_state.xid.ids, extra=log_extra)
+        logger.info("sync_to_gcp finished: %s", file_state.xid.ids, extra=log_extra)
 
     except Exception as _exc:
         logger.error("Error processing message: {exc}", exc_info=True, extra=log_extra)
@@ -1090,24 +1107,30 @@ def submission_callback(message: Message) -> None:
     if message_age > timedelta(minutes=first_notification_time):
         if not error_state_file.error_reported():
             try:
-                slacking = subprocess.call(
+                missing_files = repr(list_missing_cit_files(file_state))
+                id_v_message = "Notification at %s. Following file(s) missing: %s" % (
+                    message_age_text, missing_files)
+
+                returncode = subprocess.call(
                     ['/users/e-prints/bin/tex-compilation-problem-notification',
-                     id_v], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-                if slacking.returncode != 0:
+                     id_v, id_v_message], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                if returncode != 0:
                     logger.warning("Failed to send notification: %s", id_v, extra=log_extra)
             except:
                 logger.warning('Slacking for %s did not work', id_v)
                 pass
             error_state_file.report()
 
-
     # Deadline exceeded?
     if message_age > timedelta(minutes=compilation_timeout):
         try:
-            slacking = subprocess.call(
+            missing_files = repr(list_missing_cit_files(file_state))
+            id_v_message = "Notification at %s. Following file(s) missing: %s" % (
+                message_age_text, missing_files)
+            returncode = subprocess.call(
                 ['/users/e-prints/bin/tex-compilation-problem-notification',
-                 id_v], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-            if slacking.returncode != 0:
+                 id_v, id_v_message], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            if returncode != 0:
                 logger.error("Failed to send notification: %s", id_v, extra=log_extra)
         except:
             logger.error('Slacking for %s did not work', id_v)


### PR DESCRIPTION
1. README has more instuctions about deployment
2. email and slack message sending scripts added to the resoures
3. Fixed the "error reported" marker file name to be abel to handle the old style arxiv ID
4. First default timeout is now 90 minutes instead of 60. It seems to routinely fall behind. This may be revisited once the s2g drives the PDF gen.