### PR TITLE
sync-to-gcp upload to use md5

### DIFF
--- a/script/sync_prod_to_gcp/Makefile
+++ b/script/sync_prod_to_gcp/Makefile
@@ -12,6 +12,7 @@ sync.venv:
 	-[[ -x /opt/rh/rh-python38/root/bin/python3.8 ]] && /opt/rh/rh-python38/root/bin/python3.8 -m venv sync.venv
 	-[[ -d sync.venv ]] || [[ -x /usr/local/bin/python3.8 ]] && /usr/local/bin/python3.8 -m venv sync.venv
 	-[[ -d sync.venv ]] || [[ -x /usr/bin/python3.8 ]] && /usr/bin/python3.8 -m venv sync.venv
+	-[[ -d sync.venv ]] || [[ -x /usr/bin/python3.9 ]] && /usr/bin/python3.9 -m venv sync.venv
 
 sync.venv/bin/uwsgi: sync.venv 
 	. sync.venv/bin/activate && pip install --upgrade pip

--- a/script/sync_prod_to_gcp/submissions-to-gcp.sh
+++ b/script/sync_prod_to_gcp/submissions-to-gcp.sh
@@ -14,5 +14,7 @@ fi
 
 . sync.venv/bin/activate
 export GOOGLE_APPLICATION_CREDENTIALS=~/arxiv-production-cred.json
+export TEX_COMPILATION_FAILURE_FIRST_NOTIFICATION_TIME=180
+export TEX_COMPILATION_TIMEOUT_MINUTES=1020
 python submissions_to_gcp.py $S2G_DEBUG_FLAGS --json-log-dir $JSON_LOG_DIR
 deactivate

--- a/script/sync_prod_to_gcp/submissions_to_gcp.py
+++ b/script/sync_prod_to_gcp/submissions_to_gcp.py
@@ -768,7 +768,8 @@ class ErrorStateFile:
             try:
                 with open(self.error_state_filename, "w", encoding="utf-8") as fd:
                     fd.write(str(self.paper_id))
-            except:
+            except Exception as exc:
+                logger.warning("Report flag file %s is not made with %s", (self.error_state_filename, str(exc)))
                 pass
 
     def clear(self):

--- a/script/sync_prod_to_gcp/sync_published_to_gcp.py
+++ b/script/sync_prod_to_gcp/sync_published_to_gcp.py
@@ -62,6 +62,8 @@ logger = logging.getLogger(__file__)
 logger.setLevel(logging.WARNING)
 
 import logging_json
+import threading
+import hashlib
 
 
 class Overloaded503Exception(Exception):
@@ -104,7 +106,6 @@ ENSURE_UA = 'periodic-rebuild'
 CONCURRENCY_PER_WEBNODE = [
     ('web5.arxiv.org', 1),
     ('web6.arxiv.org', 1),
-    ('web7.arxiv.org', 1),
     ('web8.arxiv.org', 1),
     ('web9.arxiv.org', 1),
 ]
@@ -474,39 +475,80 @@ def upload_html(gs_client, ensure_tuple):
     for file in ensure_tuple[0]:
         yield upload(gs_client, file, path_to_bucket_key_html(file))
 
+
+# Thread-local storage for read buffer
+_thread_local = threading.local()
+
+def get_read_buffer(size=8192):
+    """Get thread-local read buffer to avoid repeated allocations"""
+    if not hasattr(_thread_local, 'read_buffer') or len(_thread_local.read_buffer) != size:
+        _thread_local.read_buffer = bytearray(size)
+    return _thread_local.read_buffer
+
 @STORAGE_RETRY
 def upload(gs_client, localpath, key, upload_logger=None):
     """Upload a file to GS_BUCKET"""
     if upload_logger is None:
         upload_logger = logger
-
+    
     def mime_from_fname(filepath):
         return {
             '.pdf': 'application/pdf',
             '.gz': 'application/gzip',
             '.abs': 'text/plain'
         }.get(filepath.suffix, '')
-
+    
+    def get_file_info(filepath):
+        """Get file size and MD5 hash by reading the file"""
+        md5_hash = hashlib.md5()
+        file_size = 0
+        buffer = get_read_buffer(8192)
+        
+        with open(filepath, 'rb') as f:
+            while True:
+                bytes_read = f.readinto(buffer)
+                if bytes_read == 0:
+                    break
+                md5_hash.update(buffer[:bytes_read])
+                file_size += bytes_read
+        
+        return file_size, md5_hash.hexdigest()
+    
     start = perf_counter()
-
     bucket = gs_client.bucket(GS_BUCKET)
     blob = bucket.get_blob(key)
-    if blob is None or blob.size != localpath.stat().st_size or key in REUPLOADS:
+    
+    local_size, local_md5 = get_file_info(localpath)
+    
+    timestamp_utc = datetime.now(timezone.utc).isoformat()
+    metadata = {
+        "localpath": str(localpath),
+        "local_md5": local_md5,
+        "mtime": get_file_mtime(localpath),
+        "timestamp_utc": timestamp_utc
+    }            
+
+    should_upload =  blob is None or blob.md5_hash != local_md5) key in REUPLOADS
+    if should_upload:
         destination = bucket.blob(key)
         with open(localpath, 'rb') as fh:
             destination.upload_from_file(fh, content_type=mime_from_fname(localpath))
             upload_logger.info(
-                f"upload: completed upload of {localpath} to gs://{GS_BUCKET}/{key} of size {localpath.stat().st_size}")
+                f"upload: completed upload of {localpath} to gs://{GS_BUCKET}/{key} of md5 {local_md5}, size {local_size}",
+                extra=metadata)
         try:
-            destination.metadata = {"localpath": localpath, "mtime": get_file_mtime(localpath)}
+            destination.metadata = {"localpath": str(localpath), "mtime": get_file_mtime(localpath)}
+            destination.metadata = metadata
             destination.update()
         except BaseException:
-            upload_logger.error(f"upload: could not set time on GS object gs://{GS_BUCKET}/{key}", exc_info=True)
-        return "upload", localpath, key, "uploaded", ms_since(start), localpath.stat().st_size
+            upload_logger.error(f"upload: could not set metadata on GS object gs://{GS_BUCKET}/{key}",
+                                extra=metadata,
+                                exc_info=True)
+        return "upload", localpath, key, "uploaded", ms_since(start), local_size
     else:
-        upload_logger.info(f"upload: Not uploading {localpath}, gs://{GS_BUCKET}/{key} already on gs")
+        upload_logger.info(f"upload: Not uploading {localpath}, gs://{GS_BUCKET}/{key} already on gs",
+                           extra=metadata)
         return "upload", localpath, key, "already_on_gs", ms_since(start), 0
-
 
 def sync_to_gcp(todo_q, host):
     """Target for theads that gets jobs off of the todo queue and does job actions."""


### PR DESCRIPTION
web7 out of rotation.

Notification timeouts is longer. First timeout is now 3h. 