### PR TITLE
Fixes pdf redirect to http bug ARXIVCE-2718

### DIFF
--- a/browse/controllers/list_page/author.py
+++ b/browse/controllers/list_page/author.py
@@ -168,7 +168,7 @@ def _make_json_entry (metadata: DocMetadata) -> Dict[str, str]:
     # TODO: ps format? It doesn't seem like this is possible in the arXiv-NG implementation
     entry['formats'] = {
         'html': metadata.canonical_url(),
-        'pdf': url_for('dissemination.pdf', arxiv_id=metadata.arxiv_id_v, _external=True)
+        'pdf': url_for('dissemination.pdf', arxiv_id=metadata.arxiv_id_v, _external=True, _scheme="https")
     }
 
     # 'id' field
@@ -249,7 +249,7 @@ def _add_atom_feed_entry (metadata: DocMetadata, feed: Element, atom2: bool = Fa
 
     SubElement(entry, 'link', attrib={
         'title': 'pdf',
-        'href': url_for('dissemination.pdf', arxiv_id=metadata.arxiv_id_v, _external=True),
+        'href': url_for('dissemination.pdf', arxiv_id=metadata.arxiv_id_v, _external=True, _scheme="https"),
         'rel': 'alternate', 
         'type': 'application/pdf'
     })

--- a/browse/formatting/metatags.py
+++ b/browse/formatting/metatags.py
@@ -75,7 +75,8 @@ def meta_tag_metadata(metadata: DocMetadata, truncate: bool = False) -> List:
     if cod:
         meta_tags.append(_mtag("citation_online_date", cod))
 
-    pdfurl=url_for("dissemination.pdf", arxiv_id=metadata.arxiv_id, _external=True)
+    """_external=True is used here to force ab absolute URL with https schema."""
+    pdfurl=url_for("dissemination.pdf", arxiv_id=metadata.arxiv_id, _external=True, _scheme="https")
     meta_tags.append(_mtag("citation_pdf_url",pdfurl))
 
     meta_tags.append(_mtag("citation_arxiv_id", str(metadata.arxiv_id)))

--- a/browse/routes/dissemination.py
+++ b/browse/routes/dissemination.py
@@ -36,7 +36,7 @@ def redirect_pdf(arxiv_id: str, archive=None):  # type: ignore
 
     """
     arxiv_id = f"{archive}/{arxiv_id}" if archive else arxiv_id
-    return redirect(url_for('.pdf', arxiv_id=arxiv_id, _external=True), 301)
+    return redirect(url_for('.pdf', arxiv_id=arxiv_id), 301)
 
 
 @blueprint.route("/pdf/<string:archive>/<string:arxiv_id>", methods=['GET', 'HEAD'])
@@ -57,7 +57,7 @@ def pdf(arxiv_id: str, archive=None):  # type: ignore
     """
 
     if request.query_string:  # redirect to strip off any useless query strings
-        return redirect(url_for('.pdf', arxiv_id=arxiv_id, archive=archive, _external=True), 301)
+        return redirect(url_for('.pdf', arxiv_id=arxiv_id, archive=archive), 301)
     return get_pdf_resp(arxiv_id, archive)
 
 

--- a/tests/data/classic_scholar_metadata_tags.json
+++ b/tests/data/classic_scholar_metadata_tags.json
@@ -22,7 +22,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0801.1021",
+      "content" : "https://localhost/pdf/0801.1021",
       "name" : "citation_pdf_url"
    },
    {
@@ -54,7 +54,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0801.1021",
+      "content" : "https://localhost/pdf/0801.1021",
       "name" : "citation_pdf_url"
    },
    {
@@ -86,7 +86,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0801.1021",
+      "content" : "https://localhost/pdf/0801.1021",
       "name" : "citation_pdf_url"
    },
    {
@@ -126,7 +126,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0802.0193",
+      "content" : "https://localhost/pdf/0802.0193",
       "name" : "citation_pdf_url"
    },
    {
@@ -158,7 +158,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0906.3421",
+      "content" : "https://localhost/pdf/0906.3421",
       "name" : "citation_pdf_url"
    },
    {
@@ -186,7 +186,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0906.5132",
+      "content" : "https://localhost/pdf/0906.5132",
       "name" : "citation_pdf_url"
    },
    {
@@ -218,7 +218,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0906.3421",
+      "content" : "https://localhost/pdf/0906.3421",
       "name" : "citation_pdf_url"
    },
    {
@@ -246,7 +246,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0906.5504",
+      "content" : "https://localhost/pdf/0906.5504",
       "name" : "citation_pdf_url"
    },
    {
@@ -274,7 +274,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0906.5132",
+      "content" : "https://localhost/pdf/0906.5132",
       "name" : "citation_pdf_url"
    },
    {
@@ -302,7 +302,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0906.2112",
+      "content" : "https://localhost/pdf/0906.2112",
       "name" : "citation_pdf_url"
    },
    {
@@ -330,7 +330,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0906.5504",
+      "content" : "https://localhost/pdf/0906.5504",
       "name" : "citation_pdf_url"
    },
    {
@@ -358,7 +358,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0906.5132",
+      "content" : "https://localhost/pdf/0906.5132",
       "name" : "citation_pdf_url"
    },
    {
@@ -386,7 +386,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0906.2112",
+      "content" : "https://localhost/pdf/0906.2112",
       "name" : "citation_pdf_url"
    },
    {
@@ -418,7 +418,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0906.3336",
+      "content" : "https://localhost/pdf/0906.3336",
       "name" : "citation_pdf_url"
    },
    {
@@ -458,7 +458,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0001",
+      "content" : "https://localhost/pdf/0704.0001",
       "name" : "citation_pdf_url"
    },
    {
@@ -486,7 +486,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/funct-an/9301001",
+      "content" : "https://localhost/pdf/funct-an/9301001",
       "name" : "citation_pdf_url"
    },
    {
@@ -514,7 +514,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/hep-th/9901001",
+      "content" : "https://localhost/pdf/hep-th/9901001",
       "name" : "citation_pdf_url"
    },
    {
@@ -542,7 +542,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/hep-th/9901001",
+      "content" : "https://localhost/pdf/hep-th/9901001",
       "name" : "citation_pdf_url"
    },
    {
@@ -570,7 +570,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/adap-org/9509003",
+      "content" : "https://localhost/pdf/adap-org/9509003",
       "name" : "citation_pdf_url"
    },
    {
@@ -598,7 +598,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/adap-org/9509003",
+      "content" : "https://localhost/pdf/adap-org/9509003",
       "name" : "citation_pdf_url"
    },
    {
@@ -642,7 +642,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/supr-con/9411001",
+      "content" : "https://localhost/pdf/supr-con/9411001",
       "name" : "citation_pdf_url"
    },
    {
@@ -678,7 +678,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/astro-ph/0301632",
+      "content" : "https://localhost/pdf/astro-ph/0301632",
       "name" : "citation_pdf_url"
    },
    {
@@ -718,7 +718,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/astro-ph/9204001",
+      "content" : "https://localhost/pdf/astro-ph/9204001",
       "name" : "citation_pdf_url"
    },
    {
@@ -746,7 +746,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/acc-phys/9502001",
+      "content" : "https://localhost/pdf/acc-phys/9502001",
       "name" : "citation_pdf_url"
    },
    {
@@ -842,7 +842,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/acc-phys/9503002",
+      "content" : "https://localhost/pdf/acc-phys/9503002",
       "name" : "citation_pdf_url"
    },
    {
@@ -902,7 +902,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/acc-phys/9503001",
+      "content" : "https://localhost/pdf/acc-phys/9503001",
       "name" : "citation_pdf_url"
    },
    {
@@ -934,7 +934,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/acc-phys/9411004",
+      "content" : "https://localhost/pdf/acc-phys/9411004",
       "name" : "citation_pdf_url"
    },
    {
@@ -982,7 +982,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/acc-phys/9411003",
+      "content" : "https://localhost/pdf/acc-phys/9411003",
       "name" : "citation_pdf_url"
    },
    {
@@ -1014,7 +1014,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/acc-phys/9411001",
+      "content" : "https://localhost/pdf/acc-phys/9411001",
       "name" : "citation_pdf_url"
    },
    {
@@ -1042,7 +1042,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/acc-phys/9411002",
+      "content" : "https://localhost/pdf/acc-phys/9411002",
       "name" : "citation_pdf_url"
    },
    {
@@ -1078,7 +1078,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0801.1021",
+      "content" : "https://localhost/pdf/0801.1021",
       "name" : "citation_pdf_url"
    },
    {
@@ -1118,7 +1118,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0802.0193",
+      "content" : "https://localhost/pdf/0802.0193",
       "name" : "citation_pdf_url"
    },
    {
@@ -1150,7 +1150,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/1501.00001",
+      "content" : "https://localhost/pdf/1501.00001",
       "name" : "citation_pdf_url"
    },
    {
@@ -1170,7 +1170,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/1501.99999",
+      "content" : "https://localhost/pdf/1501.99999",
       "name" : "citation_pdf_url"
    },
    {
@@ -1202,7 +1202,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/1501.00002",
+      "content" : "https://localhost/pdf/1501.00002",
       "name" : "citation_pdf_url"
    },
    {
@@ -1230,7 +1230,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0906.5132",
+      "content" : "https://localhost/pdf/0906.5132",
       "name" : "citation_pdf_url"
    },
    {
@@ -1262,7 +1262,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0906.3336",
+      "content" : "https://localhost/pdf/0906.3336",
       "name" : "citation_pdf_url"
    },
    {
@@ -1290,7 +1290,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0906.5504",
+      "content" : "https://localhost/pdf/0906.5504",
       "name" : "citation_pdf_url"
    },
    {
@@ -1326,7 +1326,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0906.5602",
+      "content" : "https://localhost/pdf/0906.5602",
       "name" : "citation_pdf_url"
    },
    {
@@ -1362,7 +1362,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0906.3421",
+      "content" : "https://localhost/pdf/0906.3421",
       "name" : "citation_pdf_url"
    },
    {
@@ -1390,7 +1390,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0906.2112",
+      "content" : "https://localhost/pdf/0906.2112",
       "name" : "citation_pdf_url"
    },
    {
@@ -1438,7 +1438,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0705.0002",
+      "content" : "https://localhost/pdf/0705.0002",
       "name" : "citation_pdf_url"
    },
    {
@@ -1474,7 +1474,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0705.0001",
+      "content" : "https://localhost/pdf/0705.0001",
       "name" : "citation_pdf_url"
    },
    {
@@ -1514,7 +1514,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0526",
+      "content" : "https://localhost/pdf/0704.0526",
       "name" : "citation_pdf_url"
    },
    {
@@ -1554,7 +1554,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0988",
+      "content" : "https://localhost/pdf/0704.0988",
       "name" : "citation_pdf_url"
    },
    {
@@ -1614,7 +1614,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0182",
+      "content" : "https://localhost/pdf/0704.0182",
       "name" : "citation_pdf_url"
    },
    {
@@ -1662,7 +1662,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0310",
+      "content" : "https://localhost/pdf/0704.0310",
       "name" : "citation_pdf_url"
    },
    {
@@ -1714,7 +1714,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0616",
+      "content" : "https://localhost/pdf/0704.0616",
       "name" : "citation_pdf_url"
    },
    {
@@ -1742,7 +1742,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0732",
+      "content" : "https://localhost/pdf/0704.0732",
       "name" : "citation_pdf_url"
    },
    {
@@ -1770,7 +1770,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0042",
+      "content" : "https://localhost/pdf/0704.0042",
       "name" : "citation_pdf_url"
    },
    {
@@ -1802,7 +1802,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0615",
+      "content" : "https://localhost/pdf/0704.0615",
       "name" : "citation_pdf_url"
    },
    {
@@ -1842,7 +1842,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0568",
+      "content" : "https://localhost/pdf/0704.0568",
       "name" : "citation_pdf_url"
    },
    {
@@ -1878,7 +1878,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0319",
+      "content" : "https://localhost/pdf/0704.0319",
       "name" : "citation_pdf_url"
    },
    {
@@ -2010,7 +2010,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0265",
+      "content" : "https://localhost/pdf/0704.0265",
       "name" : "citation_pdf_url"
    },
    {
@@ -2078,7 +2078,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0133",
+      "content" : "https://localhost/pdf/0704.0133",
       "name" : "citation_pdf_url"
    },
    {
@@ -2178,7 +2178,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0533",
+      "content" : "https://localhost/pdf/0704.0533",
       "name" : "citation_pdf_url"
    },
    {
@@ -2238,7 +2238,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0453",
+      "content" : "https://localhost/pdf/0704.0453",
       "name" : "citation_pdf_url"
    },
    {
@@ -2270,7 +2270,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0276",
+      "content" : "https://localhost/pdf/0704.0276",
       "name" : "citation_pdf_url"
    },
    {
@@ -2298,7 +2298,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0991",
+      "content" : "https://localhost/pdf/0704.0991",
       "name" : "citation_pdf_url"
    },
    {
@@ -2342,7 +2342,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0740",
+      "content" : "https://localhost/pdf/0704.0740",
       "name" : "citation_pdf_url"
    },
    {
@@ -2378,7 +2378,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0473",
+      "content" : "https://localhost/pdf/0704.0473",
       "name" : "citation_pdf_url"
    },
    {
@@ -2410,7 +2410,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0083",
+      "content" : "https://localhost/pdf/0704.0083",
       "name" : "citation_pdf_url"
    },
    {
@@ -2446,7 +2446,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0278",
+      "content" : "https://localhost/pdf/0704.0278",
       "name" : "citation_pdf_url"
    },
    {
@@ -2482,7 +2482,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0006",
+      "content" : "https://localhost/pdf/0704.0006",
       "name" : "citation_pdf_url"
    },
    {
@@ -2562,7 +2562,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0735",
+      "content" : "https://localhost/pdf/0704.0735",
       "name" : "citation_pdf_url"
    },
    {
@@ -2602,7 +2602,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0753",
+      "content" : "https://localhost/pdf/0704.0753",
       "name" : "citation_pdf_url"
    },
    {
@@ -2630,7 +2630,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0324",
+      "content" : "https://localhost/pdf/0704.0324",
       "name" : "citation_pdf_url"
    },
    {
@@ -2658,7 +2658,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0600",
+      "content" : "https://localhost/pdf/0704.0600",
       "name" : "citation_pdf_url"
    },
    {
@@ -2698,7 +2698,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0737",
+      "content" : "https://localhost/pdf/0704.0737",
       "name" : "citation_pdf_url"
    },
    {
@@ -2750,7 +2750,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0387",
+      "content" : "https://localhost/pdf/0704.0387",
       "name" : "citation_pdf_url"
    },
    {
@@ -2786,7 +2786,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0659",
+      "content" : "https://localhost/pdf/0704.0659",
       "name" : "citation_pdf_url"
    },
    {
@@ -2818,7 +2818,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0432",
+      "content" : "https://localhost/pdf/0704.0432",
       "name" : "citation_pdf_url"
    },
    {
@@ -2858,7 +2858,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0408",
+      "content" : "https://localhost/pdf/0704.0408",
       "name" : "citation_pdf_url"
    },
    {
@@ -2886,7 +2886,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0895",
+      "content" : "https://localhost/pdf/0704.0895",
       "name" : "citation_pdf_url"
    },
    {
@@ -2914,7 +2914,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0088",
+      "content" : "https://localhost/pdf/0704.0088",
       "name" : "citation_pdf_url"
    },
    {
@@ -2954,7 +2954,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0719",
+      "content" : "https://localhost/pdf/0704.0719",
       "name" : "citation_pdf_url"
    },
    {
@@ -2990,7 +2990,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0124",
+      "content" : "https://localhost/pdf/0704.0124",
       "name" : "citation_pdf_url"
    },
    {
@@ -3022,7 +3022,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0508",
+      "content" : "https://localhost/pdf/0704.0508",
       "name" : "citation_pdf_url"
    },
    {
@@ -3050,7 +3050,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0145",
+      "content" : "https://localhost/pdf/0704.0145",
       "name" : "citation_pdf_url"
    },
    {
@@ -3098,7 +3098,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0075",
+      "content" : "https://localhost/pdf/0704.0075",
       "name" : "citation_pdf_url"
    },
    {
@@ -3138,7 +3138,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0333",
+      "content" : "https://localhost/pdf/0704.0333",
       "name" : "citation_pdf_url"
    },
    {
@@ -3170,7 +3170,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0445",
+      "content" : "https://localhost/pdf/0704.0445",
       "name" : "citation_pdf_url"
    },
    {
@@ -3230,7 +3230,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0226",
+      "content" : "https://localhost/pdf/0704.0226",
       "name" : "citation_pdf_url"
    },
    {
@@ -3262,7 +3262,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0266",
+      "content" : "https://localhost/pdf/0704.0266",
       "name" : "citation_pdf_url"
    },
    {
@@ -3310,7 +3310,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0368",
+      "content" : "https://localhost/pdf/0704.0368",
       "name" : "citation_pdf_url"
    },
    {
@@ -3338,7 +3338,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0716",
+      "content" : "https://localhost/pdf/0704.0716",
       "name" : "citation_pdf_url"
    },
    {
@@ -3378,7 +3378,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0373",
+      "content" : "https://localhost/pdf/0704.0373",
       "name" : "citation_pdf_url"
    },
    {
@@ -3410,7 +3410,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0378",
+      "content" : "https://localhost/pdf/0704.0378",
       "name" : "citation_pdf_url"
    },
    {
@@ -3438,7 +3438,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0536",
+      "content" : "https://localhost/pdf/0704.0536",
       "name" : "citation_pdf_url"
    },
    {
@@ -3470,7 +3470,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0239",
+      "content" : "https://localhost/pdf/0704.0239",
       "name" : "citation_pdf_url"
    },
    {
@@ -3522,7 +3522,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0209",
+      "content" : "https://localhost/pdf/0704.0209",
       "name" : "citation_pdf_url"
    },
    {
@@ -3574,7 +3574,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0916",
+      "content" : "https://localhost/pdf/0704.0916",
       "name" : "citation_pdf_url"
    },
    {
@@ -3602,7 +3602,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0091",
+      "content" : "https://localhost/pdf/0704.0091",
       "name" : "citation_pdf_url"
    },
    {
@@ -3634,7 +3634,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0054",
+      "content" : "https://localhost/pdf/0704.0054",
       "name" : "citation_pdf_url"
    },
    {
@@ -3670,7 +3670,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0225",
+      "content" : "https://localhost/pdf/0704.0225",
       "name" : "citation_pdf_url"
    },
    {
@@ -3706,7 +3706,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0186",
+      "content" : "https://localhost/pdf/0704.0186",
       "name" : "citation_pdf_url"
    },
    {
@@ -3750,7 +3750,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0847",
+      "content" : "https://localhost/pdf/0704.0847",
       "name" : "citation_pdf_url"
    },
    {
@@ -3778,7 +3778,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0129",
+      "content" : "https://localhost/pdf/0704.0129",
       "name" : "citation_pdf_url"
    },
    {
@@ -3806,7 +3806,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0257",
+      "content" : "https://localhost/pdf/0704.0257",
       "name" : "citation_pdf_url"
    },
    {
@@ -3854,7 +3854,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0388",
+      "content" : "https://localhost/pdf/0704.0388",
       "name" : "citation_pdf_url"
    },
    {
@@ -3898,7 +3898,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0481",
+      "content" : "https://localhost/pdf/0704.0481",
       "name" : "citation_pdf_url"
    },
    {
@@ -3934,7 +3934,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0156",
+      "content" : "https://localhost/pdf/0704.0156",
       "name" : "citation_pdf_url"
    },
    {
@@ -3962,7 +3962,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0685",
+      "content" : "https://localhost/pdf/0704.0685",
       "name" : "citation_pdf_url"
    },
    {
@@ -4010,7 +4010,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0694",
+      "content" : "https://localhost/pdf/0704.0694",
       "name" : "citation_pdf_url"
    },
    {
@@ -4046,7 +4046,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0485",
+      "content" : "https://localhost/pdf/0704.0485",
       "name" : "citation_pdf_url"
    },
    {
@@ -4094,7 +4094,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0682",
+      "content" : "https://localhost/pdf/0704.0682",
       "name" : "citation_pdf_url"
    },
    {
@@ -4126,7 +4126,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0200",
+      "content" : "https://localhost/pdf/0704.0200",
       "name" : "citation_pdf_url"
    },
    {
@@ -4170,7 +4170,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0627",
+      "content" : "https://localhost/pdf/0704.0627",
       "name" : "citation_pdf_url"
    },
    {
@@ -4202,7 +4202,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0722",
+      "content" : "https://localhost/pdf/0704.0722",
       "name" : "citation_pdf_url"
    },
    {
@@ -4242,7 +4242,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0845",
+      "content" : "https://localhost/pdf/0704.0845",
       "name" : "citation_pdf_url"
    },
    {
@@ -4282,7 +4282,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0815",
+      "content" : "https://localhost/pdf/0704.0815",
       "name" : "citation_pdf_url"
    },
    {
@@ -4314,7 +4314,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0362",
+      "content" : "https://localhost/pdf/0704.0362",
       "name" : "citation_pdf_url"
    },
    {
@@ -4350,7 +4350,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0143",
+      "content" : "https://localhost/pdf/0704.0143",
       "name" : "citation_pdf_url"
    },
    {
@@ -4386,7 +4386,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0381",
+      "content" : "https://localhost/pdf/0704.0381",
       "name" : "citation_pdf_url"
    },
    {
@@ -4422,7 +4422,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0299",
+      "content" : "https://localhost/pdf/0704.0299",
       "name" : "citation_pdf_url"
    },
    {
@@ -4466,7 +4466,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0205",
+      "content" : "https://localhost/pdf/0704.0205",
       "name" : "citation_pdf_url"
    },
    {
@@ -4510,7 +4510,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0914",
+      "content" : "https://localhost/pdf/0704.0914",
       "name" : "citation_pdf_url"
    },
    {
@@ -4538,7 +4538,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0640",
+      "content" : "https://localhost/pdf/0704.0640",
       "name" : "citation_pdf_url"
    },
    {
@@ -4566,7 +4566,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0683",
+      "content" : "https://localhost/pdf/0704.0683",
       "name" : "citation_pdf_url"
    },
    {
@@ -4610,7 +4610,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0238",
+      "content" : "https://localhost/pdf/0704.0238",
       "name" : "citation_pdf_url"
    },
    {
@@ -4670,7 +4670,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0939",
+      "content" : "https://localhost/pdf/0704.0939",
       "name" : "citation_pdf_url"
    },
    {
@@ -4702,7 +4702,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0582",
+      "content" : "https://localhost/pdf/0704.0582",
       "name" : "citation_pdf_url"
    },
    {
@@ -4730,7 +4730,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0019",
+      "content" : "https://localhost/pdf/0704.0019",
       "name" : "citation_pdf_url"
    },
    {
@@ -4866,7 +4866,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0958",
+      "content" : "https://localhost/pdf/0704.0958",
       "name" : "citation_pdf_url"
    },
    {
@@ -4902,7 +4902,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0150",
+      "content" : "https://localhost/pdf/0704.0150",
       "name" : "citation_pdf_url"
    },
    {
@@ -4946,7 +4946,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0699",
+      "content" : "https://localhost/pdf/0704.0699",
       "name" : "citation_pdf_url"
    },
    {
@@ -4994,7 +4994,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0306",
+      "content" : "https://localhost/pdf/0704.0306",
       "name" : "citation_pdf_url"
    },
    {
@@ -5034,7 +5034,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0418",
+      "content" : "https://localhost/pdf/0704.0418",
       "name" : "citation_pdf_url"
    },
    {
@@ -5074,7 +5074,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0463",
+      "content" : "https://localhost/pdf/0704.0463",
       "name" : "citation_pdf_url"
    },
    {
@@ -5106,7 +5106,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0002",
+      "content" : "https://localhost/pdf/0704.0002",
       "name" : "citation_pdf_url"
    },
    {
@@ -5150,7 +5150,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0975",
+      "content" : "https://localhost/pdf/0704.0975",
       "name" : "citation_pdf_url"
    },
    {
@@ -5178,7 +5178,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0787",
+      "content" : "https://localhost/pdf/0704.0787",
       "name" : "citation_pdf_url"
    },
    {
@@ -5214,7 +5214,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0597",
+      "content" : "https://localhost/pdf/0704.0597",
       "name" : "citation_pdf_url"
    },
    {
@@ -5258,7 +5258,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0154",
+      "content" : "https://localhost/pdf/0704.0154",
       "name" : "citation_pdf_url"
    },
    {
@@ -5298,7 +5298,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0178",
+      "content" : "https://localhost/pdf/0704.0178",
       "name" : "citation_pdf_url"
    },
    {
@@ -5342,7 +5342,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0572",
+      "content" : "https://localhost/pdf/0704.0572",
       "name" : "citation_pdf_url"
    },
    {
@@ -5386,7 +5386,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0576",
+      "content" : "https://localhost/pdf/0704.0576",
       "name" : "citation_pdf_url"
    },
    {
@@ -5422,7 +5422,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0757",
+      "content" : "https://localhost/pdf/0704.0757",
       "name" : "citation_pdf_url"
    },
    {
@@ -5458,7 +5458,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0457",
+      "content" : "https://localhost/pdf/0704.0457",
       "name" : "citation_pdf_url"
    },
    {
@@ -5490,7 +5490,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0751",
+      "content" : "https://localhost/pdf/0704.0751",
       "name" : "citation_pdf_url"
    },
    {
@@ -5526,7 +5526,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0414",
+      "content" : "https://localhost/pdf/0704.0414",
       "name" : "citation_pdf_url"
    },
    {
@@ -5586,7 +5586,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0355",
+      "content" : "https://localhost/pdf/0704.0355",
       "name" : "citation_pdf_url"
    },
    {
@@ -5614,7 +5614,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0349",
+      "content" : "https://localhost/pdf/0704.0349",
       "name" : "citation_pdf_url"
    },
    {
@@ -5662,7 +5662,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0161",
+      "content" : "https://localhost/pdf/0704.0161",
       "name" : "citation_pdf_url"
    },
    {
@@ -5706,7 +5706,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0748",
+      "content" : "https://localhost/pdf/0704.0748",
       "name" : "citation_pdf_url"
    },
    {
@@ -5750,7 +5750,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0980",
+      "content" : "https://localhost/pdf/0704.0980",
       "name" : "citation_pdf_url"
    },
    {
@@ -5794,7 +5794,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0016",
+      "content" : "https://localhost/pdf/0704.0016",
       "name" : "citation_pdf_url"
    },
    {
@@ -5874,7 +5874,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0905",
+      "content" : "https://localhost/pdf/0704.0905",
       "name" : "citation_pdf_url"
    },
    {
@@ -5906,7 +5906,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0596",
+      "content" : "https://localhost/pdf/0704.0596",
       "name" : "citation_pdf_url"
    },
    {
@@ -5946,7 +5946,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0730",
+      "content" : "https://localhost/pdf/0704.0730",
       "name" : "citation_pdf_url"
    },
    {
@@ -5994,7 +5994,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0543",
+      "content" : "https://localhost/pdf/0704.0543",
       "name" : "citation_pdf_url"
    },
    {
@@ -6026,7 +6026,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0070",
+      "content" : "https://localhost/pdf/0704.0070",
       "name" : "citation_pdf_url"
    },
    {
@@ -6054,7 +6054,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0898",
+      "content" : "https://localhost/pdf/0704.0898",
       "name" : "citation_pdf_url"
    },
    {
@@ -6090,7 +6090,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0273",
+      "content" : "https://localhost/pdf/0704.0273",
       "name" : "citation_pdf_url"
    },
    {
@@ -6126,7 +6126,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0480",
+      "content" : "https://localhost/pdf/0704.0480",
       "name" : "citation_pdf_url"
    },
    {
@@ -6198,7 +6198,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0810",
+      "content" : "https://localhost/pdf/0704.0810",
       "name" : "citation_pdf_url"
    },
    {
@@ -6234,7 +6234,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0440",
+      "content" : "https://localhost/pdf/0704.0440",
       "name" : "citation_pdf_url"
    },
    {
@@ -6270,7 +6270,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0025",
+      "content" : "https://localhost/pdf/0704.0025",
       "name" : "citation_pdf_url"
    },
    {
@@ -6310,7 +6310,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0361",
+      "content" : "https://localhost/pdf/0704.0361",
       "name" : "citation_pdf_url"
    },
    {
@@ -6342,7 +6342,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0936",
+      "content" : "https://localhost/pdf/0704.0936",
       "name" : "citation_pdf_url"
    },
    {
@@ -6370,7 +6370,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0770",
+      "content" : "https://localhost/pdf/0704.0770",
       "name" : "citation_pdf_url"
    },
    {
@@ -6406,7 +6406,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0612",
+      "content" : "https://localhost/pdf/0704.0612",
       "name" : "citation_pdf_url"
    },
    {
@@ -6450,7 +6450,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0255",
+      "content" : "https://localhost/pdf/0704.0255",
       "name" : "citation_pdf_url"
    },
    {
@@ -6490,7 +6490,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0109",
+      "content" : "https://localhost/pdf/0704.0109",
       "name" : "citation_pdf_url"
    },
    {
@@ -6530,7 +6530,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0625",
+      "content" : "https://localhost/pdf/0704.0625",
       "name" : "citation_pdf_url"
    },
    {
@@ -6558,7 +6558,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0010",
+      "content" : "https://localhost/pdf/0704.0010",
       "name" : "citation_pdf_url"
    },
    {
@@ -6590,7 +6590,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0015",
+      "content" : "https://localhost/pdf/0704.0015",
       "name" : "citation_pdf_url"
    },
    {
@@ -6650,7 +6650,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0458",
+      "content" : "https://localhost/pdf/0704.0458",
       "name" : "citation_pdf_url"
    },
    {
@@ -6686,7 +6686,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0856",
+      "content" : "https://localhost/pdf/0704.0856",
       "name" : "citation_pdf_url"
    },
    {
@@ -6718,7 +6718,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0359",
+      "content" : "https://localhost/pdf/0704.0359",
       "name" : "citation_pdf_url"
    },
    {
@@ -6754,7 +6754,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0406",
+      "content" : "https://localhost/pdf/0704.0406",
       "name" : "citation_pdf_url"
    },
    {
@@ -6794,7 +6794,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0462",
+      "content" : "https://localhost/pdf/0704.0462",
       "name" : "citation_pdf_url"
    },
    {
@@ -6822,7 +6822,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0614",
+      "content" : "https://localhost/pdf/0704.0614",
       "name" : "citation_pdf_url"
    },
    {
@@ -6858,7 +6858,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0983",
+      "content" : "https://localhost/pdf/0704.0983",
       "name" : "citation_pdf_url"
    },
    {
@@ -6890,7 +6890,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0142",
+      "content" : "https://localhost/pdf/0704.0142",
       "name" : "citation_pdf_url"
    },
    {
@@ -6922,7 +6922,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0013",
+      "content" : "https://localhost/pdf/0704.0013",
       "name" : "citation_pdf_url"
    },
    {
@@ -6962,7 +6962,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0578",
+      "content" : "https://localhost/pdf/0704.0578",
       "name" : "citation_pdf_url"
    },
    {
@@ -6994,7 +6994,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0820",
+      "content" : "https://localhost/pdf/0704.0820",
       "name" : "citation_pdf_url"
    },
    {
@@ -7030,7 +7030,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0477",
+      "content" : "https://localhost/pdf/0704.0477",
       "name" : "citation_pdf_url"
    },
    {
@@ -7062,7 +7062,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0583",
+      "content" : "https://localhost/pdf/0704.0583",
       "name" : "citation_pdf_url"
    },
    {
@@ -7090,7 +7090,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0111",
+      "content" : "https://localhost/pdf/0704.0111",
       "name" : "citation_pdf_url"
    },
    {
@@ -7130,7 +7130,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0495",
+      "content" : "https://localhost/pdf/0704.0495",
       "name" : "citation_pdf_url"
    },
    {
@@ -7170,7 +7170,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0282",
+      "content" : "https://localhost/pdf/0704.0282",
       "name" : "citation_pdf_url"
    },
    {
@@ -7210,7 +7210,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0986",
+      "content" : "https://localhost/pdf/0704.0986",
       "name" : "citation_pdf_url"
    },
    {
@@ -7246,7 +7246,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0586",
+      "content" : "https://localhost/pdf/0704.0586",
       "name" : "citation_pdf_url"
    },
    {
@@ -7298,7 +7298,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0311",
+      "content" : "https://localhost/pdf/0704.0311",
       "name" : "citation_pdf_url"
    },
    {
@@ -7338,7 +7338,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0700",
+      "content" : "https://localhost/pdf/0704.0700",
       "name" : "citation_pdf_url"
    },
    {
@@ -7370,7 +7370,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0638",
+      "content" : "https://localhost/pdf/0704.0638",
       "name" : "citation_pdf_url"
    },
    {
@@ -7406,7 +7406,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0206",
+      "content" : "https://localhost/pdf/0704.0206",
       "name" : "citation_pdf_url"
    },
    {
@@ -7438,7 +7438,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0808",
+      "content" : "https://localhost/pdf/0704.0808",
       "name" : "citation_pdf_url"
    },
    {
@@ -7474,7 +7474,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0389",
+      "content" : "https://localhost/pdf/0704.0389",
       "name" : "citation_pdf_url"
    },
    {
@@ -7510,7 +7510,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0904",
+      "content" : "https://localhost/pdf/0704.0904",
       "name" : "citation_pdf_url"
    },
    {
@@ -7546,7 +7546,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0105",
+      "content" : "https://localhost/pdf/0704.0105",
       "name" : "citation_pdf_url"
    },
    {
@@ -7582,7 +7582,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0433",
+      "content" : "https://localhost/pdf/0704.0433",
       "name" : "citation_pdf_url"
    },
    {
@@ -7610,7 +7610,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0434",
+      "content" : "https://localhost/pdf/0704.0434",
       "name" : "citation_pdf_url"
    },
    {
@@ -7642,7 +7642,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0943",
+      "content" : "https://localhost/pdf/0704.0943",
       "name" : "citation_pdf_url"
    },
    {
@@ -7690,7 +7690,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0422",
+      "content" : "https://localhost/pdf/0704.0422",
       "name" : "citation_pdf_url"
    },
    {
@@ -7722,7 +7722,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0180",
+      "content" : "https://localhost/pdf/0704.0180",
       "name" : "citation_pdf_url"
    },
    {
@@ -7754,7 +7754,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0199",
+      "content" : "https://localhost/pdf/0704.0199",
       "name" : "citation_pdf_url"
    },
    {
@@ -7782,7 +7782,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0766",
+      "content" : "https://localhost/pdf/0704.0766",
       "name" : "citation_pdf_url"
    },
    {
@@ -7810,7 +7810,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0077",
+      "content" : "https://localhost/pdf/0704.0077",
       "name" : "citation_pdf_url"
    },
    {
@@ -7838,7 +7838,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0788",
+      "content" : "https://localhost/pdf/0704.0788",
       "name" : "citation_pdf_url"
    },
    {
@@ -7922,7 +7922,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0170",
+      "content" : "https://localhost/pdf/0704.0170",
       "name" : "citation_pdf_url"
    },
    {
@@ -7962,7 +7962,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0603",
+      "content" : "https://localhost/pdf/0704.0603",
       "name" : "citation_pdf_url"
    },
    {
@@ -7998,7 +7998,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0844",
+      "content" : "https://localhost/pdf/0704.0844",
       "name" : "citation_pdf_url"
    },
    {
@@ -8030,7 +8030,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0995",
+      "content" : "https://localhost/pdf/0704.0995",
       "name" : "citation_pdf_url"
    },
    {
@@ -8078,7 +8078,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0948",
+      "content" : "https://localhost/pdf/0704.0948",
       "name" : "citation_pdf_url"
    },
    {
@@ -8110,7 +8110,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0231",
+      "content" : "https://localhost/pdf/0704.0231",
       "name" : "citation_pdf_url"
    },
    {
@@ -8142,7 +8142,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0103",
+      "content" : "https://localhost/pdf/0704.0103",
       "name" : "citation_pdf_url"
    },
    {
@@ -8182,7 +8182,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0650",
+      "content" : "https://localhost/pdf/0704.0650",
       "name" : "citation_pdf_url"
    },
    {
@@ -8222,7 +8222,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0944",
+      "content" : "https://localhost/pdf/0704.0944",
       "name" : "citation_pdf_url"
    },
    {
@@ -8278,7 +8278,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0591",
+      "content" : "https://localhost/pdf/0704.0591",
       "name" : "citation_pdf_url"
    },
    {
@@ -8314,7 +8314,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0404",
+      "content" : "https://localhost/pdf/0704.0404",
       "name" : "citation_pdf_url"
    },
    {
@@ -8358,7 +8358,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0858",
+      "content" : "https://localhost/pdf/0704.0858",
       "name" : "citation_pdf_url"
    },
    {
@@ -8398,7 +8398,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0956",
+      "content" : "https://localhost/pdf/0704.0956",
       "name" : "citation_pdf_url"
    },
    {
@@ -8490,7 +8490,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0454",
+      "content" : "https://localhost/pdf/0704.0454",
       "name" : "citation_pdf_url"
    },
    {
@@ -8526,7 +8526,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0676",
+      "content" : "https://localhost/pdf/0704.0676",
       "name" : "citation_pdf_url"
    },
    {
@@ -8562,7 +8562,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0144",
+      "content" : "https://localhost/pdf/0704.0144",
       "name" : "citation_pdf_url"
    },
    {
@@ -8618,7 +8618,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0190",
+      "content" : "https://localhost/pdf/0704.0190",
       "name" : "citation_pdf_url"
    },
    {
@@ -8666,7 +8666,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0868",
+      "content" : "https://localhost/pdf/0704.0868",
       "name" : "citation_pdf_url"
    },
    {
@@ -8694,7 +8694,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0363",
+      "content" : "https://localhost/pdf/0704.0363",
       "name" : "citation_pdf_url"
    },
    {
@@ -8730,7 +8730,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0763",
+      "content" : "https://localhost/pdf/0704.0763",
       "name" : "citation_pdf_url"
    },
    {
@@ -8758,7 +8758,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0026",
+      "content" : "https://localhost/pdf/0704.0026",
       "name" : "citation_pdf_url"
    },
    {
@@ -8794,7 +8794,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0553",
+      "content" : "https://localhost/pdf/0704.0553",
       "name" : "citation_pdf_url"
    },
    {
@@ -8826,7 +8826,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0104",
+      "content" : "https://localhost/pdf/0704.0104",
       "name" : "citation_pdf_url"
    },
    {
@@ -8862,7 +8862,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0185",
+      "content" : "https://localhost/pdf/0704.0185",
       "name" : "citation_pdf_url"
    },
    {
@@ -8898,7 +8898,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0575",
+      "content" : "https://localhost/pdf/0704.0575",
       "name" : "citation_pdf_url"
    },
    {
@@ -8950,7 +8950,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0017",
+      "content" : "https://localhost/pdf/0704.0017",
       "name" : "citation_pdf_url"
    },
    {
@@ -8986,7 +8986,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0702",
+      "content" : "https://localhost/pdf/0704.0702",
       "name" : "citation_pdf_url"
    },
    {
@@ -9018,7 +9018,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0169",
+      "content" : "https://localhost/pdf/0704.0169",
       "name" : "citation_pdf_url"
    },
    {
@@ -9062,7 +9062,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0632",
+      "content" : "https://localhost/pdf/0704.0632",
       "name" : "citation_pdf_url"
    },
    {
@@ -9090,7 +9090,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0671",
+      "content" : "https://localhost/pdf/0704.0671",
       "name" : "citation_pdf_url"
    },
    {
@@ -9158,7 +9158,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0177",
+      "content" : "https://localhost/pdf/0704.0177",
       "name" : "citation_pdf_url"
    },
    {
@@ -9194,7 +9194,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0792",
+      "content" : "https://localhost/pdf/0704.0792",
       "name" : "citation_pdf_url"
    },
    {
@@ -9230,7 +9230,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0849",
+      "content" : "https://localhost/pdf/0704.0849",
       "name" : "citation_pdf_url"
    },
    {
@@ -9262,7 +9262,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0079",
+      "content" : "https://localhost/pdf/0704.0079",
       "name" : "citation_pdf_url"
    },
    {
@@ -9290,7 +9290,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0559",
+      "content" : "https://localhost/pdf/0704.0559",
       "name" : "citation_pdf_url"
    },
    {
@@ -9326,7 +9326,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0221",
+      "content" : "https://localhost/pdf/0704.0221",
       "name" : "citation_pdf_url"
    },
    {
@@ -9370,7 +9370,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0896",
+      "content" : "https://localhost/pdf/0704.0896",
       "name" : "citation_pdf_url"
    },
    {
@@ -9414,7 +9414,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0677",
+      "content" : "https://localhost/pdf/0704.0677",
       "name" : "citation_pdf_url"
    },
    {
@@ -9458,7 +9458,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0938",
+      "content" : "https://localhost/pdf/0704.0938",
       "name" : "citation_pdf_url"
    },
    {
@@ -9498,7 +9498,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0356",
+      "content" : "https://localhost/pdf/0704.0356",
       "name" : "citation_pdf_url"
    },
    {
@@ -9538,7 +9538,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0035",
+      "content" : "https://localhost/pdf/0704.0035",
       "name" : "citation_pdf_url"
    },
    {
@@ -9586,7 +9586,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0585",
+      "content" : "https://localhost/pdf/0704.0585",
       "name" : "citation_pdf_url"
    },
    {
@@ -9622,7 +9622,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0254",
+      "content" : "https://localhost/pdf/0704.0254",
       "name" : "citation_pdf_url"
    },
    {
@@ -9670,7 +9670,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0880",
+      "content" : "https://localhost/pdf/0704.0880",
       "name" : "citation_pdf_url"
    },
    {
@@ -9702,7 +9702,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0537",
+      "content" : "https://localhost/pdf/0704.0537",
       "name" : "citation_pdf_url"
    },
    {
@@ -9730,7 +9730,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0581",
+      "content" : "https://localhost/pdf/0704.0581",
       "name" : "citation_pdf_url"
    },
    {
@@ -9762,7 +9762,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0646",
+      "content" : "https://localhost/pdf/0704.0646",
       "name" : "citation_pdf_url"
    },
    {
@@ -9806,7 +9806,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0837",
+      "content" : "https://localhost/pdf/0704.0837",
       "name" : "citation_pdf_url"
    },
    {
@@ -9842,7 +9842,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0681",
+      "content" : "https://localhost/pdf/0704.0681",
       "name" : "citation_pdf_url"
    },
    {
@@ -9874,7 +9874,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0809",
+      "content" : "https://localhost/pdf/0704.0809",
       "name" : "citation_pdf_url"
    },
    {
@@ -9910,7 +9910,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0761",
+      "content" : "https://localhost/pdf/0704.0761",
       "name" : "citation_pdf_url"
    },
    {
@@ -9954,7 +9954,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0642",
+      "content" : "https://localhost/pdf/0704.0642",
       "name" : "citation_pdf_url"
    },
    {
@@ -9982,7 +9982,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0566",
+      "content" : "https://localhost/pdf/0704.0566",
       "name" : "citation_pdf_url"
    },
    {
@@ -10018,7 +10018,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0323",
+      "content" : "https://localhost/pdf/0704.0323",
       "name" : "citation_pdf_url"
    },
    {
@@ -10050,7 +10050,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0891",
+      "content" : "https://localhost/pdf/0704.0891",
       "name" : "citation_pdf_url"
    },
    {
@@ -10082,7 +10082,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0775",
+      "content" : "https://localhost/pdf/0704.0775",
       "name" : "citation_pdf_url"
    },
    {
@@ -10118,7 +10118,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0240",
+      "content" : "https://localhost/pdf/0704.0240",
       "name" : "citation_pdf_url"
    },
    {
@@ -10170,7 +10170,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0475",
+      "content" : "https://localhost/pdf/0704.0475",
       "name" : "citation_pdf_url"
    },
    {
@@ -10218,7 +10218,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0262",
+      "content" : "https://localhost/pdf/0704.0262",
       "name" : "citation_pdf_url"
    },
    {
@@ -10258,7 +10258,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0271",
+      "content" : "https://localhost/pdf/0704.0271",
       "name" : "citation_pdf_url"
    },
    {
@@ -10298,7 +10298,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0023",
+      "content" : "https://localhost/pdf/0704.0023",
       "name" : "citation_pdf_url"
    },
    {
@@ -10338,7 +10338,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0784",
+      "content" : "https://localhost/pdf/0704.0784",
       "name" : "citation_pdf_url"
    },
    {
@@ -10374,7 +10374,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0528",
+      "content" : "https://localhost/pdf/0704.0528",
       "name" : "citation_pdf_url"
    },
    {
@@ -10418,7 +10418,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0392",
+      "content" : "https://localhost/pdf/0704.0392",
       "name" : "citation_pdf_url"
    },
    {
@@ -10454,7 +10454,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0869",
+      "content" : "https://localhost/pdf/0704.0869",
       "name" : "citation_pdf_url"
    },
    {
@@ -10486,7 +10486,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0797",
+      "content" : "https://localhost/pdf/0704.0797",
       "name" : "citation_pdf_url"
    },
    {
@@ -10526,7 +10526,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0673",
+      "content" : "https://localhost/pdf/0704.0673",
       "name" : "citation_pdf_url"
    },
    {
@@ -10566,7 +10566,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0078",
+      "content" : "https://localhost/pdf/0704.0078",
       "name" : "citation_pdf_url"
    },
    {
@@ -10602,7 +10602,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0790",
+      "content" : "https://localhost/pdf/0704.0790",
       "name" : "citation_pdf_url"
    },
    {
@@ -10654,7 +10654,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0300",
+      "content" : "https://localhost/pdf/0704.0300",
       "name" : "citation_pdf_url"
    },
    {
@@ -10694,7 +10694,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0569",
+      "content" : "https://localhost/pdf/0704.0569",
       "name" : "citation_pdf_url"
    },
    {
@@ -10754,7 +10754,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0466",
+      "content" : "https://localhost/pdf/0704.0466",
       "name" : "citation_pdf_url"
    },
    {
@@ -10782,7 +10782,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0555",
+      "content" : "https://localhost/pdf/0704.0555",
       "name" : "citation_pdf_url"
    },
    {
@@ -10822,7 +10822,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0486",
+      "content" : "https://localhost/pdf/0704.0486",
       "name" : "citation_pdf_url"
    },
    {
@@ -10850,7 +10850,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0365",
+      "content" : "https://localhost/pdf/0704.0365",
       "name" : "citation_pdf_url"
    },
    {
@@ -10890,7 +10890,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0413",
+      "content" : "https://localhost/pdf/0704.0413",
       "name" : "citation_pdf_url"
    },
    {
@@ -10934,7 +10934,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0181",
+      "content" : "https://localhost/pdf/0704.0181",
       "name" : "citation_pdf_url"
    },
    {
@@ -10966,7 +10966,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0374",
+      "content" : "https://localhost/pdf/0704.0374",
       "name" : "citation_pdf_url"
    },
    {
@@ -10994,7 +10994,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0018",
+      "content" : "https://localhost/pdf/0704.0018",
       "name" : "citation_pdf_url"
    },
    {
@@ -11026,7 +11026,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0184",
+      "content" : "https://localhost/pdf/0704.0184",
       "name" : "citation_pdf_url"
    },
    {
@@ -11078,7 +11078,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0758",
+      "content" : "https://localhost/pdf/0704.0758",
       "name" : "citation_pdf_url"
    },
    {
@@ -11114,7 +11114,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0256",
+      "content" : "https://localhost/pdf/0704.0256",
       "name" : "citation_pdf_url"
    },
    {
@@ -11150,7 +11150,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0386",
+      "content" : "https://localhost/pdf/0704.0386",
       "name" : "citation_pdf_url"
    },
    {
@@ -11186,7 +11186,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0217",
+      "content" : "https://localhost/pdf/0704.0217",
       "name" : "citation_pdf_url"
    },
    {
@@ -11218,7 +11218,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0224",
+      "content" : "https://localhost/pdf/0704.0224",
       "name" : "citation_pdf_url"
    },
    {
@@ -11258,7 +11258,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0045",
+      "content" : "https://localhost/pdf/0704.0045",
       "name" : "citation_pdf_url"
    },
    {
@@ -11290,7 +11290,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0573",
+      "content" : "https://localhost/pdf/0704.0573",
       "name" : "citation_pdf_url"
    },
    {
@@ -11318,7 +11318,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0417",
+      "content" : "https://localhost/pdf/0704.0417",
       "name" : "citation_pdf_url"
    },
    {
@@ -11350,7 +11350,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0663",
+      "content" : "https://localhost/pdf/0704.0663",
       "name" : "citation_pdf_url"
    },
    {
@@ -11382,7 +11382,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0796",
+      "content" : "https://localhost/pdf/0704.0796",
       "name" : "citation_pdf_url"
    },
    {
@@ -11482,7 +11482,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0253",
+      "content" : "https://localhost/pdf/0704.0253",
       "name" : "citation_pdf_url"
    },
    {
@@ -11546,7 +11546,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0401",
+      "content" : "https://localhost/pdf/0704.0401",
       "name" : "citation_pdf_url"
    },
    {
@@ -11614,7 +11614,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0126",
+      "content" : "https://localhost/pdf/0704.0126",
       "name" : "citation_pdf_url"
    },
    {
@@ -11642,7 +11642,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0014",
+      "content" : "https://localhost/pdf/0704.0014",
       "name" : "citation_pdf_url"
    },
    {
@@ -11670,7 +11670,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0229",
+      "content" : "https://localhost/pdf/0704.0229",
       "name" : "citation_pdf_url"
    },
    {
@@ -11706,7 +11706,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0996",
+      "content" : "https://localhost/pdf/0704.0996",
       "name" : "citation_pdf_url"
    },
    {
@@ -11746,7 +11746,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0046",
+      "content" : "https://localhost/pdf/0704.0046",
       "name" : "citation_pdf_url"
    },
    {
@@ -11774,7 +11774,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0747",
+      "content" : "https://localhost/pdf/0704.0747",
       "name" : "citation_pdf_url"
    },
    {
@@ -11806,7 +11806,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0656",
+      "content" : "https://localhost/pdf/0704.0656",
       "name" : "citation_pdf_url"
    },
    {
@@ -11862,7 +11862,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0653",
+      "content" : "https://localhost/pdf/0704.0653",
       "name" : "citation_pdf_url"
    },
    {
@@ -11894,7 +11894,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0274",
+      "content" : "https://localhost/pdf/0704.0274",
       "name" : "citation_pdf_url"
    },
    {
@@ -12098,7 +12098,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0806",
+      "content" : "https://localhost/pdf/0704.0806",
       "name" : "citation_pdf_url"
    },
    {
@@ -12134,7 +12134,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0216",
+      "content" : "https://localhost/pdf/0704.0216",
       "name" : "citation_pdf_url"
    },
    {
@@ -12170,7 +12170,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0590",
+      "content" : "https://localhost/pdf/0704.0590",
       "name" : "citation_pdf_url"
    },
    {
@@ -12198,7 +12198,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0309",
+      "content" : "https://localhost/pdf/0704.0309",
       "name" : "citation_pdf_url"
    },
    {
@@ -12226,7 +12226,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0069",
+      "content" : "https://localhost/pdf/0704.0069",
       "name" : "citation_pdf_url"
    },
    {
@@ -12274,7 +12274,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0873",
+      "content" : "https://localhost/pdf/0704.0873",
       "name" : "citation_pdf_url"
    },
    {
@@ -12318,7 +12318,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0826",
+      "content" : "https://localhost/pdf/0704.0826",
       "name" : "citation_pdf_url"
    },
    {
@@ -12354,7 +12354,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0135",
+      "content" : "https://localhost/pdf/0704.0135",
       "name" : "citation_pdf_url"
    },
    {
@@ -12386,7 +12386,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0438",
+      "content" : "https://localhost/pdf/0704.0438",
       "name" : "citation_pdf_url"
    },
    {
@@ -12430,7 +12430,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0421",
+      "content" : "https://localhost/pdf/0704.0421",
       "name" : "citation_pdf_url"
    },
    {
@@ -12470,7 +12470,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0709",
+      "content" : "https://localhost/pdf/0704.0709",
       "name" : "citation_pdf_url"
    },
    {
@@ -12506,7 +12506,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0455",
+      "content" : "https://localhost/pdf/0704.0455",
       "name" : "citation_pdf_url"
    },
    {
@@ -12546,7 +12546,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0931",
+      "content" : "https://localhost/pdf/0704.0931",
       "name" : "citation_pdf_url"
    },
    {
@@ -12586,7 +12586,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0328",
+      "content" : "https://localhost/pdf/0704.0328",
       "name" : "citation_pdf_url"
    },
    {
@@ -12618,7 +12618,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0342",
+      "content" : "https://localhost/pdf/0704.0342",
       "name" : "citation_pdf_url"
    },
    {
@@ -12650,7 +12650,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0967",
+      "content" : "https://localhost/pdf/0704.0967",
       "name" : "citation_pdf_url"
    },
    {
@@ -12682,7 +12682,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0976",
+      "content" : "https://localhost/pdf/0704.0976",
       "name" : "citation_pdf_url"
    },
    {
@@ -12754,7 +12754,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0604",
+      "content" : "https://localhost/pdf/0704.0604",
       "name" : "citation_pdf_url"
    },
    {
@@ -12790,7 +12790,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0691",
+      "content" : "https://localhost/pdf/0704.0691",
       "name" : "citation_pdf_url"
    },
    {
@@ -12826,7 +12826,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0020",
+      "content" : "https://localhost/pdf/0704.0020",
       "name" : "citation_pdf_url"
    },
    {
@@ -12854,7 +12854,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0981",
+      "content" : "https://localhost/pdf/0704.0981",
       "name" : "citation_pdf_url"
    },
    {
@@ -12894,7 +12894,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0482",
+      "content" : "https://localhost/pdf/0704.0482",
       "name" : "citation_pdf_url"
    },
    {
@@ -12922,7 +12922,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0889",
+      "content" : "https://localhost/pdf/0704.0889",
       "name" : "citation_pdf_url"
    },
    {
@@ -12962,7 +12962,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0029",
+      "content" : "https://localhost/pdf/0704.0029",
       "name" : "citation_pdf_url"
    },
    {
@@ -12998,7 +12998,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0689",
+      "content" : "https://localhost/pdf/0704.0689",
       "name" : "citation_pdf_url"
    },
    {
@@ -13030,7 +13030,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0041",
+      "content" : "https://localhost/pdf/0704.0041",
       "name" : "citation_pdf_url"
    },
    {
@@ -13074,7 +13074,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0538",
+      "content" : "https://localhost/pdf/0704.0538",
       "name" : "citation_pdf_url"
    },
    {
@@ -13106,7 +13106,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0860",
+      "content" : "https://localhost/pdf/0704.0860",
       "name" : "citation_pdf_url"
    },
    {
@@ -13158,7 +13158,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0219",
+      "content" : "https://localhost/pdf/0704.0219",
       "name" : "citation_pdf_url"
    },
    {
@@ -13190,7 +13190,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0963",
+      "content" : "https://localhost/pdf/0704.0963",
       "name" : "citation_pdf_url"
    },
    {
@@ -13246,7 +13246,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0424",
+      "content" : "https://localhost/pdf/0704.0424",
       "name" : "citation_pdf_url"
    },
    {
@@ -13274,7 +13274,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0918",
+      "content" : "https://localhost/pdf/0704.0918",
       "name" : "citation_pdf_url"
    },
    {
@@ -13306,7 +13306,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0260",
+      "content" : "https://localhost/pdf/0704.0260",
       "name" : "citation_pdf_url"
    },
    {
@@ -13342,7 +13342,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0613",
+      "content" : "https://localhost/pdf/0704.0613",
       "name" : "citation_pdf_url"
    },
    {
@@ -13382,7 +13382,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0106",
+      "content" : "https://localhost/pdf/0704.0106",
       "name" : "citation_pdf_url"
    },
    {
@@ -13418,7 +13418,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0467",
+      "content" : "https://localhost/pdf/0704.0467",
       "name" : "citation_pdf_url"
    },
    {
@@ -13458,7 +13458,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0658",
+      "content" : "https://localhost/pdf/0704.0658",
       "name" : "citation_pdf_url"
    },
    {
@@ -13506,7 +13506,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0701",
+      "content" : "https://localhost/pdf/0704.0701",
       "name" : "citation_pdf_url"
    },
    {
@@ -13534,7 +13534,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0123",
+      "content" : "https://localhost/pdf/0704.0123",
       "name" : "citation_pdf_url"
    },
    {
@@ -13574,7 +13574,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0259",
+      "content" : "https://localhost/pdf/0704.0259",
       "name" : "citation_pdf_url"
    },
    {
@@ -13602,7 +13602,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0153",
+      "content" : "https://localhost/pdf/0704.0153",
       "name" : "citation_pdf_url"
    },
    {
@@ -13642,7 +13642,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0379",
+      "content" : "https://localhost/pdf/0704.0379",
       "name" : "citation_pdf_url"
    },
    {
@@ -13690,7 +13690,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0203",
+      "content" : "https://localhost/pdf/0704.0203",
       "name" : "citation_pdf_url"
    },
    {
@@ -13730,7 +13730,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0158",
+      "content" : "https://localhost/pdf/0704.0158",
       "name" : "citation_pdf_url"
    },
    {
@@ -13758,7 +13758,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0364",
+      "content" : "https://localhost/pdf/0704.0364",
       "name" : "citation_pdf_url"
    },
    {
@@ -13794,7 +13794,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0520",
+      "content" : "https://localhost/pdf/0704.0520",
       "name" : "citation_pdf_url"
    },
    {
@@ -13822,7 +13822,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0875",
+      "content" : "https://localhost/pdf/0704.0875",
       "name" : "citation_pdf_url"
    },
    {
@@ -13862,7 +13862,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0913",
+      "content" : "https://localhost/pdf/0704.0913",
       "name" : "citation_pdf_url"
    },
    {
@@ -13890,7 +13890,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0094",
+      "content" : "https://localhost/pdf/0704.0094",
       "name" : "citation_pdf_url"
    },
    {
@@ -13918,7 +13918,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0004",
+      "content" : "https://localhost/pdf/0704.0004",
       "name" : "citation_pdf_url"
    },
    {
@@ -13970,7 +13970,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0977",
+      "content" : "https://localhost/pdf/0704.0977",
       "name" : "citation_pdf_url"
    },
    {
@@ -14002,7 +14002,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0964",
+      "content" : "https://localhost/pdf/0704.0964",
       "name" : "citation_pdf_url"
    },
    {
@@ -14030,7 +14030,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0280",
+      "content" : "https://localhost/pdf/0704.0280",
       "name" : "citation_pdf_url"
    },
    {
@@ -14058,7 +14058,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0383",
+      "content" : "https://localhost/pdf/0704.0383",
       "name" : "citation_pdf_url"
    },
    {
@@ -14090,7 +14090,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0817",
+      "content" : "https://localhost/pdf/0704.0817",
       "name" : "citation_pdf_url"
    },
    {
@@ -14130,7 +14130,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0426",
+      "content" : "https://localhost/pdf/0704.0426",
       "name" : "citation_pdf_url"
    },
    {
@@ -14162,7 +14162,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0565",
+      "content" : "https://localhost/pdf/0704.0565",
       "name" : "citation_pdf_url"
    },
    {
@@ -14198,7 +14198,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0439",
+      "content" : "https://localhost/pdf/0704.0439",
       "name" : "citation_pdf_url"
    },
    {
@@ -14242,7 +14242,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0084",
+      "content" : "https://localhost/pdf/0704.0084",
       "name" : "citation_pdf_url"
    },
    {
@@ -14282,7 +14282,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0675",
+      "content" : "https://localhost/pdf/0704.0675",
       "name" : "citation_pdf_url"
    },
    {
@@ -14314,7 +14314,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0067",
+      "content" : "https://localhost/pdf/0704.0067",
       "name" : "citation_pdf_url"
    },
    {
@@ -14346,7 +14346,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0704",
+      "content" : "https://localhost/pdf/0704.0704",
       "name" : "citation_pdf_url"
    },
    {
@@ -14386,7 +14386,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0119",
+      "content" : "https://localhost/pdf/0704.0119",
       "name" : "citation_pdf_url"
    },
    {
@@ -14422,7 +14422,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0781",
+      "content" : "https://localhost/pdf/0704.0781",
       "name" : "citation_pdf_url"
    },
    {
@@ -14450,7 +14450,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0049",
+      "content" : "https://localhost/pdf/0704.0049",
       "name" : "citation_pdf_url"
    },
    {
@@ -14494,7 +14494,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0628",
+      "content" : "https://localhost/pdf/0704.0628",
       "name" : "citation_pdf_url"
    },
    {
@@ -14526,7 +14526,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0074",
+      "content" : "https://localhost/pdf/0704.0074",
       "name" : "citation_pdf_url"
    },
    {
@@ -14562,7 +14562,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0377",
+      "content" : "https://localhost/pdf/0704.0377",
       "name" : "citation_pdf_url"
    },
    {
@@ -14594,7 +14594,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0588",
+      "content" : "https://localhost/pdf/0704.0588",
       "name" : "citation_pdf_url"
    },
    {
@@ -14630,7 +14630,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0196",
+      "content" : "https://localhost/pdf/0704.0196",
       "name" : "citation_pdf_url"
    },
    {
@@ -14666,7 +14666,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0057",
+      "content" : "https://localhost/pdf/0704.0057",
       "name" : "citation_pdf_url"
    },
    {
@@ -14694,7 +14694,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0416",
+      "content" : "https://localhost/pdf/0704.0416",
       "name" : "citation_pdf_url"
    },
    {
@@ -14738,7 +14738,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0804",
+      "content" : "https://localhost/pdf/0704.0804",
       "name" : "citation_pdf_url"
    },
    {
@@ -14774,7 +14774,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0828",
+      "content" : "https://localhost/pdf/0704.0828",
       "name" : "citation_pdf_url"
    },
    {
@@ -14814,7 +14814,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0192",
+      "content" : "https://localhost/pdf/0704.0192",
       "name" : "citation_pdf_url"
    },
    {
@@ -14850,7 +14850,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0649",
+      "content" : "https://localhost/pdf/0704.0649",
       "name" : "citation_pdf_url"
    },
    {
@@ -14886,7 +14886,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0452",
+      "content" : "https://localhost/pdf/0704.0452",
       "name" : "citation_pdf_url"
    },
    {
@@ -14922,7 +14922,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0402",
+      "content" : "https://localhost/pdf/0704.0402",
       "name" : "citation_pdf_url"
    },
    {
@@ -14958,7 +14958,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0657",
+      "content" : "https://localhost/pdf/0704.0657",
       "name" : "citation_pdf_url"
    },
    {
@@ -14986,7 +14986,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0073",
+      "content" : "https://localhost/pdf/0704.0073",
       "name" : "citation_pdf_url"
    },
    {
@@ -15014,7 +15014,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0972",
+      "content" : "https://localhost/pdf/0704.0972",
       "name" : "citation_pdf_url"
    },
    {
@@ -15054,7 +15054,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0919",
+      "content" : "https://localhost/pdf/0704.0919",
       "name" : "citation_pdf_url"
    },
    {
@@ -15086,7 +15086,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0786",
+      "content" : "https://localhost/pdf/0704.0786",
       "name" : "citation_pdf_url"
    },
    {
@@ -15114,7 +15114,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0420",
+      "content" : "https://localhost/pdf/0704.0420",
       "name" : "citation_pdf_url"
    },
    {
@@ -15150,7 +15150,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0288",
+      "content" : "https://localhost/pdf/0704.0288",
       "name" : "citation_pdf_url"
    },
    {
@@ -15186,7 +15186,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0080",
+      "content" : "https://localhost/pdf/0704.0080",
       "name" : "citation_pdf_url"
    },
    {
@@ -15214,7 +15214,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0687",
+      "content" : "https://localhost/pdf/0704.0687",
       "name" : "citation_pdf_url"
    },
    {
@@ -15246,7 +15246,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0448",
+      "content" : "https://localhost/pdf/0704.0448",
       "name" : "citation_pdf_url"
    },
    {
@@ -15294,7 +15294,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0664",
+      "content" : "https://localhost/pdf/0704.0664",
       "name" : "citation_pdf_url"
    },
    {
@@ -15326,7 +15326,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0742",
+      "content" : "https://localhost/pdf/0704.0742",
       "name" : "citation_pdf_url"
    },
    {
@@ -15354,7 +15354,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0236",
+      "content" : "https://localhost/pdf/0704.0236",
       "name" : "citation_pdf_url"
    },
    {
@@ -15390,7 +15390,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0647",
+      "content" : "https://localhost/pdf/0704.0647",
       "name" : "citation_pdf_url"
    },
    {
@@ -15426,7 +15426,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0881",
+      "content" : "https://localhost/pdf/0704.0881",
       "name" : "citation_pdf_url"
    },
    {
@@ -15454,7 +15454,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0354",
+      "content" : "https://localhost/pdf/0704.0354",
       "name" : "citation_pdf_url"
    },
    {
@@ -15482,7 +15482,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0295",
+      "content" : "https://localhost/pdf/0704.0295",
       "name" : "citation_pdf_url"
    },
    {
@@ -15582,7 +15582,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0780",
+      "content" : "https://localhost/pdf/0704.0780",
       "name" : "citation_pdf_url"
    },
    {
@@ -15614,7 +15614,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0052",
+      "content" : "https://localhost/pdf/0704.0052",
       "name" : "citation_pdf_url"
    },
    {
@@ -15658,7 +15658,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0794",
+      "content" : "https://localhost/pdf/0704.0794",
       "name" : "citation_pdf_url"
    },
    {
@@ -15710,7 +15710,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0771",
+      "content" : "https://localhost/pdf/0704.0771",
       "name" : "citation_pdf_url"
    },
    {
@@ -15738,7 +15738,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0497",
+      "content" : "https://localhost/pdf/0704.0497",
       "name" : "citation_pdf_url"
    },
    {
@@ -15770,7 +15770,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0631",
+      "content" : "https://localhost/pdf/0704.0631",
       "name" : "citation_pdf_url"
    },
    {
@@ -15810,7 +15810,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0863",
+      "content" : "https://localhost/pdf/0704.0863",
       "name" : "citation_pdf_url"
    },
    {
@@ -15854,7 +15854,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0114",
+      "content" : "https://localhost/pdf/0704.0114",
       "name" : "citation_pdf_url"
    },
    {
@@ -15890,7 +15890,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0030",
+      "content" : "https://localhost/pdf/0704.0030",
       "name" : "citation_pdf_url"
    },
    {
@@ -15922,7 +15922,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0987",
+      "content" : "https://localhost/pdf/0704.0987",
       "name" : "citation_pdf_url"
    },
    {
@@ -15962,7 +15962,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0312",
+      "content" : "https://localhost/pdf/0704.0312",
       "name" : "citation_pdf_url"
    },
    {
@@ -15998,7 +15998,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0971",
+      "content" : "https://localhost/pdf/0704.0971",
       "name" : "citation_pdf_url"
    },
    {
@@ -16038,7 +16038,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0344",
+      "content" : "https://localhost/pdf/0704.0344",
       "name" : "citation_pdf_url"
    },
    {
@@ -16066,7 +16066,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0556",
+      "content" : "https://localhost/pdf/0704.0556",
       "name" : "citation_pdf_url"
    },
    {
@@ -16094,7 +16094,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0012",
+      "content" : "https://localhost/pdf/0704.0012",
       "name" : "citation_pdf_url"
    },
    {
@@ -16130,7 +16130,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0955",
+      "content" : "https://localhost/pdf/0704.0955",
       "name" : "citation_pdf_url"
    },
    {
@@ -16170,7 +16170,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0782",
+      "content" : "https://localhost/pdf/0704.0782",
       "name" : "citation_pdf_url"
    },
    {
@@ -16202,7 +16202,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0836",
+      "content" : "https://localhost/pdf/0704.0836",
       "name" : "citation_pdf_url"
    },
    {
@@ -16250,7 +16250,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0261",
+      "content" : "https://localhost/pdf/0704.0261",
       "name" : "citation_pdf_url"
    },
    {
@@ -16282,7 +16282,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0430",
+      "content" : "https://localhost/pdf/0704.0430",
       "name" : "citation_pdf_url"
    },
    {
@@ -16314,7 +16314,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0304",
+      "content" : "https://localhost/pdf/0704.0304",
       "name" : "citation_pdf_url"
    },
    {
@@ -16342,7 +16342,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0063",
+      "content" : "https://localhost/pdf/0704.0063",
       "name" : "citation_pdf_url"
    },
    {
@@ -16378,7 +16378,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0696",
+      "content" : "https://localhost/pdf/0704.0696",
       "name" : "citation_pdf_url"
    },
    {
@@ -16414,7 +16414,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0593",
+      "content" : "https://localhost/pdf/0704.0593",
       "name" : "citation_pdf_url"
    },
    {
@@ -16446,7 +16446,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0965",
+      "content" : "https://localhost/pdf/0704.0965",
       "name" : "citation_pdf_url"
    },
    {
@@ -16482,7 +16482,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0643",
+      "content" : "https://localhost/pdf/0704.0643",
       "name" : "citation_pdf_url"
    },
    {
@@ -16514,7 +16514,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0241",
+      "content" : "https://localhost/pdf/0704.0241",
       "name" : "citation_pdf_url"
    },
    {
@@ -16558,7 +16558,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0928",
+      "content" : "https://localhost/pdf/0704.0928",
       "name" : "citation_pdf_url"
    },
    {
@@ -16610,7 +16610,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0864",
+      "content" : "https://localhost/pdf/0704.0864",
       "name" : "citation_pdf_url"
    },
    {
@@ -16646,7 +16646,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0053",
+      "content" : "https://localhost/pdf/0704.0053",
       "name" : "citation_pdf_url"
    },
    {
@@ -16682,7 +16682,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0773",
+      "content" : "https://localhost/pdf/0704.0773",
       "name" : "citation_pdf_url"
    },
    {
@@ -16718,7 +16718,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0510",
+      "content" : "https://localhost/pdf/0704.0510",
       "name" : "citation_pdf_url"
    },
    {
@@ -16762,7 +16762,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0879",
+      "content" : "https://localhost/pdf/0704.0879",
       "name" : "citation_pdf_url"
    },
    {
@@ -16790,7 +16790,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0811",
+      "content" : "https://localhost/pdf/0704.0811",
       "name" : "citation_pdf_url"
    },
    {
@@ -16826,7 +16826,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0038",
+      "content" : "https://localhost/pdf/0704.0038",
       "name" : "citation_pdf_url"
    },
    {
@@ -16858,7 +16858,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0444",
+      "content" : "https://localhost/pdf/0704.0444",
       "name" : "citation_pdf_url"
    },
    {
@@ -16894,7 +16894,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0194",
+      "content" : "https://localhost/pdf/0704.0194",
       "name" : "citation_pdf_url"
    },
    {
@@ -16942,7 +16942,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0731",
+      "content" : "https://localhost/pdf/0704.0731",
       "name" : "citation_pdf_url"
    },
    {
@@ -16978,7 +16978,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0277",
+      "content" : "https://localhost/pdf/0704.0277",
       "name" : "citation_pdf_url"
    },
    {
@@ -17010,7 +17010,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0036",
+      "content" : "https://localhost/pdf/0704.0036",
       "name" : "citation_pdf_url"
    },
    {
@@ -17046,7 +17046,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0511",
+      "content" : "https://localhost/pdf/0704.0511",
       "name" : "citation_pdf_url"
    },
    {
@@ -17078,7 +17078,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0252",
+      "content" : "https://localhost/pdf/0704.0252",
       "name" : "citation_pdf_url"
    },
    {
@@ -17106,7 +17106,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0922",
+      "content" : "https://localhost/pdf/0704.0922",
       "name" : "citation_pdf_url"
    },
    {
@@ -17142,7 +17142,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0530",
+      "content" : "https://localhost/pdf/0704.0530",
       "name" : "citation_pdf_url"
    },
    {
@@ -17182,7 +17182,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0945",
+      "content" : "https://localhost/pdf/0704.0945",
       "name" : "citation_pdf_url"
    },
    {
@@ -17214,7 +17214,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0302",
+      "content" : "https://localhost/pdf/0704.0302",
       "name" : "citation_pdf_url"
    },
    {
@@ -17250,7 +17250,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0580",
+      "content" : "https://localhost/pdf/0704.0580",
       "name" : "citation_pdf_url"
    },
    {
@@ -17298,7 +17298,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0293",
+      "content" : "https://localhost/pdf/0704.0293",
       "name" : "citation_pdf_url"
    },
    {
@@ -17362,7 +17362,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0227",
+      "content" : "https://localhost/pdf/0704.0227",
       "name" : "citation_pdf_url"
    },
    {
@@ -17410,7 +17410,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0925",
+      "content" : "https://localhost/pdf/0704.0925",
       "name" : "citation_pdf_url"
    },
    {
@@ -17442,7 +17442,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0842",
+      "content" : "https://localhost/pdf/0704.0842",
       "name" : "citation_pdf_url"
    },
    {
@@ -17482,7 +17482,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0768",
+      "content" : "https://localhost/pdf/0704.0768",
       "name" : "citation_pdf_url"
    },
    {
@@ -17510,7 +17510,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0545",
+      "content" : "https://localhost/pdf/0704.0545",
       "name" : "citation_pdf_url"
    },
    {
@@ -17538,7 +17538,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0097",
+      "content" : "https://localhost/pdf/0704.0097",
       "name" : "citation_pdf_url"
    },
    {
@@ -17570,7 +17570,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0008",
+      "content" : "https://localhost/pdf/0704.0008",
       "name" : "citation_pdf_url"
    },
    {
@@ -17614,7 +17614,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0570",
+      "content" : "https://localhost/pdf/0704.0570",
       "name" : "citation_pdf_url"
    },
    {
@@ -17658,7 +17658,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0450",
+      "content" : "https://localhost/pdf/0704.0450",
       "name" : "citation_pdf_url"
    },
    {
@@ -17698,7 +17698,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0007",
+      "content" : "https://localhost/pdf/0704.0007",
       "name" : "citation_pdf_url"
    },
    {
@@ -17734,7 +17734,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0684",
+      "content" : "https://localhost/pdf/0704.0684",
       "name" : "citation_pdf_url"
    },
    {
@@ -17778,7 +17778,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0764",
+      "content" : "https://localhost/pdf/0704.0764",
       "name" : "citation_pdf_url"
    },
    {
@@ -17842,7 +17842,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0370",
+      "content" : "https://localhost/pdf/0704.0370",
       "name" : "citation_pdf_url"
    },
    {
@@ -17874,7 +17874,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0686",
+      "content" : "https://localhost/pdf/0704.0686",
       "name" : "citation_pdf_url"
    },
    {
@@ -17910,7 +17910,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0552",
+      "content" : "https://localhost/pdf/0704.0552",
       "name" : "citation_pdf_url"
    },
    {
@@ -17938,7 +17938,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0281",
+      "content" : "https://localhost/pdf/0704.0281",
       "name" : "citation_pdf_url"
    },
    {
@@ -17974,7 +17974,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0279",
+      "content" : "https://localhost/pdf/0704.0279",
       "name" : "citation_pdf_url"
    },
    {
@@ -18034,7 +18034,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0746",
+      "content" : "https://localhost/pdf/0704.0746",
       "name" : "citation_pdf_url"
    },
    {
@@ -18066,7 +18066,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0071",
+      "content" : "https://localhost/pdf/0704.0071",
       "name" : "citation_pdf_url"
    },
    {
@@ -18098,7 +18098,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0831",
+      "content" : "https://localhost/pdf/0704.0831",
       "name" : "citation_pdf_url"
    },
    {
@@ -18126,7 +18126,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0358",
+      "content" : "https://localhost/pdf/0704.0358",
       "name" : "citation_pdf_url"
    },
    {
@@ -18166,7 +18166,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0637",
+      "content" : "https://localhost/pdf/0704.0637",
       "name" : "citation_pdf_url"
    },
    {
@@ -18206,7 +18206,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0179",
+      "content" : "https://localhost/pdf/0704.0179",
       "name" : "citation_pdf_url"
    },
    {
@@ -18238,7 +18238,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0957",
+      "content" : "https://localhost/pdf/0704.0957",
       "name" : "citation_pdf_url"
    },
    {
@@ -18290,7 +18290,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0244",
+      "content" : "https://localhost/pdf/0704.0244",
       "name" : "citation_pdf_url"
    },
    {
@@ -18342,7 +18342,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0654",
+      "content" : "https://localhost/pdf/0704.0654",
       "name" : "citation_pdf_url"
    },
    {
@@ -18370,7 +18370,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0841",
+      "content" : "https://localhost/pdf/0704.0841",
       "name" : "citation_pdf_url"
    },
    {
@@ -18426,7 +18426,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0912",
+      "content" : "https://localhost/pdf/0704.0912",
       "name" : "citation_pdf_url"
    },
    {
@@ -18454,7 +18454,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0315",
+      "content" : "https://localhost/pdf/0704.0315",
       "name" : "citation_pdf_url"
    },
    {
@@ -18486,7 +18486,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0031",
+      "content" : "https://localhost/pdf/0704.0031",
       "name" : "citation_pdf_url"
    },
    {
@@ -18526,7 +18526,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0729",
+      "content" : "https://localhost/pdf/0704.0729",
       "name" : "citation_pdf_url"
    },
    {
@@ -18558,7 +18558,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0391",
+      "content" : "https://localhost/pdf/0704.0391",
       "name" : "citation_pdf_url"
    },
    {
@@ -18606,7 +18606,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0660",
+      "content" : "https://localhost/pdf/0704.0660",
       "name" : "citation_pdf_url"
    },
    {
@@ -18646,7 +18646,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0117",
+      "content" : "https://localhost/pdf/0704.0117",
       "name" : "citation_pdf_url"
    },
    {
@@ -18678,7 +18678,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0403",
+      "content" : "https://localhost/pdf/0704.0403",
       "name" : "citation_pdf_url"
    },
    {
@@ -18710,7 +18710,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0202",
+      "content" : "https://localhost/pdf/0704.0202",
       "name" : "citation_pdf_url"
    },
    {
@@ -18738,7 +18738,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0644",
+      "content" : "https://localhost/pdf/0704.0644",
       "name" : "citation_pdf_url"
    },
    {
@@ -18778,7 +18778,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0819",
+      "content" : "https://localhost/pdf/0704.0819",
       "name" : "citation_pdf_url"
    },
    {
@@ -18822,7 +18822,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0855",
+      "content" : "https://localhost/pdf/0704.0855",
       "name" : "citation_pdf_url"
    },
    {
@@ -18866,7 +18866,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0212",
+      "content" : "https://localhost/pdf/0704.0212",
       "name" : "citation_pdf_url"
    },
    {
@@ -18906,7 +18906,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0474",
+      "content" : "https://localhost/pdf/0704.0474",
       "name" : "citation_pdf_url"
    },
    {
@@ -18938,7 +18938,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0335",
+      "content" : "https://localhost/pdf/0704.0335",
       "name" : "citation_pdf_url"
    },
    {
@@ -18966,7 +18966,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0110",
+      "content" : "https://localhost/pdf/0704.0110",
       "name" : "citation_pdf_url"
    },
    {
@@ -18994,7 +18994,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0698",
+      "content" : "https://localhost/pdf/0704.0698",
       "name" : "citation_pdf_url"
    },
    {
@@ -19038,7 +19038,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0610",
+      "content" : "https://localhost/pdf/0704.0610",
       "name" : "citation_pdf_url"
    },
    {
@@ -19070,7 +19070,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0220",
+      "content" : "https://localhost/pdf/0704.0220",
       "name" : "citation_pdf_url"
    },
    {
@@ -19130,7 +19130,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0139",
+      "content" : "https://localhost/pdf/0704.0139",
       "name" : "citation_pdf_url"
    },
    {
@@ -19174,7 +19174,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0973",
+      "content" : "https://localhost/pdf/0704.0973",
       "name" : "citation_pdf_url"
    },
    {
@@ -19214,7 +19214,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0491",
+      "content" : "https://localhost/pdf/0704.0491",
       "name" : "citation_pdf_url"
    },
    {
@@ -19266,7 +19266,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0534",
+      "content" : "https://localhost/pdf/0704.0534",
       "name" : "citation_pdf_url"
    },
    {
@@ -19302,7 +19302,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0215",
+      "content" : "https://localhost/pdf/0704.0215",
       "name" : "citation_pdf_url"
    },
    {
@@ -19330,7 +19330,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0321",
+      "content" : "https://localhost/pdf/0704.0321",
       "name" : "citation_pdf_url"
    },
    {
@@ -19370,7 +19370,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0409",
+      "content" : "https://localhost/pdf/0704.0409",
       "name" : "citation_pdf_url"
    },
    {
@@ -19418,7 +19418,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0375",
+      "content" : "https://localhost/pdf/0704.0375",
       "name" : "citation_pdf_url"
    },
    {
@@ -19458,7 +19458,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0267",
+      "content" : "https://localhost/pdf/0704.0267",
       "name" : "citation_pdf_url"
    },
    {
@@ -19486,7 +19486,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0040",
+      "content" : "https://localhost/pdf/0704.0040",
       "name" : "citation_pdf_url"
    },
    {
@@ -19514,7 +19514,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0648",
+      "content" : "https://localhost/pdf/0704.0648",
       "name" : "citation_pdf_url"
    },
    {
@@ -19546,7 +19546,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0755",
+      "content" : "https://localhost/pdf/0704.0755",
       "name" : "citation_pdf_url"
    },
    {
@@ -19582,7 +19582,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0507",
+      "content" : "https://localhost/pdf/0704.0507",
       "name" : "citation_pdf_url"
    },
    {
@@ -19610,7 +19610,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0883",
+      "content" : "https://localhost/pdf/0704.0883",
       "name" : "citation_pdf_url"
    },
    {
@@ -19654,7 +19654,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0316",
+      "content" : "https://localhost/pdf/0704.0316",
       "name" : "citation_pdf_url"
    },
    {
@@ -19690,7 +19690,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0608",
+      "content" : "https://localhost/pdf/0704.0608",
       "name" : "citation_pdf_url"
    },
    {
@@ -19730,7 +19730,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0172",
+      "content" : "https://localhost/pdf/0704.0172",
       "name" : "citation_pdf_url"
    },
    {
@@ -19774,7 +19774,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0776",
+      "content" : "https://localhost/pdf/0704.0776",
       "name" : "citation_pdf_url"
    },
    {
@@ -19814,7 +19814,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0814",
+      "content" : "https://localhost/pdf/0704.0814",
       "name" : "citation_pdf_url"
    },
    {
@@ -19850,7 +19850,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0527",
+      "content" : "https://localhost/pdf/0704.0527",
       "name" : "citation_pdf_url"
    },
    {
@@ -19882,7 +19882,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0242",
+      "content" : "https://localhost/pdf/0704.0242",
       "name" : "citation_pdf_url"
    },
    {
@@ -19918,7 +19918,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0900",
+      "content" : "https://localhost/pdf/0704.0900",
       "name" : "citation_pdf_url"
    },
    {
@@ -19954,7 +19954,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0039",
+      "content" : "https://localhost/pdf/0704.0039",
       "name" : "citation_pdf_url"
    },
    {
@@ -19986,7 +19986,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0668",
+      "content" : "https://localhost/pdf/0704.0668",
       "name" : "citation_pdf_url"
    },
    {
@@ -20022,7 +20022,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0589",
+      "content" : "https://localhost/pdf/0704.0589",
       "name" : "citation_pdf_url"
    },
    {
@@ -20062,7 +20062,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0470",
+      "content" : "https://localhost/pdf/0704.0470",
       "name" : "citation_pdf_url"
    },
    {
@@ -20090,7 +20090,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0283",
+      "content" : "https://localhost/pdf/0704.0283",
       "name" : "citation_pdf_url"
    },
    {
@@ -20134,7 +20134,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0483",
+      "content" : "https://localhost/pdf/0704.0483",
       "name" : "citation_pdf_url"
    },
    {
@@ -20182,7 +20182,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0560",
+      "content" : "https://localhost/pdf/0704.0560",
       "name" : "citation_pdf_url"
    },
    {
@@ -20214,7 +20214,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0284",
+      "content" : "https://localhost/pdf/0704.0284",
       "name" : "citation_pdf_url"
    },
    {
@@ -20246,7 +20246,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0669",
+      "content" : "https://localhost/pdf/0704.0669",
       "name" : "citation_pdf_url"
    },
    {
@@ -20286,7 +20286,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0033",
+      "content" : "https://localhost/pdf/0704.0033",
       "name" : "citation_pdf_url"
    },
    {
@@ -20322,7 +20322,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0056",
+      "content" : "https://localhost/pdf/0704.0056",
       "name" : "citation_pdf_url"
    },
    {
@@ -20354,7 +20354,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0713",
+      "content" : "https://localhost/pdf/0704.0713",
       "name" : "citation_pdf_url"
    },
    {
@@ -20418,7 +20418,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0307",
+      "content" : "https://localhost/pdf/0704.0307",
       "name" : "citation_pdf_url"
    },
    {
@@ -20486,7 +20486,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0059",
+      "content" : "https://localhost/pdf/0704.0059",
       "name" : "citation_pdf_url"
    },
    {
@@ -20514,7 +20514,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0412",
+      "content" : "https://localhost/pdf/0704.0412",
       "name" : "citation_pdf_url"
    },
    {
@@ -20546,7 +20546,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0005",
+      "content" : "https://localhost/pdf/0704.0005",
       "name" : "citation_pdf_url"
    },
    {
@@ -20586,7 +20586,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0937",
+      "content" : "https://localhost/pdf/0704.0937",
       "name" : "citation_pdf_url"
    },
    {
@@ -20638,7 +20638,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0727",
+      "content" : "https://localhost/pdf/0704.0727",
       "name" : "citation_pdf_url"
    },
    {
@@ -20678,7 +20678,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0690",
+      "content" : "https://localhost/pdf/0704.0690",
       "name" : "citation_pdf_url"
    },
    {
@@ -20714,7 +20714,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0577",
+      "content" : "https://localhost/pdf/0704.0577",
       "name" : "citation_pdf_url"
    },
    {
@@ -20750,7 +20750,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0926",
+      "content" : "https://localhost/pdf/0704.0926",
       "name" : "citation_pdf_url"
    },
    {
@@ -20790,7 +20790,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0887",
+      "content" : "https://localhost/pdf/0704.0887",
       "name" : "citation_pdf_url"
    },
    {
@@ -20818,7 +20818,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0750",
+      "content" : "https://localhost/pdf/0704.0750",
       "name" : "citation_pdf_url"
    },
    {
@@ -20894,7 +20894,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0871",
+      "content" : "https://localhost/pdf/0704.0871",
       "name" : "citation_pdf_url"
    },
    {
@@ -20926,7 +20926,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0332",
+      "content" : "https://localhost/pdf/0704.0332",
       "name" : "citation_pdf_url"
    },
    {
@@ -20958,7 +20958,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0222",
+      "content" : "https://localhost/pdf/0704.0222",
       "name" : "citation_pdf_url"
    },
    {
@@ -20994,7 +20994,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0385",
+      "content" : "https://localhost/pdf/0704.0385",
       "name" : "citation_pdf_url"
    },
    {
@@ -21034,7 +21034,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0714",
+      "content" : "https://localhost/pdf/0704.0714",
       "name" : "citation_pdf_url"
    },
    {
@@ -21074,7 +21074,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0992",
+      "content" : "https://localhost/pdf/0704.0992",
       "name" : "citation_pdf_url"
    },
    {
@@ -21114,7 +21114,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0550",
+      "content" : "https://localhost/pdf/0704.0550",
       "name" : "citation_pdf_url"
    },
    {
@@ -21150,7 +21150,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0602",
+      "content" : "https://localhost/pdf/0704.0602",
       "name" : "citation_pdf_url"
    },
    {
@@ -21178,7 +21178,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0622",
+      "content" : "https://localhost/pdf/0704.0622",
       "name" : "citation_pdf_url"
    },
    {
@@ -21214,7 +21214,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0756",
+      "content" : "https://localhost/pdf/0704.0756",
       "name" : "citation_pdf_url"
    },
    {
@@ -21258,7 +21258,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0861",
+      "content" : "https://localhost/pdf/0704.0861",
       "name" : "citation_pdf_url"
    },
    {
@@ -21286,7 +21286,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0923",
+      "content" : "https://localhost/pdf/0704.0923",
       "name" : "citation_pdf_url"
    },
    {
@@ -21322,7 +21322,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0840",
+      "content" : "https://localhost/pdf/0704.0840",
       "name" : "citation_pdf_url"
    },
    {
@@ -21394,7 +21394,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0917",
+      "content" : "https://localhost/pdf/0704.0917",
       "name" : "citation_pdf_url"
    },
    {
@@ -21422,7 +21422,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0061",
+      "content" : "https://localhost/pdf/0704.0061",
       "name" : "citation_pdf_url"
    },
    {
@@ -21462,7 +21462,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0308",
+      "content" : "https://localhost/pdf/0704.0308",
       "name" : "citation_pdf_url"
    },
    {
@@ -21490,7 +21490,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0390",
+      "content" : "https://localhost/pdf/0704.0390",
       "name" : "citation_pdf_url"
    },
    {
@@ -21522,7 +21522,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0852",
+      "content" : "https://localhost/pdf/0704.0852",
       "name" : "citation_pdf_url"
    },
    {
@@ -21558,7 +21558,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0920",
+      "content" : "https://localhost/pdf/0704.0920",
       "name" : "citation_pdf_url"
    },
    {
@@ -21590,7 +21590,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0011",
+      "content" : "https://localhost/pdf/0704.0011",
       "name" : "citation_pdf_url"
    },
    {
@@ -21622,7 +21622,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0929",
+      "content" : "https://localhost/pdf/0704.0929",
       "name" : "citation_pdf_url"
    },
    {
@@ -21650,7 +21650,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0739",
+      "content" : "https://localhost/pdf/0704.0739",
       "name" : "citation_pdf_url"
    },
    {
@@ -21686,7 +21686,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0982",
+      "content" : "https://localhost/pdf/0704.0982",
       "name" : "citation_pdf_url"
    },
    {
@@ -21722,7 +21722,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0606",
+      "content" : "https://localhost/pdf/0704.0606",
       "name" : "citation_pdf_url"
    },
    {
@@ -21850,7 +21850,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0952",
+      "content" : "https://localhost/pdf/0704.0952",
       "name" : "citation_pdf_url"
    },
    {
@@ -21890,7 +21890,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0759",
+      "content" : "https://localhost/pdf/0704.0759",
       "name" : "citation_pdf_url"
    },
    {
@@ -21918,7 +21918,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0134",
+      "content" : "https://localhost/pdf/0704.0134",
       "name" : "citation_pdf_url"
    },
    {
@@ -21954,7 +21954,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0651",
+      "content" : "https://localhost/pdf/0704.0651",
       "name" : "citation_pdf_url"
    },
    {
@@ -21994,7 +21994,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0818",
+      "content" : "https://localhost/pdf/0704.0818",
       "name" : "citation_pdf_url"
    },
    {
@@ -22030,7 +22030,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0609",
+      "content" : "https://localhost/pdf/0704.0609",
       "name" : "citation_pdf_url"
    },
    {
@@ -22078,7 +22078,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0272",
+      "content" : "https://localhost/pdf/0704.0272",
       "name" : "citation_pdf_url"
    },
    {
@@ -22126,7 +22126,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0120",
+      "content" : "https://localhost/pdf/0704.0120",
       "name" : "citation_pdf_url"
    },
    {
@@ -22166,7 +22166,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0380",
+      "content" : "https://localhost/pdf/0704.0380",
       "name" : "citation_pdf_url"
    },
    {
@@ -22198,7 +22198,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0197",
+      "content" : "https://localhost/pdf/0704.0197",
       "name" : "citation_pdf_url"
    },
    {
@@ -22234,7 +22234,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0116",
+      "content" : "https://localhost/pdf/0704.0116",
       "name" : "citation_pdf_url"
    },
    {
@@ -22262,7 +22262,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0962",
+      "content" : "https://localhost/pdf/0704.0962",
       "name" : "citation_pdf_url"
    },
    {
@@ -22294,7 +22294,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0985",
+      "content" : "https://localhost/pdf/0704.0985",
       "name" : "citation_pdf_url"
    },
    {
@@ -22334,7 +22334,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0515",
+      "content" : "https://localhost/pdf/0704.0515",
       "name" : "citation_pdf_url"
    },
    {
@@ -22370,7 +22370,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0546",
+      "content" : "https://localhost/pdf/0704.0546",
       "name" : "citation_pdf_url"
    },
    {
@@ -22406,7 +22406,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0141",
+      "content" : "https://localhost/pdf/0704.0141",
       "name" : "citation_pdf_url"
    },
    {
@@ -22438,7 +22438,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0058",
+      "content" : "https://localhost/pdf/0704.0058",
       "name" : "citation_pdf_url"
    },
    {
@@ -22474,7 +22474,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0850",
+      "content" : "https://localhost/pdf/0704.0850",
       "name" : "citation_pdf_url"
    },
    {
@@ -22514,7 +22514,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0665",
+      "content" : "https://localhost/pdf/0704.0665",
       "name" : "citation_pdf_url"
    },
    {
@@ -22558,7 +22558,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0187",
+      "content" : "https://localhost/pdf/0704.0187",
       "name" : "citation_pdf_url"
    },
    {
@@ -22590,7 +22590,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0151",
+      "content" : "https://localhost/pdf/0704.0151",
       "name" : "citation_pdf_url"
    },
    {
@@ -22626,7 +22626,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0661",
+      "content" : "https://localhost/pdf/0704.0661",
       "name" : "citation_pdf_url"
    },
    {
@@ -22694,7 +22694,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0419",
+      "content" : "https://localhost/pdf/0704.0419",
       "name" : "citation_pdf_url"
    },
    {
@@ -22722,7 +22722,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0851",
+      "content" : "https://localhost/pdf/0704.0851",
       "name" : "citation_pdf_url"
    },
    {
@@ -22754,7 +22754,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0211",
+      "content" : "https://localhost/pdf/0704.0211",
       "name" : "citation_pdf_url"
    },
    {
@@ -22818,7 +22818,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0953",
+      "content" : "https://localhost/pdf/0704.0953",
       "name" : "citation_pdf_url"
    },
    {
@@ -22846,7 +22846,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0679",
+      "content" : "https://localhost/pdf/0704.0679",
       "name" : "citation_pdf_url"
    },
    {
@@ -22878,7 +22878,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0720",
+      "content" : "https://localhost/pdf/0704.0720",
       "name" : "citation_pdf_url"
    },
    {
@@ -22906,7 +22906,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0998",
+      "content" : "https://localhost/pdf/0704.0998",
       "name" : "citation_pdf_url"
    },
    {
@@ -22942,7 +22942,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0168",
+      "content" : "https://localhost/pdf/0704.0168",
       "name" : "citation_pdf_url"
    },
    {
@@ -22978,7 +22978,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0296",
+      "content" : "https://localhost/pdf/0704.0296",
       "name" : "citation_pdf_url"
    },
    {
@@ -23006,7 +23006,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0807",
+      "content" : "https://localhost/pdf/0704.0807",
       "name" : "citation_pdf_url"
    },
    {
@@ -23034,7 +23034,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0264",
+      "content" : "https://localhost/pdf/0704.0264",
       "name" : "citation_pdf_url"
    },
    {
@@ -23130,7 +23130,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0670",
+      "content" : "https://localhost/pdf/0704.0670",
       "name" : "citation_pdf_url"
    },
    {
@@ -23178,7 +23178,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0127",
+      "content" : "https://localhost/pdf/0704.0127",
       "name" : "citation_pdf_url"
    },
    {
@@ -23218,7 +23218,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0825",
+      "content" : "https://localhost/pdf/0704.0825",
       "name" : "citation_pdf_url"
    },
    {
@@ -23254,7 +23254,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0621",
+      "content" : "https://localhost/pdf/0704.0621",
       "name" : "citation_pdf_url"
    },
    {
@@ -23306,7 +23306,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0791",
+      "content" : "https://localhost/pdf/0704.0791",
       "name" : "citation_pdf_url"
    },
    {
@@ -23338,7 +23338,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0532",
+      "content" : "https://localhost/pdf/0704.0532",
       "name" : "citation_pdf_url"
    },
    {
@@ -23378,7 +23378,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0496",
+      "content" : "https://localhost/pdf/0704.0496",
       "name" : "citation_pdf_url"
    },
    {
@@ -23406,7 +23406,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0003",
+      "content" : "https://localhost/pdf/0704.0003",
       "name" : "citation_pdf_url"
    },
    {
@@ -23454,7 +23454,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0247",
+      "content" : "https://localhost/pdf/0704.0247",
       "name" : "citation_pdf_url"
    },
    {
@@ -23490,7 +23490,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0708",
+      "content" : "https://localhost/pdf/0704.0708",
       "name" : "citation_pdf_url"
    },
    {
@@ -23522,7 +23522,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0492",
+      "content" : "https://localhost/pdf/0704.0492",
       "name" : "citation_pdf_url"
    },
    {
@@ -23558,7 +23558,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0574",
+      "content" : "https://localhost/pdf/0704.0574",
       "name" : "citation_pdf_url"
    },
    {
@@ -23590,7 +23590,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0927",
+      "content" : "https://localhost/pdf/0704.0927",
       "name" : "citation_pdf_url"
    },
    {
@@ -23622,7 +23622,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0778",
+      "content" : "https://localhost/pdf/0704.0778",
       "name" : "citation_pdf_url"
    },
    {
@@ -23666,7 +23666,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0951",
+      "content" : "https://localhost/pdf/0704.0951",
       "name" : "citation_pdf_url"
    },
    {
@@ -23754,7 +23754,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0128",
+      "content" : "https://localhost/pdf/0704.0128",
       "name" : "citation_pdf_url"
    },
    {
@@ -23786,7 +23786,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0372",
+      "content" : "https://localhost/pdf/0704.0372",
       "name" : "citation_pdf_url"
    },
    {
@@ -23822,7 +23822,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0183",
+      "content" : "https://localhost/pdf/0704.0183",
       "name" : "citation_pdf_url"
    },
    {
@@ -23858,7 +23858,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0949",
+      "content" : "https://localhost/pdf/0704.0949",
       "name" : "citation_pdf_url"
    },
    {
@@ -23894,7 +23894,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0629",
+      "content" : "https://localhost/pdf/0704.0629",
       "name" : "citation_pdf_url"
    },
    {
@@ -23950,7 +23950,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0915",
+      "content" : "https://localhost/pdf/0704.0915",
       "name" : "citation_pdf_url"
    },
    {
@@ -23986,7 +23986,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0446",
+      "content" : "https://localhost/pdf/0704.0446",
       "name" : "citation_pdf_url"
    },
    {
@@ -24026,7 +24026,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0544",
+      "content" : "https://localhost/pdf/0704.0544",
       "name" : "citation_pdf_url"
    },
    {
@@ -24062,7 +24062,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0269",
+      "content" : "https://localhost/pdf/0704.0269",
       "name" : "citation_pdf_url"
    },
    {
@@ -24110,7 +24110,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0132",
+      "content" : "https://localhost/pdf/0704.0132",
       "name" : "citation_pdf_url"
    },
    {
@@ -24138,7 +24138,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0218",
+      "content" : "https://localhost/pdf/0704.0218",
       "name" : "citation_pdf_url"
    },
    {
@@ -24194,7 +24194,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0443",
+      "content" : "https://localhost/pdf/0704.0443",
       "name" : "citation_pdf_url"
    },
    {
@@ -24234,7 +24234,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0564",
+      "content" : "https://localhost/pdf/0704.0564",
       "name" : "citation_pdf_url"
    },
    {
@@ -24266,7 +24266,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0662",
+      "content" : "https://localhost/pdf/0704.0662",
       "name" : "citation_pdf_url"
    },
    {
@@ -24298,7 +24298,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0490",
+      "content" : "https://localhost/pdf/0704.0490",
       "name" : "citation_pdf_url"
    },
    {
@@ -24334,7 +24334,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0326",
+      "content" : "https://localhost/pdf/0704.0326",
       "name" : "citation_pdf_url"
    },
    {
@@ -24390,7 +24390,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0619",
+      "content" : "https://localhost/pdf/0704.0619",
       "name" : "citation_pdf_url"
    },
    {
@@ -24422,7 +24422,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0394",
+      "content" : "https://localhost/pdf/0704.0394",
       "name" : "citation_pdf_url"
    },
    {
@@ -24466,7 +24466,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0384",
+      "content" : "https://localhost/pdf/0704.0384",
       "name" : "citation_pdf_url"
    },
    {
@@ -24506,7 +24506,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.1001",
+      "content" : "https://localhost/pdf/0704.1001",
       "name" : "citation_pdf_url"
    },
    {
@@ -24534,7 +24534,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0189",
+      "content" : "https://localhost/pdf/0704.0189",
       "name" : "citation_pdf_url"
    },
    {
@@ -24574,7 +24574,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0032",
+      "content" : "https://localhost/pdf/0704.0032",
       "name" : "citation_pdf_url"
    },
    {
@@ -24606,7 +24606,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0246",
+      "content" : "https://localhost/pdf/0704.0246",
       "name" : "citation_pdf_url"
    },
    {
@@ -24638,7 +24638,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0540",
+      "content" : "https://localhost/pdf/0704.0540",
       "name" : "citation_pdf_url"
    },
    {
@@ -24670,7 +24670,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0099",
+      "content" : "https://localhost/pdf/0704.0099",
       "name" : "citation_pdf_url"
    },
    {
@@ -24702,7 +24702,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0942",
+      "content" : "https://localhost/pdf/0704.0942",
       "name" : "citation_pdf_url"
    },
    {
@@ -24742,7 +24742,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0314",
+      "content" : "https://localhost/pdf/0704.0314",
       "name" : "citation_pdf_url"
    },
    {
@@ -24786,7 +24786,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0369",
+      "content" : "https://localhost/pdf/0704.0369",
       "name" : "citation_pdf_url"
    },
    {
@@ -24858,7 +24858,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0460",
+      "content" : "https://localhost/pdf/0704.0460",
       "name" : "citation_pdf_url"
    },
    {
@@ -25014,7 +25014,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0655",
+      "content" : "https://localhost/pdf/0704.0655",
       "name" : "citation_pdf_url"
    },
    {
@@ -25054,7 +25054,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0725",
+      "content" : "https://localhost/pdf/0704.0725",
       "name" : "citation_pdf_url"
    },
    {
@@ -25094,7 +25094,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0353",
+      "content" : "https://localhost/pdf/0704.0353",
       "name" : "citation_pdf_url"
    },
    {
@@ -25150,7 +25150,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0113",
+      "content" : "https://localhost/pdf/0704.0113",
       "name" : "citation_pdf_url"
    },
    {
@@ -25198,7 +25198,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0890",
+      "content" : "https://localhost/pdf/0704.0890",
       "name" : "citation_pdf_url"
    },
    {
@@ -25246,7 +25246,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0407",
+      "content" : "https://localhost/pdf/0704.0407",
       "name" : "citation_pdf_url"
    },
    {
@@ -25282,7 +25282,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0340",
+      "content" : "https://localhost/pdf/0704.0340",
       "name" : "citation_pdf_url"
    },
    {
@@ -25318,7 +25318,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0594",
+      "content" : "https://localhost/pdf/0704.0594",
       "name" : "citation_pdf_url"
    },
    {
@@ -25358,7 +25358,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0521",
+      "content" : "https://localhost/pdf/0704.0521",
       "name" : "citation_pdf_url"
    },
    {
@@ -25398,7 +25398,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0947",
+      "content" : "https://localhost/pdf/0704.0947",
       "name" : "citation_pdf_url"
    },
    {
@@ -25438,7 +25438,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0346",
+      "content" : "https://localhost/pdf/0704.0346",
       "name" : "citation_pdf_url"
    },
    {
@@ -25470,7 +25470,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0371",
+      "content" : "https://localhost/pdf/0704.0371",
       "name" : "citation_pdf_url"
    },
    {
@@ -25506,7 +25506,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0557",
+      "content" : "https://localhost/pdf/0704.0557",
       "name" : "citation_pdf_url"
    },
    {
@@ -25542,7 +25542,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0865",
+      "content" : "https://localhost/pdf/0704.0865",
       "name" : "citation_pdf_url"
    },
    {
@@ -25582,7 +25582,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0138",
+      "content" : "https://localhost/pdf/0704.0138",
       "name" : "citation_pdf_url"
    },
    {
@@ -25614,7 +25614,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0752",
+      "content" : "https://localhost/pdf/0704.0752",
       "name" : "citation_pdf_url"
    },
    {
@@ -25670,7 +25670,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0697",
+      "content" : "https://localhost/pdf/0704.0697",
       "name" : "citation_pdf_url"
    },
    {
@@ -25706,7 +25706,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0802",
+      "content" : "https://localhost/pdf/0704.0802",
       "name" : "citation_pdf_url"
    },
    {
@@ -25734,7 +25734,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0095",
+      "content" : "https://localhost/pdf/0704.0095",
       "name" : "citation_pdf_url"
    },
    {
@@ -25782,7 +25782,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0774",
+      "content" : "https://localhost/pdf/0704.0774",
       "name" : "citation_pdf_url"
    },
    {
@@ -25822,7 +25822,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0037",
+      "content" : "https://localhost/pdf/0704.0037",
       "name" : "citation_pdf_url"
    },
    {
@@ -25858,7 +25858,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0405",
+      "content" : "https://localhost/pdf/0704.0405",
       "name" : "citation_pdf_url"
    },
    {
@@ -25890,7 +25890,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0493",
+      "content" : "https://localhost/pdf/0704.0493",
       "name" : "citation_pdf_url"
    },
    {
@@ -25930,7 +25930,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0399",
+      "content" : "https://localhost/pdf/0704.0399",
       "name" : "citation_pdf_url"
    },
    {
@@ -25958,7 +25958,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0347",
+      "content" : "https://localhost/pdf/0704.0347",
       "name" : "citation_pdf_url"
    },
    {
@@ -26002,7 +26002,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0605",
+      "content" : "https://localhost/pdf/0704.0605",
       "name" : "citation_pdf_url"
    },
    {
@@ -26034,7 +26034,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0548",
+      "content" : "https://localhost/pdf/0704.0548",
       "name" : "citation_pdf_url"
    },
    {
@@ -26070,7 +26070,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0624",
+      "content" : "https://localhost/pdf/0704.0624",
       "name" : "citation_pdf_url"
    },
    {
@@ -26098,7 +26098,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0089",
+      "content" : "https://localhost/pdf/0704.0089",
       "name" : "citation_pdf_url"
    },
    {
@@ -26130,7 +26130,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0859",
+      "content" : "https://localhost/pdf/0704.0859",
       "name" : "citation_pdf_url"
    },
    {
@@ -26170,7 +26170,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0712",
+      "content" : "https://localhost/pdf/0704.0712",
       "name" : "citation_pdf_url"
    },
    {
@@ -26198,7 +26198,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0469",
+      "content" : "https://localhost/pdf/0704.0469",
       "name" : "citation_pdf_url"
    },
    {
@@ -26254,7 +26254,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0044",
+      "content" : "https://localhost/pdf/0704.0044",
       "name" : "citation_pdf_url"
    },
    {
@@ -26290,7 +26290,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0710",
+      "content" : "https://localhost/pdf/0704.0710",
       "name" : "citation_pdf_url"
    },
    {
@@ -26326,7 +26326,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0395",
+      "content" : "https://localhost/pdf/0704.0395",
       "name" : "citation_pdf_url"
    },
    {
@@ -26366,7 +26366,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0498",
+      "content" : "https://localhost/pdf/0704.0498",
       "name" : "citation_pdf_url"
    },
    {
@@ -26414,7 +26414,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0155",
+      "content" : "https://localhost/pdf/0704.0155",
       "name" : "citation_pdf_url"
    },
    {
@@ -26450,7 +26450,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0693",
+      "content" : "https://localhost/pdf/0704.0693",
       "name" : "citation_pdf_url"
    },
    {
@@ -26490,7 +26490,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0870",
+      "content" : "https://localhost/pdf/0704.0870",
       "name" : "citation_pdf_url"
    },
    {
@@ -26530,7 +26530,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0195",
+      "content" : "https://localhost/pdf/0704.0195",
       "name" : "citation_pdf_url"
    },
    {
@@ -26570,7 +26570,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0535",
+      "content" : "https://localhost/pdf/0704.0535",
       "name" : "citation_pdf_url"
    },
    {
@@ -26610,7 +26610,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0234",
+      "content" : "https://localhost/pdf/0704.0234",
       "name" : "citation_pdf_url"
    },
    {
@@ -26658,7 +26658,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0513",
+      "content" : "https://localhost/pdf/0704.0513",
       "name" : "citation_pdf_url"
    },
    {
@@ -26694,7 +26694,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0489",
+      "content" : "https://localhost/pdf/0704.0489",
       "name" : "citation_pdf_url"
    },
    {
@@ -26738,7 +26738,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0055",
+      "content" : "https://localhost/pdf/0704.0055",
       "name" : "citation_pdf_url"
    },
    {
@@ -26774,7 +26774,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0705",
+      "content" : "https://localhost/pdf/0704.0705",
       "name" : "citation_pdf_url"
    },
    {
@@ -26814,7 +26814,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0472",
+      "content" : "https://localhost/pdf/0704.0472",
       "name" : "citation_pdf_url"
    },
    {
@@ -26842,7 +26842,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0558",
+      "content" : "https://localhost/pdf/0704.0558",
       "name" : "citation_pdf_url"
    },
    {
@@ -26874,7 +26874,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0567",
+      "content" : "https://localhost/pdf/0704.0567",
       "name" : "citation_pdf_url"
    },
    {
@@ -26906,7 +26906,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0909",
+      "content" : "https://localhost/pdf/0704.0909",
       "name" : "citation_pdf_url"
    },
    {
@@ -26942,7 +26942,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0680",
+      "content" : "https://localhost/pdf/0704.0680",
       "name" : "citation_pdf_url"
    },
    {
@@ -26978,7 +26978,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0946",
+      "content" : "https://localhost/pdf/0704.0946",
       "name" : "citation_pdf_url"
    },
    {
@@ -27014,7 +27014,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0478",
+      "content" : "https://localhost/pdf/0704.0478",
       "name" : "citation_pdf_url"
    },
    {
@@ -27058,7 +27058,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0779",
+      "content" : "https://localhost/pdf/0704.0779",
       "name" : "citation_pdf_url"
    },
    {
@@ -27090,7 +27090,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0598",
+      "content" : "https://localhost/pdf/0704.0598",
       "name" : "citation_pdf_url"
    },
    {
@@ -27126,7 +27126,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0886",
+      "content" : "https://localhost/pdf/0704.0886",
       "name" : "citation_pdf_url"
    },
    {
@@ -27162,7 +27162,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0519",
+      "content" : "https://localhost/pdf/0704.0519",
       "name" : "citation_pdf_url"
    },
    {
@@ -27202,7 +27202,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0718",
+      "content" : "https://localhost/pdf/0704.0718",
       "name" : "citation_pdf_url"
    },
    {
@@ -27234,7 +27234,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0494",
+      "content" : "https://localhost/pdf/0704.0494",
       "name" : "citation_pdf_url"
    },
    {
@@ -27270,7 +27270,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0337",
+      "content" : "https://localhost/pdf/0704.0337",
       "name" : "citation_pdf_url"
    },
    {
@@ -27306,7 +27306,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0345",
+      "content" : "https://localhost/pdf/0704.0345",
       "name" : "citation_pdf_url"
    },
    {
@@ -27362,7 +27362,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0907",
+      "content" : "https://localhost/pdf/0704.0907",
       "name" : "citation_pdf_url"
    },
    {
@@ -27398,7 +27398,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0098",
+      "content" : "https://localhost/pdf/0704.0098",
       "name" : "citation_pdf_url"
    },
    {
@@ -27426,7 +27426,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0503",
+      "content" : "https://localhost/pdf/0704.0503",
       "name" : "citation_pdf_url"
    },
    {
@@ -27462,7 +27462,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0523",
+      "content" : "https://localhost/pdf/0704.0523",
       "name" : "citation_pdf_url"
    },
    {
@@ -27502,7 +27502,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0249",
+      "content" : "https://localhost/pdf/0704.0249",
       "name" : "citation_pdf_url"
    },
    {
@@ -27554,7 +27554,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0518",
+      "content" : "https://localhost/pdf/0704.0518",
       "name" : "citation_pdf_url"
    },
    {
@@ -27582,7 +27582,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0131",
+      "content" : "https://localhost/pdf/0704.0131",
       "name" : "citation_pdf_url"
    },
    {
@@ -27614,7 +27614,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0331",
+      "content" : "https://localhost/pdf/0704.0331",
       "name" : "citation_pdf_url"
    },
    {
@@ -27642,7 +27642,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0882",
+      "content" : "https://localhost/pdf/0704.0882",
       "name" : "citation_pdf_url"
    },
    {
@@ -27690,7 +27690,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0862",
+      "content" : "https://localhost/pdf/0704.0862",
       "name" : "citation_pdf_url"
    },
    {
@@ -27718,7 +27718,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0514",
+      "content" : "https://localhost/pdf/0704.0514",
       "name" : "citation_pdf_url"
    },
    {
@@ -27746,7 +27746,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0248",
+      "content" : "https://localhost/pdf/0704.0248",
       "name" : "citation_pdf_url"
    },
    {
@@ -27786,7 +27786,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0471",
+      "content" : "https://localhost/pdf/0704.0471",
       "name" : "citation_pdf_url"
    },
    {
@@ -27826,7 +27826,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0799",
+      "content" : "https://localhost/pdf/0704.0799",
       "name" : "citation_pdf_url"
    },
    {
@@ -27858,7 +27858,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0086",
+      "content" : "https://localhost/pdf/0704.0086",
       "name" : "citation_pdf_url"
    },
    {
@@ -27902,7 +27902,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0911",
+      "content" : "https://localhost/pdf/0704.0911",
       "name" : "citation_pdf_url"
    },
    {
@@ -27942,7 +27942,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0932",
+      "content" : "https://localhost/pdf/0704.0932",
       "name" : "citation_pdf_url"
    },
    {
@@ -27978,7 +27978,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0082",
+      "content" : "https://localhost/pdf/0704.0082",
       "name" : "citation_pdf_url"
    },
    {
@@ -28010,7 +28010,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0745",
+      "content" : "https://localhost/pdf/0704.0745",
       "name" : "citation_pdf_url"
    },
    {
@@ -28042,7 +28042,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0641",
+      "content" : "https://localhost/pdf/0704.0641",
       "name" : "citation_pdf_url"
    },
    {
@@ -28082,7 +28082,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0157",
+      "content" : "https://localhost/pdf/0704.0157",
       "name" : "citation_pdf_url"
    },
    {
@@ -28114,7 +28114,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0022",
+      "content" : "https://localhost/pdf/0704.0022",
       "name" : "citation_pdf_url"
    },
    {
@@ -28146,7 +28146,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0504",
+      "content" : "https://localhost/pdf/0704.0504",
       "name" : "citation_pdf_url"
    },
    {
@@ -28190,7 +28190,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0198",
+      "content" : "https://localhost/pdf/0704.0198",
       "name" : "citation_pdf_url"
    },
    {
@@ -28222,7 +28222,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0667",
+      "content" : "https://localhost/pdf/0704.0667",
       "name" : "citation_pdf_url"
    },
    {
@@ -28258,7 +28258,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0562",
+      "content" : "https://localhost/pdf/0704.0562",
       "name" : "citation_pdf_url"
    },
    {
@@ -28286,7 +28286,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0051",
+      "content" : "https://localhost/pdf/0704.0051",
       "name" : "citation_pdf_url"
    },
    {
@@ -28314,7 +28314,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0213",
+      "content" : "https://localhost/pdf/0704.0213",
       "name" : "citation_pdf_url"
    },
    {
@@ -28346,7 +28346,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0997",
+      "content" : "https://localhost/pdf/0704.0997",
       "name" : "citation_pdf_url"
    },
    {
@@ -28386,7 +28386,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0695",
+      "content" : "https://localhost/pdf/0704.0695",
       "name" : "citation_pdf_url"
    },
    {
@@ -28434,7 +28434,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0721",
+      "content" : "https://localhost/pdf/0704.0721",
       "name" : "citation_pdf_url"
    },
    {
@@ -28462,7 +28462,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0028",
+      "content" : "https://localhost/pdf/0704.0028",
       "name" : "citation_pdf_url"
    },
    {
@@ -28506,7 +28506,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0979",
+      "content" : "https://localhost/pdf/0704.0979",
       "name" : "citation_pdf_url"
    },
    {
@@ -28546,7 +28546,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0666",
+      "content" : "https://localhost/pdf/0704.0666",
       "name" : "citation_pdf_url"
    },
    {
@@ -28586,7 +28586,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0715",
+      "content" : "https://localhost/pdf/0704.0715",
       "name" : "citation_pdf_url"
    },
    {
@@ -28626,7 +28626,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0984",
+      "content" : "https://localhost/pdf/0704.0984",
       "name" : "citation_pdf_url"
    },
    {
@@ -28682,7 +28682,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0592",
+      "content" : "https://localhost/pdf/0704.0592",
       "name" : "citation_pdf_url"
    },
    {
@@ -28718,7 +28718,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0313",
+      "content" : "https://localhost/pdf/0704.0313",
       "name" : "citation_pdf_url"
    },
    {
@@ -28754,7 +28754,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0437",
+      "content" : "https://localhost/pdf/0704.0437",
       "name" : "citation_pdf_url"
    },
    {
@@ -28798,7 +28798,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0093",
+      "content" : "https://localhost/pdf/0704.0093",
       "name" : "citation_pdf_url"
    },
    {
@@ -28878,7 +28878,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0579",
+      "content" : "https://localhost/pdf/0704.0579",
       "name" : "citation_pdf_url"
    },
    {
@@ -28926,7 +28926,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0343",
+      "content" : "https://localhost/pdf/0704.0343",
       "name" : "citation_pdf_url"
    },
    {
@@ -28958,7 +28958,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0298",
+      "content" : "https://localhost/pdf/0704.0298",
       "name" : "citation_pdf_url"
    },
    {
@@ -28994,7 +28994,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0250",
+      "content" : "https://localhost/pdf/0704.0250",
       "name" : "citation_pdf_url"
    },
    {
@@ -29026,7 +29026,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0848",
+      "content" : "https://localhost/pdf/0704.0848",
       "name" : "citation_pdf_url"
    },
    {
@@ -29062,7 +29062,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0336",
+      "content" : "https://localhost/pdf/0704.0336",
       "name" : "citation_pdf_url"
    },
    {
@@ -29090,7 +29090,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0885",
+      "content" : "https://localhost/pdf/0704.0885",
       "name" : "citation_pdf_url"
    },
    {
@@ -29150,7 +29150,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0674",
+      "content" : "https://localhost/pdf/0704.0674",
       "name" : "citation_pdf_url"
    },
    {
@@ -29190,7 +29190,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0672",
+      "content" : "https://localhost/pdf/0704.0672",
       "name" : "citation_pdf_url"
    },
    {
@@ -29218,7 +29218,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0783",
+      "content" : "https://localhost/pdf/0704.0783",
       "name" : "citation_pdf_url"
    },
    {
@@ -29246,7 +29246,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0549",
+      "content" : "https://localhost/pdf/0704.0549",
       "name" : "citation_pdf_url"
    },
    {
@@ -29278,7 +29278,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0633",
+      "content" : "https://localhost/pdf/0704.0633",
       "name" : "citation_pdf_url"
    },
    {
@@ -29318,7 +29318,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0148",
+      "content" : "https://localhost/pdf/0704.0148",
       "name" : "citation_pdf_url"
    },
    {
@@ -29350,7 +29350,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0969",
+      "content" : "https://localhost/pdf/0704.0969",
       "name" : "citation_pdf_url"
    },
    {
@@ -29386,7 +29386,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0382",
+      "content" : "https://localhost/pdf/0704.0382",
       "name" : "citation_pdf_url"
    },
    {
@@ -29422,7 +29422,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0339",
+      "content" : "https://localhost/pdf/0704.0339",
       "name" : "citation_pdf_url"
    },
    {
@@ -29450,7 +29450,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0839",
+      "content" : "https://localhost/pdf/0704.0839",
       "name" : "citation_pdf_url"
    },
    {
@@ -29502,7 +29502,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0176",
+      "content" : "https://localhost/pdf/0704.0176",
       "name" : "citation_pdf_url"
    },
    {
@@ -29554,7 +29554,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0894",
+      "content" : "https://localhost/pdf/0704.0894",
       "name" : "citation_pdf_url"
    },
    {
@@ -29582,7 +29582,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0853",
+      "content" : "https://localhost/pdf/0704.0853",
       "name" : "citation_pdf_url"
    },
    {
@@ -29666,7 +29666,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0048",
+      "content" : "https://localhost/pdf/0704.0048",
       "name" : "citation_pdf_url"
    },
    {
@@ -29706,7 +29706,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0744",
+      "content" : "https://localhost/pdf/0704.0744",
       "name" : "citation_pdf_url"
    },
    {
@@ -29742,7 +29742,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0954",
+      "content" : "https://localhost/pdf/0704.0954",
       "name" : "citation_pdf_url"
    },
    {
@@ -29774,7 +29774,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0149",
+      "content" : "https://localhost/pdf/0704.0149",
       "name" : "citation_pdf_url"
    },
    {
@@ -29802,7 +29802,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0101",
+      "content" : "https://localhost/pdf/0704.0101",
       "name" : "citation_pdf_url"
    },
    {
@@ -29838,7 +29838,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0163",
+      "content" : "https://localhost/pdf/0704.0163",
       "name" : "citation_pdf_url"
    },
    {
@@ -29874,7 +29874,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0587",
+      "content" : "https://localhost/pdf/0704.0587",
       "name" : "citation_pdf_url"
    },
    {
@@ -29918,7 +29918,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0941",
+      "content" : "https://localhost/pdf/0704.0941",
       "name" : "citation_pdf_url"
    },
    {
@@ -29950,7 +29950,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0906",
+      "content" : "https://localhost/pdf/0704.0906",
       "name" : "citation_pdf_url"
    },
    {
@@ -29986,7 +29986,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0723",
+      "content" : "https://localhost/pdf/0704.0723",
       "name" : "citation_pdf_url"
    },
    {
@@ -30022,7 +30022,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0191",
+      "content" : "https://localhost/pdf/0704.0191",
       "name" : "citation_pdf_url"
    },
    {
@@ -30054,7 +30054,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0411",
+      "content" : "https://localhost/pdf/0704.0411",
       "name" : "citation_pdf_url"
    },
    {
@@ -30086,7 +30086,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0174",
+      "content" : "https://localhost/pdf/0704.0174",
       "name" : "citation_pdf_url"
    },
    {
@@ -30122,7 +30122,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0130",
+      "content" : "https://localhost/pdf/0704.0130",
       "name" : "citation_pdf_url"
    },
    {
@@ -30158,7 +30158,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0329",
+      "content" : "https://localhost/pdf/0704.0329",
       "name" : "citation_pdf_url"
    },
    {
@@ -30190,7 +30190,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0884",
+      "content" : "https://localhost/pdf/0704.0884",
       "name" : "citation_pdf_url"
    },
    {
@@ -30234,7 +30234,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0152",
+      "content" : "https://localhost/pdf/0704.0152",
       "name" : "citation_pdf_url"
    },
    {
@@ -30274,7 +30274,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0902",
+      "content" : "https://localhost/pdf/0704.0902",
       "name" : "citation_pdf_url"
    },
    {
@@ -30310,7 +30310,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0769",
+      "content" : "https://localhost/pdf/0704.0769",
       "name" : "citation_pdf_url"
    },
    {
@@ -30350,7 +30350,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0160",
+      "content" : "https://localhost/pdf/0704.0160",
       "name" : "citation_pdf_url"
    },
    {
@@ -30378,7 +30378,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0034",
+      "content" : "https://localhost/pdf/0704.0034",
       "name" : "citation_pdf_url"
    },
    {
@@ -30410,7 +30410,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0484",
+      "content" : "https://localhost/pdf/0704.0484",
       "name" : "citation_pdf_url"
    },
    {
@@ -30450,7 +30450,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0289",
+      "content" : "https://localhost/pdf/0704.0289",
       "name" : "citation_pdf_url"
    },
    {
@@ -30494,7 +30494,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0122",
+      "content" : "https://localhost/pdf/0704.0122",
       "name" : "citation_pdf_url"
    },
    {
@@ -30534,7 +30534,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0193",
+      "content" : "https://localhost/pdf/0704.0193",
       "name" : "citation_pdf_url"
    },
    {
@@ -30586,7 +30586,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0888",
+      "content" : "https://localhost/pdf/0704.0888",
       "name" : "citation_pdf_url"
    },
    {
@@ -30618,7 +30618,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0171",
+      "content" : "https://localhost/pdf/0704.0171",
       "name" : "citation_pdf_url"
    },
    {
@@ -30646,7 +30646,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0072",
+      "content" : "https://localhost/pdf/0704.0072",
       "name" : "citation_pdf_url"
    },
    {
@@ -30738,7 +30738,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0789",
+      "content" : "https://localhost/pdf/0704.0789",
       "name" : "citation_pdf_url"
    },
    {
@@ -30774,7 +30774,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0733",
+      "content" : "https://localhost/pdf/0704.0733",
       "name" : "citation_pdf_url"
    },
    {
@@ -30806,7 +30806,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0096",
+      "content" : "https://localhost/pdf/0704.0096",
       "name" : "citation_pdf_url"
    },
    {
@@ -30842,7 +30842,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0398",
+      "content" : "https://localhost/pdf/0704.0398",
       "name" : "citation_pdf_url"
    },
    {
@@ -30882,7 +30882,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0827",
+      "content" : "https://localhost/pdf/0704.0827",
       "name" : "citation_pdf_url"
    },
    {
@@ -30910,7 +30910,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0275",
+      "content" : "https://localhost/pdf/0704.0275",
       "name" : "citation_pdf_url"
    },
    {
@@ -30938,7 +30938,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0367",
+      "content" : "https://localhost/pdf/0704.0367",
       "name" : "citation_pdf_url"
    },
    {
@@ -30966,7 +30966,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0500",
+      "content" : "https://localhost/pdf/0704.0500",
       "name" : "citation_pdf_url"
    },
    {
@@ -31002,7 +31002,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0501",
+      "content" : "https://localhost/pdf/0704.0501",
       "name" : "citation_pdf_url"
    },
    {
@@ -31030,7 +31030,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0066",
+      "content" : "https://localhost/pdf/0704.0066",
       "name" : "citation_pdf_url"
    },
    {
@@ -31098,7 +31098,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0159",
+      "content" : "https://localhost/pdf/0704.0159",
       "name" : "citation_pdf_url"
    },
    {
@@ -31134,7 +31134,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0531",
+      "content" : "https://localhost/pdf/0704.0531",
       "name" : "citation_pdf_url"
    },
    {
@@ -31170,7 +31170,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0341",
+      "content" : "https://localhost/pdf/0704.0341",
       "name" : "citation_pdf_url"
    },
    {
@@ -31202,7 +31202,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0994",
+      "content" : "https://localhost/pdf/0704.0994",
       "name" : "citation_pdf_url"
    },
    {
@@ -31230,7 +31230,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0136",
+      "content" : "https://localhost/pdf/0704.0136",
       "name" : "citation_pdf_url"
    },
    {
@@ -31266,7 +31266,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0711",
+      "content" : "https://localhost/pdf/0704.0711",
       "name" : "citation_pdf_url"
    },
    {
@@ -31302,7 +31302,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0024",
+      "content" : "https://localhost/pdf/0704.0024",
       "name" : "citation_pdf_url"
    },
    {
@@ -31330,7 +31330,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0214",
+      "content" : "https://localhost/pdf/0704.0214",
       "name" : "citation_pdf_url"
    },
    {
@@ -31366,7 +31366,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0966",
+      "content" : "https://localhost/pdf/0704.0966",
       "name" : "citation_pdf_url"
    },
    {
@@ -31406,7 +31406,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0021",
+      "content" : "https://localhost/pdf/0704.0021",
       "name" : "citation_pdf_url"
    },
    {
@@ -31434,7 +31434,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0634",
+      "content" : "https://localhost/pdf/0704.0634",
       "name" : "citation_pdf_url"
    },
    {
@@ -31466,7 +31466,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0924",
+      "content" : "https://localhost/pdf/0704.0924",
       "name" : "citation_pdf_url"
    },
    {
@@ -31506,7 +31506,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0062",
+      "content" : "https://localhost/pdf/0704.0062",
       "name" : "citation_pdf_url"
    },
    {
@@ -31538,7 +31538,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0232",
+      "content" : "https://localhost/pdf/0704.0232",
       "name" : "citation_pdf_url"
    },
    {
@@ -31566,7 +31566,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0813",
+      "content" : "https://localhost/pdf/0704.0813",
       "name" : "citation_pdf_url"
    },
    {
@@ -31594,7 +31594,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0400",
+      "content" : "https://localhost/pdf/0704.0400",
       "name" : "citation_pdf_url"
    },
    {
@@ -31674,7 +31674,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0270",
+      "content" : "https://localhost/pdf/0704.0270",
       "name" : "citation_pdf_url"
    },
    {
@@ -31710,7 +31710,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0125",
+      "content" : "https://localhost/pdf/0704.0125",
       "name" : "citation_pdf_url"
    },
    {
@@ -31762,7 +31762,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0547",
+      "content" : "https://localhost/pdf/0704.0547",
       "name" : "citation_pdf_url"
    },
    {
@@ -31798,7 +31798,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0188",
+      "content" : "https://localhost/pdf/0704.0188",
       "name" : "citation_pdf_url"
    },
    {
@@ -31846,7 +31846,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0060",
+      "content" : "https://localhost/pdf/0704.0060",
       "name" : "citation_pdf_url"
    },
    {
@@ -31890,7 +31890,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0449",
+      "content" : "https://localhost/pdf/0704.0449",
       "name" : "citation_pdf_url"
    },
    {
@@ -31918,7 +31918,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0167",
+      "content" : "https://localhost/pdf/0704.0167",
       "name" : "citation_pdf_url"
    },
    {
@@ -31966,7 +31966,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0734",
+      "content" : "https://localhost/pdf/0704.0734",
       "name" : "citation_pdf_url"
    },
    {
@@ -31998,7 +31998,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0173",
+      "content" : "https://localhost/pdf/0704.0173",
       "name" : "citation_pdf_url"
    },
    {
@@ -32050,7 +32050,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0352",
+      "content" : "https://localhost/pdf/0704.0352",
       "name" : "citation_pdf_url"
    },
    {
@@ -32078,7 +32078,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0459",
+      "content" : "https://localhost/pdf/0704.0459",
       "name" : "citation_pdf_url"
    },
    {
@@ -32114,7 +32114,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0903",
+      "content" : "https://localhost/pdf/0704.0903",
       "name" : "citation_pdf_url"
    },
    {
@@ -32166,7 +32166,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0854",
+      "content" : "https://localhost/pdf/0704.0854",
       "name" : "citation_pdf_url"
    },
    {
@@ -32202,7 +32202,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0652",
+      "content" : "https://localhost/pdf/0704.0652",
       "name" : "citation_pdf_url"
    },
    {
@@ -32242,7 +32242,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0601",
+      "content" : "https://localhost/pdf/0704.0601",
       "name" : "citation_pdf_url"
    },
    {
@@ -32274,7 +32274,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0736",
+      "content" : "https://localhost/pdf/0704.0736",
       "name" : "citation_pdf_url"
    },
    {
@@ -32306,7 +32306,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0561",
+      "content" : "https://localhost/pdf/0704.0561",
       "name" : "citation_pdf_url"
    },
    {
@@ -32350,7 +32350,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0237",
+      "content" : "https://localhost/pdf/0704.0237",
       "name" : "citation_pdf_url"
    },
    {
@@ -32378,7 +32378,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0468",
+      "content" : "https://localhost/pdf/0704.0468",
       "name" : "citation_pdf_url"
    },
    {
@@ -32414,7 +32414,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0974",
+      "content" : "https://localhost/pdf/0704.0974",
       "name" : "citation_pdf_url"
    },
    {
@@ -32462,7 +32462,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0506",
+      "content" : "https://localhost/pdf/0704.0506",
       "name" : "citation_pdf_url"
    },
    {
@@ -32490,7 +32490,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0857",
+      "content" : "https://localhost/pdf/0704.0857",
       "name" : "citation_pdf_url"
    },
    {
@@ -32526,7 +32526,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.1000",
+      "content" : "https://localhost/pdf/0704.1000",
       "name" : "citation_pdf_url"
    },
    {
@@ -32554,7 +32554,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0618",
+      "content" : "https://localhost/pdf/0704.0618",
       "name" : "citation_pdf_url"
    },
    {
@@ -32590,7 +32590,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0833",
+      "content" : "https://localhost/pdf/0704.0833",
       "name" : "citation_pdf_url"
    },
    {
@@ -32630,7 +32630,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0290",
+      "content" : "https://localhost/pdf/0704.0290",
       "name" : "citation_pdf_url"
    },
    {
@@ -32658,7 +32658,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0112",
+      "content" : "https://localhost/pdf/0704.0112",
       "name" : "citation_pdf_url"
    },
    {
@@ -32694,7 +32694,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0935",
+      "content" : "https://localhost/pdf/0704.0935",
       "name" : "citation_pdf_url"
    },
    {
@@ -32726,7 +32726,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0910",
+      "content" : "https://localhost/pdf/0704.0910",
       "name" : "citation_pdf_url"
    },
    {
@@ -32766,7 +32766,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0465",
+      "content" : "https://localhost/pdf/0704.0465",
       "name" : "citation_pdf_url"
    },
    {
@@ -32798,7 +32798,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0940",
+      "content" : "https://localhost/pdf/0704.0940",
       "name" : "citation_pdf_url"
    },
    {
@@ -32830,7 +32830,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0607",
+      "content" : "https://localhost/pdf/0704.0607",
       "name" : "citation_pdf_url"
    },
    {
@@ -32866,7 +32866,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0243",
+      "content" : "https://localhost/pdf/0704.0243",
       "name" : "citation_pdf_url"
    },
    {
@@ -32894,7 +32894,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0425",
+      "content" : "https://localhost/pdf/0704.0425",
       "name" : "citation_pdf_url"
    },
    {
@@ -32926,7 +32926,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0047",
+      "content" : "https://localhost/pdf/0704.0047",
       "name" : "citation_pdf_url"
    },
    {
@@ -32958,7 +32958,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0517",
+      "content" : "https://localhost/pdf/0704.0517",
       "name" : "citation_pdf_url"
    },
    {
@@ -32998,7 +32998,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0617",
+      "content" : "https://localhost/pdf/0704.0617",
       "name" : "citation_pdf_url"
    },
    {
@@ -33042,7 +33042,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0305",
+      "content" : "https://localhost/pdf/0704.0305",
       "name" : "citation_pdf_url"
    },
    {
@@ -33082,7 +33082,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0824",
+      "content" : "https://localhost/pdf/0704.0824",
       "name" : "citation_pdf_url"
    },
    {
@@ -33118,7 +33118,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0741",
+      "content" : "https://localhost/pdf/0704.0741",
       "name" : "citation_pdf_url"
    },
    {
@@ -33150,7 +33150,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0393",
+      "content" : "https://localhost/pdf/0704.0393",
       "name" : "citation_pdf_url"
    },
    {
@@ -33182,7 +33182,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0798",
+      "content" : "https://localhost/pdf/0704.0798",
       "name" : "citation_pdf_url"
    },
    {
@@ -33214,7 +33214,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0085",
+      "content" : "https://localhost/pdf/0704.0085",
       "name" : "citation_pdf_url"
    },
    {
@@ -33354,7 +33354,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0423",
+      "content" : "https://localhost/pdf/0704.0423",
       "name" : "citation_pdf_url"
    },
    {
@@ -33386,7 +33386,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0456",
+      "content" : "https://localhost/pdf/0704.0456",
       "name" : "citation_pdf_url"
    },
    {
@@ -33450,7 +33450,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0717",
+      "content" : "https://localhost/pdf/0704.0717",
       "name" : "citation_pdf_url"
    },
    {
@@ -33482,7 +33482,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0263",
+      "content" : "https://localhost/pdf/0704.0263",
       "name" : "citation_pdf_url"
    },
    {
@@ -33514,7 +33514,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0286",
+      "content" : "https://localhost/pdf/0704.0286",
       "name" : "citation_pdf_url"
    },
    {
@@ -33550,7 +33550,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0505",
+      "content" : "https://localhost/pdf/0704.0505",
       "name" : "citation_pdf_url"
    },
    {
@@ -33594,7 +33594,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0001",
+      "content" : "https://localhost/pdf/0704.0001",
       "name" : "citation_pdf_url"
    },
    {
@@ -33630,7 +33630,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0800",
+      "content" : "https://localhost/pdf/0704.0800",
       "name" : "citation_pdf_url"
    },
    {
@@ -33670,7 +33670,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0726",
+      "content" : "https://localhost/pdf/0704.0726",
       "name" : "citation_pdf_url"
    },
    {
@@ -33702,7 +33702,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0950",
+      "content" : "https://localhost/pdf/0704.0950",
       "name" : "citation_pdf_url"
    },
    {
@@ -33746,7 +33746,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0027",
+      "content" : "https://localhost/pdf/0704.0027",
       "name" : "citation_pdf_url"
    },
    {
@@ -33782,7 +33782,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0738",
+      "content" : "https://localhost/pdf/0704.0738",
       "name" : "citation_pdf_url"
    },
    {
@@ -33818,7 +33818,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0464",
+      "content" : "https://localhost/pdf/0704.0464",
       "name" : "citation_pdf_url"
    },
    {
@@ -33870,7 +33870,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0303",
+      "content" : "https://localhost/pdf/0704.0303",
       "name" : "citation_pdf_url"
    },
    {
@@ -33906,7 +33906,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0442",
+      "content" : "https://localhost/pdf/0704.0442",
       "name" : "citation_pdf_url"
    },
    {
@@ -33946,7 +33946,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0933",
+      "content" : "https://localhost/pdf/0704.0933",
       "name" : "citation_pdf_url"
    },
    {
@@ -33978,7 +33978,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0436",
+      "content" : "https://localhost/pdf/0704.0436",
       "name" : "citation_pdf_url"
    },
    {
@@ -34010,7 +34010,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0121",
+      "content" : "https://localhost/pdf/0704.0121",
       "name" : "citation_pdf_url"
    },
    {
@@ -34038,7 +34038,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0108",
+      "content" : "https://localhost/pdf/0704.0108",
       "name" : "citation_pdf_url"
    },
    {
@@ -34070,7 +34070,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0294",
+      "content" : "https://localhost/pdf/0704.0294",
       "name" : "citation_pdf_url"
    },
    {
@@ -34106,7 +34106,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0223",
+      "content" : "https://localhost/pdf/0704.0223",
       "name" : "citation_pdf_url"
    },
    {
@@ -34134,7 +34134,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0164",
+      "content" : "https://localhost/pdf/0704.0164",
       "name" : "citation_pdf_url"
    },
    {
@@ -34162,7 +34162,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0846",
+      "content" : "https://localhost/pdf/0704.0846",
       "name" : "citation_pdf_url"
    },
    {
@@ -34202,7 +34202,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0777",
+      "content" : "https://localhost/pdf/0704.0777",
       "name" : "citation_pdf_url"
    },
    {
@@ -34234,7 +34234,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0301",
+      "content" : "https://localhost/pdf/0704.0301",
       "name" : "citation_pdf_url"
    },
    {
@@ -34290,7 +34290,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0350",
+      "content" : "https://localhost/pdf/0704.0350",
       "name" : "citation_pdf_url"
    },
    {
@@ -34318,7 +34318,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0563",
+      "content" : "https://localhost/pdf/0704.0563",
       "name" : "citation_pdf_url"
    },
    {
@@ -34350,7 +34350,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0930",
+      "content" : "https://localhost/pdf/0704.0930",
       "name" : "citation_pdf_url"
    },
    {
@@ -34390,7 +34390,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0892",
+      "content" : "https://localhost/pdf/0704.0892",
       "name" : "citation_pdf_url"
    },
    {
@@ -34426,7 +34426,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0692",
+      "content" : "https://localhost/pdf/0704.0692",
       "name" : "citation_pdf_url"
    },
    {
@@ -34462,7 +34462,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0921",
+      "content" : "https://localhost/pdf/0704.0921",
       "name" : "citation_pdf_url"
    },
    {
@@ -34494,7 +34494,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0816",
+      "content" : "https://localhost/pdf/0704.0816",
       "name" : "citation_pdf_url"
    },
    {
@@ -34526,7 +34526,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0959",
+      "content" : "https://localhost/pdf/0704.0959",
       "name" : "citation_pdf_url"
    },
    {
@@ -34554,7 +34554,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0623",
+      "content" : "https://localhost/pdf/0704.0623",
       "name" : "citation_pdf_url"
    },
    {
@@ -34586,7 +34586,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0050",
+      "content" : "https://localhost/pdf/0704.0050",
       "name" : "citation_pdf_url"
    },
    {
@@ -34626,7 +34626,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0812",
+      "content" : "https://localhost/pdf/0704.0812",
       "name" : "citation_pdf_url"
    },
    {
@@ -34662,7 +34662,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0678",
+      "content" : "https://localhost/pdf/0704.0678",
       "name" : "citation_pdf_url"
    },
    {
@@ -34702,7 +34702,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0645",
+      "content" : "https://localhost/pdf/0704.0645",
       "name" : "citation_pdf_url"
    },
    {
@@ -34738,7 +34738,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0318",
+      "content" : "https://localhost/pdf/0704.0318",
       "name" : "citation_pdf_url"
    },
    {
@@ -34770,7 +34770,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0843",
+      "content" : "https://localhost/pdf/0704.0843",
       "name" : "citation_pdf_url"
    },
    {
@@ -34818,7 +34818,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0410",
+      "content" : "https://localhost/pdf/0704.0410",
       "name" : "citation_pdf_url"
    },
    {
@@ -34846,7 +34846,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0571",
+      "content" : "https://localhost/pdf/0704.0571",
       "name" : "citation_pdf_url"
    },
    {
@@ -34878,7 +34878,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0076",
+      "content" : "https://localhost/pdf/0704.0076",
       "name" : "citation_pdf_url"
    },
    {
@@ -34906,7 +34906,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0897",
+      "content" : "https://localhost/pdf/0704.0897",
       "name" : "citation_pdf_url"
    },
    {
@@ -34950,7 +34950,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0635",
+      "content" : "https://localhost/pdf/0704.0635",
       "name" : "citation_pdf_url"
    },
    {
@@ -34990,7 +34990,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0043",
+      "content" : "https://localhost/pdf/0704.0043",
       "name" : "citation_pdf_url"
    },
    {
@@ -35018,7 +35018,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0429",
+      "content" : "https://localhost/pdf/0704.0429",
       "name" : "citation_pdf_url"
    },
    {
@@ -35106,7 +35106,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0706",
+      "content" : "https://localhost/pdf/0704.0706",
       "name" : "citation_pdf_url"
    },
    {
@@ -35150,7 +35150,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0901",
+      "content" : "https://localhost/pdf/0704.0901",
       "name" : "citation_pdf_url"
    },
    {
@@ -35186,7 +35186,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0512",
+      "content" : "https://localhost/pdf/0704.0512",
       "name" : "citation_pdf_url"
    },
    {
@@ -35226,7 +35226,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0765",
+      "content" : "https://localhost/pdf/0704.0765",
       "name" : "citation_pdf_url"
    },
    {
@@ -35266,7 +35266,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0877",
+      "content" : "https://localhost/pdf/0704.0877",
       "name" : "citation_pdf_url"
    },
    {
@@ -35302,7 +35302,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0584",
+      "content" : "https://localhost/pdf/0704.0584",
       "name" : "citation_pdf_url"
    },
    {
@@ -35338,7 +35338,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0251",
+      "content" : "https://localhost/pdf/0704.0251",
       "name" : "citation_pdf_url"
    },
    {
@@ -35370,7 +35370,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0829",
+      "content" : "https://localhost/pdf/0704.0829",
       "name" : "citation_pdf_url"
    },
    {
@@ -35414,7 +35414,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0990",
+      "content" : "https://localhost/pdf/0704.0990",
       "name" : "citation_pdf_url"
    },
    {
@@ -35462,7 +35462,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0626",
+      "content" : "https://localhost/pdf/0704.0626",
       "name" : "citation_pdf_url"
    },
    {
@@ -35502,7 +35502,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0525",
+      "content" : "https://localhost/pdf/0704.0525",
       "name" : "citation_pdf_url"
    },
    {
@@ -35538,7 +35538,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0934",
+      "content" : "https://localhost/pdf/0704.0934",
       "name" : "citation_pdf_url"
    },
    {
@@ -35578,7 +35578,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0830",
+      "content" : "https://localhost/pdf/0704.0830",
       "name" : "citation_pdf_url"
    },
    {
@@ -35606,7 +35606,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0081",
+      "content" : "https://localhost/pdf/0704.0081",
       "name" : "citation_pdf_url"
    },
    {
@@ -35634,7 +35634,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0874",
+      "content" : "https://localhost/pdf/0704.0874",
       "name" : "citation_pdf_url"
    },
    {
@@ -35662,7 +35662,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0823",
+      "content" : "https://localhost/pdf/0704.0823",
       "name" : "citation_pdf_url"
    },
    {
@@ -35690,7 +35690,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0838",
+      "content" : "https://localhost/pdf/0704.0838",
       "name" : "citation_pdf_url"
    },
    {
@@ -35730,7 +35730,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0524",
+      "content" : "https://localhost/pdf/0704.0524",
       "name" : "citation_pdf_url"
    },
    {
@@ -35770,7 +35770,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0551",
+      "content" : "https://localhost/pdf/0704.0551",
       "name" : "citation_pdf_url"
    },
    {
@@ -35802,7 +35802,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0834",
+      "content" : "https://localhost/pdf/0704.0834",
       "name" : "citation_pdf_url"
    },
    {
@@ -35830,7 +35830,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0065",
+      "content" : "https://localhost/pdf/0704.0065",
       "name" : "citation_pdf_url"
    },
    {
@@ -35866,7 +35866,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0805",
+      "content" : "https://localhost/pdf/0704.0805",
       "name" : "citation_pdf_url"
    },
    {
@@ -35906,7 +35906,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0728",
+      "content" : "https://localhost/pdf/0704.0728",
       "name" : "citation_pdf_url"
    },
    {
@@ -35946,7 +35946,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0993",
+      "content" : "https://localhost/pdf/0704.0993",
       "name" : "citation_pdf_url"
    },
    {
@@ -35978,7 +35978,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0207",
+      "content" : "https://localhost/pdf/0704.0207",
       "name" : "citation_pdf_url"
    },
    {
@@ -36010,7 +36010,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0754",
+      "content" : "https://localhost/pdf/0704.0754",
       "name" : "citation_pdf_url"
    },
    {
@@ -36042,7 +36042,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0760",
+      "content" : "https://localhost/pdf/0704.0760",
       "name" : "citation_pdf_url"
    },
    {
@@ -36070,7 +36070,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0487",
+      "content" : "https://localhost/pdf/0704.0487",
       "name" : "citation_pdf_url"
    },
    {
@@ -36126,7 +36126,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0291",
+      "content" : "https://localhost/pdf/0704.0291",
       "name" : "citation_pdf_url"
    },
    {
@@ -36158,7 +36158,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0140",
+      "content" : "https://localhost/pdf/0704.0140",
       "name" : "citation_pdf_url"
    },
    {
@@ -36190,7 +36190,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0989",
+      "content" : "https://localhost/pdf/0704.0989",
       "name" : "citation_pdf_url"
    },
    {
@@ -36230,7 +36230,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0832",
+      "content" : "https://localhost/pdf/0704.0832",
       "name" : "citation_pdf_url"
    },
    {
@@ -36286,7 +36286,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0447",
+      "content" : "https://localhost/pdf/0704.0447",
       "name" : "citation_pdf_url"
    },
    {
@@ -36326,7 +36326,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0327",
+      "content" : "https://localhost/pdf/0704.0327",
       "name" : "citation_pdf_url"
    },
    {
@@ -36362,7 +36362,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0961",
+      "content" : "https://localhost/pdf/0704.0961",
       "name" : "citation_pdf_url"
    },
    {
@@ -36434,7 +36434,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0529",
+      "content" : "https://localhost/pdf/0704.0529",
       "name" : "citation_pdf_url"
    },
    {
@@ -36482,7 +36482,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0878",
+      "content" : "https://localhost/pdf/0704.0878",
       "name" : "citation_pdf_url"
    },
    {
@@ -36518,7 +36518,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0599",
+      "content" : "https://localhost/pdf/0704.0599",
       "name" : "citation_pdf_url"
    },
    {
@@ -36546,7 +36546,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0115",
+      "content" : "https://localhost/pdf/0704.0115",
       "name" : "citation_pdf_url"
    },
    {
@@ -36582,7 +36582,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0516",
+      "content" : "https://localhost/pdf/0704.0516",
       "name" : "citation_pdf_url"
    },
    {
@@ -36614,7 +36614,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0201",
+      "content" : "https://localhost/pdf/0704.0201",
       "name" : "citation_pdf_url"
    },
    {
@@ -36658,7 +36658,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0322",
+      "content" : "https://localhost/pdf/0704.0322",
       "name" : "citation_pdf_url"
    },
    {
@@ -36690,7 +36690,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0165",
+      "content" : "https://localhost/pdf/0704.0165",
       "name" : "citation_pdf_url"
    },
    {
@@ -36726,7 +36726,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0688",
+      "content" : "https://localhost/pdf/0704.0688",
       "name" : "citation_pdf_url"
    },
    {
@@ -36754,7 +36754,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0068",
+      "content" : "https://localhost/pdf/0704.0068",
       "name" : "citation_pdf_url"
    },
    {
@@ -36794,7 +36794,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0268",
+      "content" : "https://localhost/pdf/0704.0268",
       "name" : "citation_pdf_url"
    },
    {
@@ -36830,7 +36830,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0821",
+      "content" : "https://localhost/pdf/0704.0821",
       "name" : "citation_pdf_url"
    },
    {
@@ -36870,7 +36870,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0908",
+      "content" : "https://localhost/pdf/0704.0908",
       "name" : "citation_pdf_url"
    },
    {
@@ -36918,7 +36918,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0724",
+      "content" : "https://localhost/pdf/0704.0724",
       "name" : "citation_pdf_url"
    },
    {
@@ -36946,7 +36946,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0999",
+      "content" : "https://localhost/pdf/0704.0999",
       "name" : "citation_pdf_url"
    },
    {
@@ -36978,7 +36978,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0228",
+      "content" : "https://localhost/pdf/0704.0228",
       "name" : "citation_pdf_url"
    },
    {
@@ -37006,7 +37006,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0090",
+      "content" : "https://localhost/pdf/0704.0090",
       "name" : "citation_pdf_url"
    },
    {
@@ -37038,7 +37038,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0107",
+      "content" : "https://localhost/pdf/0704.0107",
       "name" : "citation_pdf_url"
    },
    {
@@ -37074,7 +37074,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0866",
+      "content" : "https://localhost/pdf/0704.0866",
       "name" : "citation_pdf_url"
    },
    {
@@ -37106,7 +37106,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0803",
+      "content" : "https://localhost/pdf/0704.0803",
       "name" : "citation_pdf_url"
    },
    {
@@ -37142,7 +37142,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0100",
+      "content" : "https://localhost/pdf/0704.0100",
       "name" : "citation_pdf_url"
    },
    {
@@ -37182,7 +37182,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0461",
+      "content" : "https://localhost/pdf/0704.0461",
       "name" : "citation_pdf_url"
    },
    {
@@ -37214,7 +37214,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0509",
+      "content" : "https://localhost/pdf/0704.0509",
       "name" : "citation_pdf_url"
    },
    {
@@ -37250,7 +37250,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0795",
+      "content" : "https://localhost/pdf/0704.0795",
       "name" : "citation_pdf_url"
    },
    {
@@ -37278,7 +37278,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0801",
+      "content" : "https://localhost/pdf/0704.0801",
       "name" : "citation_pdf_url"
    },
    {
@@ -37314,7 +37314,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0366",
+      "content" : "https://localhost/pdf/0704.0366",
       "name" : "citation_pdf_url"
    },
    {
@@ -37342,7 +37342,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0317",
+      "content" : "https://localhost/pdf/0704.0317",
       "name" : "citation_pdf_url"
    },
    {
@@ -37378,7 +37378,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0541",
+      "content" : "https://localhost/pdf/0704.0541",
       "name" : "citation_pdf_url"
    },
    {
@@ -37414,7 +37414,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0630",
+      "content" : "https://localhost/pdf/0704.0630",
       "name" : "citation_pdf_url"
    },
    {
@@ -37442,7 +37442,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0539",
+      "content" : "https://localhost/pdf/0704.0539",
       "name" : "citation_pdf_url"
    },
    {
@@ -37486,7 +37486,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0338",
+      "content" : "https://localhost/pdf/0704.0338",
       "name" : "citation_pdf_url"
    },
    {
@@ -37526,7 +37526,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0175",
+      "content" : "https://localhost/pdf/0704.0175",
       "name" : "citation_pdf_url"
    },
    {
@@ -37566,7 +37566,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0703",
+      "content" : "https://localhost/pdf/0704.0703",
       "name" : "citation_pdf_url"
    },
    {
@@ -37602,7 +37602,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0488",
+      "content" : "https://localhost/pdf/0704.0488",
       "name" : "citation_pdf_url"
    },
    {
@@ -37638,7 +37638,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0210",
+      "content" : "https://localhost/pdf/0704.0210",
       "name" : "citation_pdf_url"
    },
    {
@@ -37670,7 +37670,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0707",
+      "content" : "https://localhost/pdf/0704.0707",
       "name" : "citation_pdf_url"
    },
    {
@@ -37718,7 +37718,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0431",
+      "content" : "https://localhost/pdf/0704.0431",
       "name" : "citation_pdf_url"
    },
    {
@@ -37758,7 +37758,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0639",
+      "content" : "https://localhost/pdf/0704.0639",
       "name" : "citation_pdf_url"
    },
    {
@@ -37798,7 +37798,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0785",
+      "content" : "https://localhost/pdf/0704.0785",
       "name" : "citation_pdf_url"
    },
    {
@@ -37850,7 +37850,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0441",
+      "content" : "https://localhost/pdf/0704.0441",
       "name" : "citation_pdf_url"
    },
    {
@@ -37890,7 +37890,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0204",
+      "content" : "https://localhost/pdf/0704.0204",
       "name" : "citation_pdf_url"
    },
    {
@@ -37926,7 +37926,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0330",
+      "content" : "https://localhost/pdf/0704.0330",
       "name" : "citation_pdf_url"
    },
    {
@@ -37962,7 +37962,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0357",
+      "content" : "https://localhost/pdf/0704.0357",
       "name" : "citation_pdf_url"
    },
    {
@@ -38022,7 +38022,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0334",
+      "content" : "https://localhost/pdf/0704.0334",
       "name" : "citation_pdf_url"
    },
    {
@@ -38058,7 +38058,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0292",
+      "content" : "https://localhost/pdf/0704.0292",
       "name" : "citation_pdf_url"
    },
    {
@@ -38090,7 +38090,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0064",
+      "content" : "https://localhost/pdf/0704.0064",
       "name" : "citation_pdf_url"
    },
    {
@@ -38122,7 +38122,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0960",
+      "content" : "https://localhost/pdf/0704.0960",
       "name" : "citation_pdf_url"
    },
    {
@@ -38166,7 +38166,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0762",
+      "content" : "https://localhost/pdf/0704.0762",
       "name" : "citation_pdf_url"
    },
    {
@@ -38210,7 +38210,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0245",
+      "content" : "https://localhost/pdf/0704.0245",
       "name" : "citation_pdf_url"
    },
    {
@@ -38238,7 +38238,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0872",
+      "content" : "https://localhost/pdf/0704.0872",
       "name" : "citation_pdf_url"
    },
    {
@@ -38270,7 +38270,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0970",
+      "content" : "https://localhost/pdf/0704.0970",
       "name" : "citation_pdf_url"
    },
    {
@@ -38302,7 +38302,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0087",
+      "content" : "https://localhost/pdf/0704.0087",
       "name" : "citation_pdf_url"
    },
    {
@@ -38338,7 +38338,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0867",
+      "content" : "https://localhost/pdf/0704.0867",
       "name" : "citation_pdf_url"
    },
    {
@@ -38382,7 +38382,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0893",
+      "content" : "https://localhost/pdf/0704.0893",
       "name" : "citation_pdf_url"
    },
    {
@@ -38418,7 +38418,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0620",
+      "content" : "https://localhost/pdf/0704.0620",
       "name" : "citation_pdf_url"
    },
    {
@@ -38454,7 +38454,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0092",
+      "content" : "https://localhost/pdf/0704.0092",
       "name" : "citation_pdf_url"
    },
    {
@@ -38490,7 +38490,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0351",
+      "content" : "https://localhost/pdf/0704.0351",
       "name" : "citation_pdf_url"
    },
    {
@@ -38518,7 +38518,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0502",
+      "content" : "https://localhost/pdf/0704.0502",
       "name" : "citation_pdf_url"
    },
    {
@@ -38550,7 +38550,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0235",
+      "content" : "https://localhost/pdf/0704.0235",
       "name" : "citation_pdf_url"
    },
    {
@@ -38594,7 +38594,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0978",
+      "content" : "https://localhost/pdf/0704.0978",
       "name" : "citation_pdf_url"
    },
    {
@@ -38622,7 +38622,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0749",
+      "content" : "https://localhost/pdf/0704.0749",
       "name" : "citation_pdf_url"
    },
    {
@@ -38658,7 +38658,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0396",
+      "content" : "https://localhost/pdf/0704.0396",
       "name" : "citation_pdf_url"
    },
    {
@@ -38686,7 +38686,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0348",
+      "content" : "https://localhost/pdf/0704.0348",
       "name" : "citation_pdf_url"
    },
    {
@@ -38714,7 +38714,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0772",
+      "content" : "https://localhost/pdf/0704.0772",
       "name" : "citation_pdf_url"
    },
    {
@@ -38742,7 +38742,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0137",
+      "content" : "https://localhost/pdf/0704.0137",
       "name" : "citation_pdf_url"
    },
    {
@@ -38778,7 +38778,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0822",
+      "content" : "https://localhost/pdf/0704.0822",
       "name" : "citation_pdf_url"
    },
    {
@@ -38818,7 +38818,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0258",
+      "content" : "https://localhost/pdf/0704.0258",
       "name" : "citation_pdf_url"
    },
    {
@@ -38858,7 +38858,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0435",
+      "content" : "https://localhost/pdf/0704.0435",
       "name" : "citation_pdf_url"
    },
    {
@@ -38898,7 +38898,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0233",
+      "content" : "https://localhost/pdf/0704.0233",
       "name" : "citation_pdf_url"
    },
    {
@@ -38934,7 +38934,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0611",
+      "content" : "https://localhost/pdf/0704.0611",
       "name" : "citation_pdf_url"
    },
    {
@@ -38970,7 +38970,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0499",
+      "content" : "https://localhost/pdf/0704.0499",
       "name" : "citation_pdf_url"
    },
    {
@@ -39026,7 +39026,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0451",
+      "content" : "https://localhost/pdf/0704.0451",
       "name" : "citation_pdf_url"
    },
    {
@@ -39062,7 +39062,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0360",
+      "content" : "https://localhost/pdf/0704.0360",
       "name" : "citation_pdf_url"
    },
    {
@@ -39102,7 +39102,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0636",
+      "content" : "https://localhost/pdf/0704.0636",
       "name" : "citation_pdf_url"
    },
    {
@@ -39178,7 +39178,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0285",
+      "content" : "https://localhost/pdf/0704.0285",
       "name" : "citation_pdf_url"
    },
    {
@@ -39230,7 +39230,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0554",
+      "content" : "https://localhost/pdf/0704.0554",
       "name" : "citation_pdf_url"
    },
    {
@@ -39322,7 +39322,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0899",
+      "content" : "https://localhost/pdf/0704.0899",
       "name" : "citation_pdf_url"
    },
    {
@@ -39362,7 +39362,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0147",
+      "content" : "https://localhost/pdf/0704.0147",
       "name" : "citation_pdf_url"
    },
    {
@@ -39406,7 +39406,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0427",
+      "content" : "https://localhost/pdf/0704.0427",
       "name" : "citation_pdf_url"
    },
    {
@@ -39438,7 +39438,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0208",
+      "content" : "https://localhost/pdf/0704.0208",
       "name" : "citation_pdf_url"
    },
    {
@@ -39474,7 +39474,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0476",
+      "content" : "https://localhost/pdf/0704.0476",
       "name" : "citation_pdf_url"
    },
    {
@@ -39502,7 +39502,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0479",
+      "content" : "https://localhost/pdf/0704.0479",
       "name" : "citation_pdf_url"
    },
    {
@@ -39534,7 +39534,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0230",
+      "content" : "https://localhost/pdf/0704.0230",
       "name" : "citation_pdf_url"
    },
    {
@@ -39574,7 +39574,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0166",
+      "content" : "https://localhost/pdf/0704.0166",
       "name" : "citation_pdf_url"
    },
    {
@@ -39610,7 +39610,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0118",
+      "content" : "https://localhost/pdf/0704.0118",
       "name" : "citation_pdf_url"
    },
    {
@@ -39646,7 +39646,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0595",
+      "content" : "https://localhost/pdf/0704.0595",
       "name" : "citation_pdf_url"
    },
    {
@@ -39702,7 +39702,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0009",
+      "content" : "https://localhost/pdf/0704.0009",
       "name" : "citation_pdf_url"
    },
    {
@@ -39734,7 +39734,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0743",
+      "content" : "https://localhost/pdf/0704.0743",
       "name" : "citation_pdf_url"
    },
    {
@@ -39774,7 +39774,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0102",
+      "content" : "https://localhost/pdf/0704.0102",
       "name" : "citation_pdf_url"
    },
    {
@@ -39806,7 +39806,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0835",
+      "content" : "https://localhost/pdf/0704.0835",
       "name" : "citation_pdf_url"
    },
    {
@@ -39842,7 +39842,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0320",
+      "content" : "https://localhost/pdf/0704.0320",
       "name" : "citation_pdf_url"
    },
    {
@@ -39870,7 +39870,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0162",
+      "content" : "https://localhost/pdf/0704.0162",
       "name" : "citation_pdf_url"
    },
    {
@@ -39906,7 +39906,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0428",
+      "content" : "https://localhost/pdf/0704.0428",
       "name" : "citation_pdf_url"
    },
    {
@@ -39950,7 +39950,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0146",
+      "content" : "https://localhost/pdf/0704.0146",
       "name" : "citation_pdf_url"
    },
    {
@@ -39986,7 +39986,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0876",
+      "content" : "https://localhost/pdf/0704.0876",
       "name" : "citation_pdf_url"
    },
    {
@@ -40026,7 +40026,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0325",
+      "content" : "https://localhost/pdf/0704.0325",
       "name" : "citation_pdf_url"
    },
    {
@@ -40058,7 +40058,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0542",
+      "content" : "https://localhost/pdf/0704.0542",
       "name" : "citation_pdf_url"
    },
    {
@@ -40102,7 +40102,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0376",
+      "content" : "https://localhost/pdf/0704.0376",
       "name" : "citation_pdf_url"
    },
    {
@@ -40142,7 +40142,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0297",
+      "content" : "https://localhost/pdf/0704.0297",
       "name" : "citation_pdf_url"
    },
    {
@@ -40178,7 +40178,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0397",
+      "content" : "https://localhost/pdf/0704.0397",
       "name" : "citation_pdf_url"
    },
    {
@@ -40210,7 +40210,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0968",
+      "content" : "https://localhost/pdf/0704.0968",
       "name" : "citation_pdf_url"
    },
    {
@@ -40242,7 +40242,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0415",
+      "content" : "https://localhost/pdf/0704.0415",
       "name" : "citation_pdf_url"
    },
    {
@@ -40278,7 +40278,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0793",
+      "content" : "https://localhost/pdf/0704.0793",
       "name" : "citation_pdf_url"
    },
    {
@@ -40310,7 +40310,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0287",
+      "content" : "https://localhost/pdf/0704.0287",
       "name" : "citation_pdf_url"
    },
    {
@@ -40346,7 +40346,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0767",
+      "content" : "https://localhost/pdf/0704.0767",
       "name" : "citation_pdf_url"
    },
    {
@@ -40382,7 +40382,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0704.0522",
+      "content" : "https://localhost/pdf/0704.0522",
       "name" : "citation_pdf_url"
    },
    {
@@ -40418,7 +40418,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/1307.0001",
+      "content" : "https://localhost/pdf/1307.0001",
       "name" : "citation_pdf_url"
    },
    {
@@ -40454,7 +40454,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/1307.0010",
+      "content" : "https://localhost/pdf/1307.0010",
       "name" : "citation_pdf_url"
    },
    {
@@ -40498,7 +40498,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/1307.0101",
+      "content" : "https://localhost/pdf/1307.0101",
       "name" : "citation_pdf_url"
    },
    {
@@ -40534,7 +40534,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/1307.0584",
+      "content" : "https://localhost/pdf/1307.0584",
       "name" : "citation_pdf_url"
    },
    {
@@ -40586,7 +40586,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0806.0920",
+      "content" : "https://localhost/pdf/0806.0920",
       "name" : "citation_pdf_url"
    },
    {
@@ -40614,7 +40614,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/0907.2020",
+      "content" : "https://localhost/pdf/0907.2020",
       "name" : "citation_pdf_url"
    },
    {
@@ -40646,7 +40646,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/1502.00001",
+      "content" : "https://localhost/pdf/1502.00001",
       "name" : "citation_pdf_url"
    },
    {
@@ -40674,7 +40674,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/funct-an/9301001",
+      "content" : "https://localhost/pdf/funct-an/9301001",
       "name" : "citation_pdf_url"
    },
    {
@@ -40706,7 +40706,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/ao-sci/9502001",
+      "content" : "https://localhost/pdf/ao-sci/9502001",
       "name" : "citation_pdf_url"
    },
    {
@@ -40738,7 +40738,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/hep-th/9901001",
+      "content" : "https://localhost/pdf/hep-th/9901001",
       "name" : "citation_pdf_url"
    },
    {
@@ -40770,7 +40770,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/hep-th/9108002",
+      "content" : "https://localhost/pdf/hep-th/9108002",
       "name" : "citation_pdf_url"
    },
    {
@@ -40806,7 +40806,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/atom-ph/9509001",
+      "content" : "https://localhost/pdf/atom-ph/9509001",
       "name" : "citation_pdf_url"
    },
    {
@@ -40834,7 +40834,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/alg-geom/9202001",
+      "content" : "https://localhost/pdf/alg-geom/9202001",
       "name" : "citation_pdf_url"
    },
    {
@@ -40866,7 +40866,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/alg-geom/9311008",
+      "content" : "https://localhost/pdf/alg-geom/9311008",
       "name" : "citation_pdf_url"
    },
    {
@@ -40894,7 +40894,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/adap-org/9509001",
+      "content" : "https://localhost/pdf/adap-org/9509001",
       "name" : "citation_pdf_url"
    },
    {
@@ -40922,7 +40922,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/adap-org/9509003",
+      "content" : "https://localhost/pdf/adap-org/9509003",
       "name" : "citation_pdf_url"
    },
    {
@@ -40954,7 +40954,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/adap-org/9303002",
+      "content" : "https://localhost/pdf/adap-org/9303002",
       "name" : "citation_pdf_url"
    },
    {
@@ -40982,7 +40982,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/adap-org/9303001",
+      "content" : "https://localhost/pdf/adap-org/9303001",
       "name" : "citation_pdf_url"
    },
    {
@@ -41014,7 +41014,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509011",
+      "content" : "https://localhost/pdf/math-ph/0509011",
       "name" : "citation_pdf_url"
    },
    {
@@ -41046,7 +41046,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509013",
+      "content" : "https://localhost/pdf/math-ph/0509013",
       "name" : "citation_pdf_url"
    },
    {
@@ -41074,7 +41074,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509012",
+      "content" : "https://localhost/pdf/math-ph/0509012",
       "name" : "citation_pdf_url"
    },
    {
@@ -41110,7 +41110,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509032",
+      "content" : "https://localhost/pdf/math-ph/0509032",
       "name" : "citation_pdf_url"
    },
    {
@@ -41146,7 +41146,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509008",
+      "content" : "https://localhost/pdf/math-ph/0509008",
       "name" : "citation_pdf_url"
    },
    {
@@ -41178,7 +41178,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509022",
+      "content" : "https://localhost/pdf/math-ph/0509022",
       "name" : "citation_pdf_url"
    },
    {
@@ -41206,7 +41206,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509023",
+      "content" : "https://localhost/pdf/math-ph/0509023",
       "name" : "citation_pdf_url"
    },
    {
@@ -41234,7 +41234,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509015",
+      "content" : "https://localhost/pdf/math-ph/0509015",
       "name" : "citation_pdf_url"
    },
    {
@@ -41270,7 +41270,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509007",
+      "content" : "https://localhost/pdf/math-ph/0509007",
       "name" : "citation_pdf_url"
    },
    {
@@ -41302,7 +41302,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509036",
+      "content" : "https://localhost/pdf/math-ph/0509036",
       "name" : "citation_pdf_url"
    },
    {
@@ -41346,7 +41346,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509033",
+      "content" : "https://localhost/pdf/math-ph/0509033",
       "name" : "citation_pdf_url"
    },
    {
@@ -41382,7 +41382,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509010",
+      "content" : "https://localhost/pdf/math-ph/0509010",
       "name" : "citation_pdf_url"
    },
    {
@@ -41414,7 +41414,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509030",
+      "content" : "https://localhost/pdf/math-ph/0509030",
       "name" : "citation_pdf_url"
    },
    {
@@ -41442,7 +41442,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509035",
+      "content" : "https://localhost/pdf/math-ph/0509035",
       "name" : "citation_pdf_url"
    },
    {
@@ -41478,7 +41478,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509038",
+      "content" : "https://localhost/pdf/math-ph/0509038",
       "name" : "citation_pdf_url"
    },
    {
@@ -41506,7 +41506,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509006",
+      "content" : "https://localhost/pdf/math-ph/0509006",
       "name" : "citation_pdf_url"
    },
    {
@@ -41534,7 +41534,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509029",
+      "content" : "https://localhost/pdf/math-ph/0509029",
       "name" : "citation_pdf_url"
    },
    {
@@ -41570,7 +41570,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509028",
+      "content" : "https://localhost/pdf/math-ph/0509028",
       "name" : "citation_pdf_url"
    },
    {
@@ -41602,7 +41602,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509026",
+      "content" : "https://localhost/pdf/math-ph/0509026",
       "name" : "citation_pdf_url"
    },
    {
@@ -41634,7 +41634,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509019",
+      "content" : "https://localhost/pdf/math-ph/0509019",
       "name" : "citation_pdf_url"
    },
    {
@@ -41670,7 +41670,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509004",
+      "content" : "https://localhost/pdf/math-ph/0509004",
       "name" : "citation_pdf_url"
    },
    {
@@ -41702,7 +41702,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509034",
+      "content" : "https://localhost/pdf/math-ph/0509034",
       "name" : "citation_pdf_url"
    },
    {
@@ -41734,7 +41734,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509005",
+      "content" : "https://localhost/pdf/math-ph/0509005",
       "name" : "citation_pdf_url"
    },
    {
@@ -41762,7 +41762,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509003",
+      "content" : "https://localhost/pdf/math-ph/0509003",
       "name" : "citation_pdf_url"
    },
    {
@@ -41790,7 +41790,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509002",
+      "content" : "https://localhost/pdf/math-ph/0509002",
       "name" : "citation_pdf_url"
    },
    {
@@ -41822,7 +41822,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509024",
+      "content" : "https://localhost/pdf/math-ph/0509024",
       "name" : "citation_pdf_url"
    },
    {
@@ -41850,7 +41850,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509018",
+      "content" : "https://localhost/pdf/math-ph/0509018",
       "name" : "citation_pdf_url"
    },
    {
@@ -41878,7 +41878,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509016",
+      "content" : "https://localhost/pdf/math-ph/0509016",
       "name" : "citation_pdf_url"
    },
    {
@@ -41910,7 +41910,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509027",
+      "content" : "https://localhost/pdf/math-ph/0509027",
       "name" : "citation_pdf_url"
    },
    {
@@ -41938,7 +41938,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509020",
+      "content" : "https://localhost/pdf/math-ph/0509020",
       "name" : "citation_pdf_url"
    },
    {
@@ -41978,7 +41978,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509039",
+      "content" : "https://localhost/pdf/math-ph/0509039",
       "name" : "citation_pdf_url"
    },
    {
@@ -42014,7 +42014,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509021",
+      "content" : "https://localhost/pdf/math-ph/0509021",
       "name" : "citation_pdf_url"
    },
    {
@@ -42050,7 +42050,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509001",
+      "content" : "https://localhost/pdf/math-ph/0509001",
       "name" : "citation_pdf_url"
    },
    {
@@ -42086,7 +42086,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509009",
+      "content" : "https://localhost/pdf/math-ph/0509009",
       "name" : "citation_pdf_url"
    },
    {
@@ -42122,7 +42122,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509031",
+      "content" : "https://localhost/pdf/math-ph/0509031",
       "name" : "citation_pdf_url"
    },
    {
@@ -42150,7 +42150,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509025",
+      "content" : "https://localhost/pdf/math-ph/0509025",
       "name" : "citation_pdf_url"
    },
    {
@@ -42190,7 +42190,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509017",
+      "content" : "https://localhost/pdf/math-ph/0509017",
       "name" : "citation_pdf_url"
    },
    {
@@ -42218,7 +42218,7 @@
       "name" : "citation_online_date"
    },
    {
-      "content" : "http://localhost/pdf/math-ph/0509014",
+      "content" : "https://localhost/pdf/math-ph/0509014",
       "name" : "citation_pdf_url"
    },
    {

--- a/tests/dissemination/test_pdf.py
+++ b/tests/dissemination/test_pdf.py
@@ -23,8 +23,8 @@ def test_pdf_headers(client_with_test_fs):
 def test_pdf_redirect(client_with_test_fs):
     rv=client_with_test_fs.head("/pdf/cs/0011004v1?crazy_query_string=notgood")
     assert rv.status_code == 301
-    assert rv.headers["Location"] == "http://localhost/pdf/cs/0011004v1"
+    assert rv.headers["Location"] == "/pdf/cs/0011004v1"
 
     rv = client_with_test_fs.head("/pdf/2201.0001?crazy_query_string=notgood")
     assert rv.status_code == 301
-    assert rv.headers["Location"] == "http://localhost/pdf/2201.0001"
+    assert rv.headers["Location"] == "/pdf/2201.0001"


### PR DESCRIPTION
The bug was that a URL like https://arxiv.org/pdf/2501.12345.pdf would redirect to http://arxiv.org/pdf/2501.12345. Note the https is chagned to http and the trailing .pdf is removed. The chagne from https to http is the bug. This commit fixes that bug.

Changes the abs HTML metadata pdf URL from a http to https.

Changes the author list page pdf URL from a http to https.