### PR TITLE
ARXIVCE-3884 Opt in banner refinements - add new status button

### DIFF
--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -3318,3 +3318,12 @@ a:hover .icon.filter-red {
   border-radius: 4px;
   padding: 0.5em;
 }
+
+
+#opt-in-status-button-container {
+  margin-left: 1rem;
+}
+.opt-in-status-wrapper {
+  text-align: right;
+  padding-right: 1rem;
+}

--- a/browse/static/js/optin.js
+++ b/browse/static/js/optin.js
@@ -1,37 +1,59 @@
 // Support Opt-In banner and associated buttons
 function checkOptInParticipation() {
+  const banner = document.querySelector('.slider-wrapper.bps-banner.forum:not(.blue)');
   const cookies = document.cookie;
+  // User opted in
   const optedIn = cookies.includes('opt-in-tracking');
+  // User opted out (this is different than dismissed banner)
   const optedOut = cookies.includes('opt-out-tracking');
+  // We want to know whether the user made an opt-in choice or simply
+  // dismissed the banner. Remember, selection cookies may expire at
+  // different times. This allows us to make informed decisions for each case.
   const userDismissedBanner = cookies.includes('seenBanner_opt-in');
+  // We have control over our own opt-in dismissed cookie. This may
+  // be set differently depending on whether the user opted in, opted out,
+  // or simply dismissed the banner (x).
   const optInDismissed = cookies.includes('opt-in-dismissed');
+
+  // Hide the banner after user makes a choice
+  if ((optedIn || optedOut || optInDismissed) && banner) {
+    console.log("Hiding banner due to user choice (checkOptIn)");
+    banner.style.display = 'none';
+    banner.style.setProperty('display', 'none', 'important');
+  }
 
   const message = document.getElementById('opt-in-message');
   const optInBtn = document.getElementById('opt-in-registration');
   const enrolledMsg = document.getElementById('opt-in-enrolled');
 
   if (userDismissedBanner) {
+    // Refresh and expire after users is idle for a period of time.
     document.cookie = 'opt-in-dismissed=true; Path=/; Max-Age=2592000';
-    document.cookie = 'seenBanner_opt-in=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
   }
 
+  // This was used to provide status information - this may end up informing
+  // the opt-in status button.
   if (optedIn) {
     if (message) {
       message.innerHTML = "Thank you for agreeing to participate in research by allowing researchers to collect anonymized usage data. Your preferences have been saved."
-        + "<p>DEBUG: USER OPTED IN: THIS STATE WILL APPEAR AS SEPARATE BUTTON TBD</p>";
+        + "<p>USER OPTED IN: THIS STATE WILL APPEAR AS SEPARATE BUTTON TBD</p>";
     }
+    updateStatusButton('optedIn');
   } else if (optedOut) {
     if (message) {
       message.innerHTML = "Thank you for your response. Your preference not to participate has been saved. Click 'I agree' below if you later decide to participate."
-        + "<p>DEBUG: USER OPTED OUT: THIS STATE WILL APPEAR AS SEPARATE BUTTON TBD</p>";
+        + "<p>USER OPTED OUT: THIS STATE WILL APPEAR AS SEPARATE BUTTON TBD</p>";
     }
+    updateStatusButton('optedOut');
   } else if (optInDismissed && !optedIn && !optedOut) {
     if (message) {
       message.innerHTML = "You've previously dismissed this banner. You can still opt in by clicking 'I Agree' below."
-        + "<p>DEBUG: USER DISMISSED BANNER: THIS STATE WILL APPEAR AS SEPARATE BUTTON TBD!</p>";
+        + "<p>USER DISMISSED BANNER: THIS STATE WILL APPEAR AS SEPARATE BUTTON TBD!</p>";
     }
+    updateStatusButton('dismissed');
   }
 
+  // Control state of banner
   if (optedIn) {
     optInBtn.style.display = 'none';
     enrolledMsg.style.display = 'inline';
@@ -50,6 +72,15 @@ document.addEventListener('DOMContentLoaded', function () {
     document.cookie = `opt-in-tracking=${uuid}; Path=/; Max-Age=31536000`;
     document.cookie = 'opt-out-tracking=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
     document.cookie = 'opt-in-dismissed=true; Path=/; Max-Age=2592000';
+
+    const banner = document.querySelector('.slider-wrapper.bps-banner.forum:not(.blue');
+    if (banner) {
+        console.log("Hiding banner due to user choice (Opt In event)");
+        banner.style.display = 'none'
+        // Disable banner on refresh after user has made selection
+        document.cookie = 'seenBanner_opt-in=; Path=/; Max-Age=2592000';
+    }
+
     checkOptInParticipation();
   });
 
@@ -58,7 +89,55 @@ document.addEventListener('DOMContentLoaded', function () {
     document.cookie = 'opt-in-tracking=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
     document.cookie = 'opt-out-tracking=true; Path=/; Max-Age=2592000';
     document.cookie = 'opt-in-dismissed=true; Path=/; Max-Age=2592000';
+
+    const banner = document.querySelector('.slider-wrapper.bps-banner.forum:not(.blue)');
+    if (banner) {
+        console.log("Hiding banner due to user choice (Opt Out event)");
+        banner.style.display = 'none';
+        // Disable banner on refresh after user has made selection
+        document.cookie = 'seenBanner_opt-in=; Path=/; Max-Age=2592000';
+    }
+
     checkOptInParticipation();
   });
 });
 
