### PR TITLE
Adds test of filename for html sourced paper

### DIFF
--- a/tests/test_src.py
+++ b/tests/test_src.py
@@ -58,6 +58,7 @@ cases = [
     ["cs/0012007", "cs0012007v3.tar.gz", ""],
     # ["cs/0011004", "cs-0011004"], # single file gz paper but bad gzip file
     # ["cs/0011004v1", "cs-0011004v1"],  # single file gz paper but bad gzip file
+    ["2403.10561", "arXiv-2403.10561v1.html.gz", "html source"],
 ]
 
 @pytest.mark.parametrize("path,paperid,expected_file,desc", [ ["/src/"]+c for c in cases] )


### PR DESCRIPTION
Alberto Accomazzi from ADS asked about this and it was quick to add this missing test.