### PR TITLE
Removed link to outdated content

### DIFF
--- a/browse/templates/stats/main.html
+++ b/browse/templates/stats/main.html
@@ -25,10 +25,6 @@
         <h3><a href="https://info.arxiv.org/about/reports/submission_category_by_year.html">Submissions by Subject</a></h3>
         <a href="https://info.arxiv.org/about/reports/submission_category_by_year.html"><img alt="Submissions by Subject" class="stat-thumb" src="{{ url_for('static', filename='images/stat-thumb-subject.jpg') }}"></a>
       </div>
-      <div class="column">
-        <h3><a href="https://info.arxiv.org/about/reports/2022_usage.html">Institutional Downloads</a></h3>
-        <a href="https://info.arxiv.org/about/reports/2022_usage.html"><img alt="Institutional Downloads" class="stat-thumb" src="{{ url_for('static', filename='images/stat-thumb-institutional.jpg') }}"></a>
-      </div>
     </div>
   </div>
   <div class="chart_text chart_notes">


### PR DESCRIPTION
1. Remove the link: https://info.arxiv.org/about/reports/2022_usage.html from the arXiv Usage Statistics page: https://arxiv.org/stats/main on [arxiv-browse](https://github.com/arXiv/arxiv-browse).