+// Update residual 'status' indicator after initial choice has ben
+// made and banner is hidden. The status button does not appear when
+// banner is displayed.
+function updateStatusButton(state) {
+  const container = document.getElementById('opt-in-status-button-container');
+  const button = document.getElementById('opt-in-status-button');
+
+  container.style.display = 'block';
+
+  if (state === 'optedIn') {
+    button.textContent = 'Opt Out';
+    button.title = 'You are currently opted in. Click to opt out.';
+    button.onclick = function () {
+      document.cookie = 'opt-in-tracking=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+      document.cookie = 'opt-out-tracking=true; Path=/; Max-Age=2592000';
+      console.log("Hiding banner due to user choice (Opt Out button)");
+      checkOptInParticipation();
+    };
+  } else if (state === 'optedOut') {
+    button.textContent = 'Opt In';
+    button.title = 'You are currently opted out. Click to opt in.';
+    button.onclick = function () {
+      const uuid = crypto.randomUUID();
+      document.cookie = `opt-in-tracking=${uuid}; Path=/; Max-Age=31536000`;
+      document.cookie = 'opt-out-tracking=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+      console.log("Hiding banner due to user choice (Opt In button)");
+      checkOptInParticipation();
+    };
+  } else if (state === 'dismissed') {
+    button.textContent = 'Opt In';
+    button.title = 'You previously dismissed the banner. Click to opt in.';
+    button.onclick = function () {
+      const uuid = crypto.randomUUID();
+      document.cookie = `opt-in-tracking=${uuid}; Path=/; Max-Age=31536000`;
+      document.cookie = 'opt-out-tracking=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+      checkOptInParticipation();
+    };
+  }
+}

--- a/browse/static/js/optin.js
+++ b/browse/static/js/optin.js
@@ -1,6 +1,6 @@
 // Support Opt-In banner and associated buttons
 function checkOptInParticipation() {
-  const banner = document.querySelector('.slider-wrapper.bps-banner.forum:not(.blue)');
+  const banner = document.getElementById('opt-in-banner');
   const cookies = document.cookie;
   // User opted in
   const optedIn = cookies.includes('opt-in-tracking');
@@ -17,7 +17,7 @@ function checkOptInParticipation() {
 
   // Hide the banner after user makes a choice
   if ((optedIn || optedOut || optInDismissed) && banner) {
-    console.log("Hiding banner due to user choice (checkOptIn)");
+    console.log("Hiding banner due to user choice (checkOptInParticipation)");
     banner.style.display = 'none';
     banner.style.setProperty('display', 'none', 'important');
   }
@@ -73,12 +73,11 @@ document.addEventListener('DOMContentLoaded', function () {
     document.cookie = 'opt-out-tracking=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
     document.cookie = 'opt-in-dismissed=true; Path=/; Max-Age=2592000';
 
-    const banner = document.querySelector('.slider-wrapper.bps-banner.forum:not(.blue');
+    const banner = document.getElementById('opt-in-banner');
     if (banner) {
-        console.log("Hiding banner due to user choice (Opt In event)");
-        banner.style.display = 'none'
+        console.log("Hiding banner due to user choice (Opt In/Out event)");
         // Disable banner on refresh after user has made selection
-        document.cookie = 'seenBanner_opt-in=; Path=/; Max-Age=2592000';
+        banner.style.display = 'none'
     }
 
     checkOptInParticipation();
@@ -90,7 +89,7 @@ document.addEventListener('DOMContentLoaded', function () {
     document.cookie = 'opt-out-tracking=true; Path=/; Max-Age=2592000';
     document.cookie = 'opt-in-dismissed=true; Path=/; Max-Age=2592000';
 
-    const banner = document.querySelector('.slider-wrapper.bps-banner.forum:not(.blue)');
+    const banner = document.getElementById('opt-in-banner');
     if (banner) {
         console.log("Hiding banner due to user choice (Opt Out event)");
         banner.style.display = 'none';

--- a/browse/templates/base.html
+++ b/browse/templates/base.html
@@ -85,7 +85,10 @@
             aria-hidden prevents screenreaders from being caught, and tabindex prevents it from being selectable via the tab key. -#}
         <a aria-hidden="true" tabindex="-1" href="/IgnoreMe"></a>
         {% block header_h1 %}<h1><img src="{{ url_for('static', filename='images/arxiv-logo-one-color-white.svg') }}" alt="arxiv logo" style="height:60px;"/></h1>{% endblock header_h1%}
-        {% block login_link %}{% endblock %}
+        <div class="columns is-vcentered is-mobile" style="justify-content: flex-end;">
+          {% block opt_in_button %}{% endblock %}
+          {% block login_link %}{% endblock %}
+        </div>
         {{ base_macros.compactsearch() }}
        {% endblock header %}
      </div><!-- /end desktop header -->

--- a/browse/templates/home/home.html
+++ b/browse/templates/home/home.html
@@ -3,7 +3,7 @@
 {% block head %}
   {{ super() -}}
 {% endblock head %}
-
+{% block opt_in_button %}{% include 'opt_in_button.html' %}{% endblock %}
 {% block login_link %}{% include 'login.html' %}{% endblock %}
 {% block body_id %}id="front"{% endblock %}
 

--- a/browse/templates/opt_in_button.html
+++ b/browse/templates/opt_in_button.html
@@ -1,0 +1,3 @@
+<div class="column is-narrow" id="opt-in-status-button-container" style="display:none;">
+  <button id="opt-in-status-button" class="button is-small is-light"  title="">Status</button>
+</div>

--- a/browse/templates/user_banner.html
+++ b/browse/templates/user_banner.html
@@ -18,7 +18,7 @@ production.
 Adding an environment var, so we can enable only on gcp.
 -#}
 
-{# Banner varaibles - if you just want a default banner #}
+{# Banner variables - if you just want a default banner #}
 {% set BANNER_1_NAME = "birthday" %}
 {# Set these variables to a string of YYYYMMDD of the start and end date #}
 {% set BANNER_START_1 = 202508140000 %} {#  8/14  start of day#}
@@ -30,8 +30,8 @@ Adding an environment var, so we can enable only on gcp.
 
 {% set BANNER_2_NAME = "opt-in" %}
 {# Set these variables to a string of YYYYMMDD of the start and end date #}
-{% set BANNER_START_2 = 202508210000 %} {#  8/22  start of day#}
-{% set BANNER_END_2 = 202508262350 %}{#  8/26 end of day#}
+{% set BANNER_START_2 = 202509010000 %} {#  8/22  start of day#}
+{% set BANNER_END_2 = 202509102350 %}{#  8/26 end of day#}
 
 {% set SLIDE = True %}
 
@@ -59,7 +59,7 @@ Adding an environment var, so we can enable only on gcp.
 {%- macro banner_2_content(request_datetime) -%}
   {%- set now=request_datetime.strftime("%Y%m%d%H%M")|int -%}
   {%- if now >= BANNER_START_2 and now < BANNER_END_2 -%}
-    <aside class="slider-wrapper bps-banner forum">
+    <aside id="opt-in-banner" class="slider-wrapper bps-banner forum ">
       <a class="close-slider do-close-slider bps-banner" href="#">
         <img src="{{ url_for('static', filename='images/icons/close-slider.png') }}" alt="close this message">
       </a>

--- a/browse/templates/user_banner.html
+++ b/browse/templates/user_banner.html
@@ -30,8 +30,8 @@ Adding an environment var, so we can enable only on gcp.
 
 {% set BANNER_2_NAME = "opt-in" %}
 {# Set these variables to a string of YYYYMMDD of the start and end date #}
-{% set BANNER_START_2 = 202508170000 %} {#  8/18  start of day#}
-{% set BANNER_END_2 = 202508222350 %}{#  8/22 end of day#}
+{% set BANNER_START_2 = 202508210000 %} {#  8/22  start of day#}
+{% set BANNER_END_2 = 202508262350 %}{#  8/26 end of day#}
 
 {% set SLIDE = True %}
 


### PR DESCRIPTION
This PR includes a lot of code cleanup and changes to control the display states of the banner and new status button. This PR adds a "placeholder" button to represent the status of the opt-in feature. This was not designed or specified in the OptIn banner mockup document. This new 'status' button is intended to present the state of the opt-in feature and allow the user to change the state after the banner is hidden (once the user makes a choice).

This PR is necessary to deploy these changes to the browse.dev.arxiv.org server.

### Initial Banner display:

<img width="1340" height="458" alt="InitialOptInBanner" src="https://github.com/user-attachments/assets/7eda7f3a-38fe-4757-b4aa-87cd29ddf77f" />

### Opt In status button [Banner is hidden once user makes a decision (opt in, opt out, dismiss banner)]:

<img width="1337" height="364" alt="OptedIn" src="https://github.com/user-attachments/assets/7627e47c-19b6-4d14-8784-04b3fc25d3d6" />

### Opt Out Status

<img width="1325" height="393" alt="OptOut" src="https://github.com/user-attachments/assets/b35e3280-397e-4792-8ebf-0c7b7c552c5a" />

I still need to make adjustments to the button. The mockup document contains 'for discussion' bullet points for how to present this information on an arXiv page. The design of this status 'feature' needs to be discussed by stakeholders.

Once this is approved I will merge and deploy to browse.dev.arxiv.org. 