### PR TITLE
Changes to sync_prod_to_gcp README

### DIFF
--- a/script/sync_prod_to_gcp/README.md
+++ b/script/sync_prod_to_gcp/README.md
@@ -1,61 +1,35 @@
 # Sync published submissons + PDFs from Cornell to a GS bucket
 
-This is a script to sync the published submissions and PDFs from a publish cycle to a GS Bucket.
+`sync_published_at_gcp.py` is the script sync published papers to GCP.
 
-# History
+It listens to pubsub events from the publish cycle, builds the PDF if needed,
+and then syncs the published source, .abs files and PDFs to a GS Bucket.
 
-## Pre 2024-08
+# How published papers get synced to GCP GS
+(Accurate as of 2025-10)
+## Publish fires events that get listened to by `sync_published_at_gcp.py`
+At publish the submission-published topic gets events for each published
+change. That gets subscribed to by `sync_published_at_gcp.py` which makes a HTTP
+request to the CIT web nodes to build the PDF. This is a normal
+`https://arxiv.org/pdf/{paperidv}` HTTP request to the web nodes.
 
-Originally, when the daily.sh runs and generates the published log file, the cron job picks it up,
-make the list of files to upload to GCP, ask the web node to generate PDF, and uploads them all.
+## PDF is built by HTTP requesting it from CIT web node
+The HTTP request to the web node ends up running `arxiv-lib`
+`arXiv::Converter::TeX::process()` which will run `arxiv-bin`
+`/compile_at_gcp/compile_announced_at_gcp.py` with the URL
+https://tex-to-pdf-default-1090350072932.us-central1.run.app This value might
+change. It is configured in `arxiv-lib` `arXiv::Config::Site-main::AutoTeX`.
+The resulting PDF from this is put in the CIT SFS under `/cache/ps_cache/`.
 
-Since the webnode's pdf generation is limited to certain number of processes, asking to generate
-PDF as a batch job was somewhat unreliable. Because of this, the multiple cron jobs are needed
-to complete the PDF generation and upload. 
+## Source, .abs and PDF from CIT SFS copied to GS
+The sync_published_at_gcp.py will then be able to get the PDF from the SFS and
+copy it to GCP.
 
-When HTML submission put in the GCP queue, it became possible to not only manage the published 
-articles more evenly spread out, it is now capable of retrying the PDF with sensible back off.
-
-The two clients of the queue is created, one to generate PDF so that the cron jobs don't have to
-generate PDFs for most of times, and the syncing of tarballs to GCP is spread out during the
-daily.sh run to make the published list. 
-
-Having 2 services + cron job were working okay but one omission was that, every week another 
-rsync based cron job was running but it was suspected to remove files when the CIT's file server
-mysteriously corrupts or not list a file. 
-
-6 daily cron jobs, one weekly sync, 2 services - one to make PDF, other to sync blobs - was too
-complex and esp. the weekly sync was not only dangerous but unexplainable due to the file server's
-flakyness.
-
-## Post 2024-08
-
-submissions-to-gcp unifies all this and "trashes" the older version of published submissions 
-if it exits on GCP bucket.
-
-See [submissions-to-gcp-service](#submissions-to-gcp-service)
-
-## Contributors
-
-* BrianC (bdc34): The original log based sync-to-gcp
-* ntai (nt385): The queue based sync-to-gcp, borrowing the functionality from the original
-* mark (men73): kicked off the pub/sub based publishing  
-
-# Synopsys of sync based on the published log
-
-    cd sync_prod_to_gcp
-    python --version
-    # Python 3.8.0
-    echo $GOOGLE_APPLICATION_CREDENTIALS
-    # /users/e-prints/arxiv-production-1234.json or your own credentials
-    # make will set up `sync.venv` the virtual env for sync to run.
-    make
-    #
-    . sync.venv/bin/activate
-    python sync_published_to_gcp.py /data/new/logs/publish_221101.log
-
-Although this became obsolete by the use of queue, it is still useful if you have to manually sync
-the published submissions to GCP.
+This system is not ideal and was developed before we had submission 1.5 and
+compile at GCP. But one requirement is that the PDFs end up both at CIT SFS and
+on GCP. At some point we'll be able to remove this requirement. But right now
+the EUST expects the PDFs to be at CIT SFS. There is code and other stuff that
+expects this too. (edited)
 
 # Development/Testing
 
@@ -104,22 +78,6 @@ permission.
     op read "op:///hs3xn7ldhg3pgrql5j524rgpee/w2wtsf5v7kahbngr64m43mciou/qrdfsd5gbnatjpv7zof6vwca4q"
 
 See `Makefile`
-
-# Obsolete: cron-based Deployment
-
-The script is designed to run as a cron job. With the use of pub/sub, the unit of work management
-is done by the queue. Therefore, there is no reason to run the cron jobs for multiple retry just
-to finish the job.
-
-## cronjob (obsolete) 
-
-Old:
-
-    15 21 * * 0-4 /opt_arxiv/e-prints/dissemination/sync_prod_to_gcp/sync_published.sh
-
-New:
-
-    15 21 * * 0-4 /users/e-prints/arxiv-browse/scrip/sync_prod_to_gcp/sync_published.sh
 
 # Queue-based Deployment - "submissions to gcp service"
 
@@ -271,13 +229,12 @@ Second is to copy the files from CIT to GCP.
 ## Running it
 
 Any **bad** becomes nacking of the event. GCP pub/sub backs off so this 
-becomes the retry attemp. When generating PDF, it is not unusual for
-web node to fail to bulid PDF in time. 
+becomes the retry attempt. When generating PDF, it is not unusual for
+web node to fail to build PDF in time.
 
-If the events get stuck, someone needs to take a look at the failuer.
+If the events get stuck, someone needs to take a look at the failure.
 GCP logging gives some clue, and def. you can know the paper ID. 
-Alart is set up on GCP so pay some attention to it.
-
+An alert is set up on GCP so pay some attention to it.
 
 ## Deployment
 
@@ -333,3 +290,61 @@ have it ~/arxiv-production-39d850b0221d.json as e-prints user
     mkdir /tmp/sync-to-gcp
 	sudo chown e-prints /tmp/sync-to-gcp
 	
+
+# Synopsys of sync based on the published log
+
+The sync_published_to_gcp.py is no longer used.
+
+    cd sync_prod_to_gcp
+    python --version
+    # Python 3.8.0
+    echo $GOOGLE_APPLICATION_CREDENTIALS
+    # /users/e-prints/arxiv-production-1234.json or your own credentials
+    # make will set up `sync.venv` the virtual env for sync to run.
+    make
+    #
+    . sync.venv/bin/activate
+    python sync_published_to_gcp.py /data/new/logs/publish_221101.log
+
+Although this became obsolete by the use of queue, it is still useful if you have to manually sync
+the published submissions to GCP.
+
+# History
+## Pre 2024-08
+
+Originally, when the daily.sh runs and generates the published log file, the cron job picks it up,
+make the list of files to upload to GCP, ask the web node to generate PDF, and uploads them all.
+
+Since the webnode's pdf generation is limited to certain number of processes, asking to generate
+PDF as a batch job was somewhat unreliable. Because of this, the multiple cron jobs are needed
+to complete the PDF generation and upload.
+
+When HTML submission put in the GCP queue, it became possible to not only manage the published
+articles more evenly spread out, it is now capable of retrying the PDF with sensible back off.
+
+The two clients of the queue is created, one to generate PDF so that the cron jobs don't have to
+generate PDFs for most of times, and the syncing of tarballs to GCP is spread out during the
+daily.sh run to make the published list.
+
+Having 2 services + cron job were working okay but one omission was that, every week another
+rsync based cron job was running but it was suspected to remove files when the CIT's file server
+mysteriously corrupts or not list a file.
+
+6 daily cron jobs, one weekly sync, 2 services - one to make PDF, other to sync blobs - was too
+complex and esp. the weekly sync was not only dangerous but unexplainable due to the file server's
+flakyness.
+
+## Post 2024-08
+
+submissions-to-gcp unifies all this and "trashes" the older version of published submissions
+if it exits on GCP bucket.
+
+No longer runs as a cron job, listens to a pubsub topic. All cron jobs removed.
+
+See [submissions-to-gcp-service](#submissions-to-gcp-service)
+
+## Contributors
+
+* BrianC (bdc34): The original log based sync-to-gcp
+* ntai (nt385): The queue based sync-to-gcp, borrowing the functionality from the original
+* mark (men73): kicked off the pub/sub based publishing


### PR DESCRIPTION
Adds as first prominent heading an overview of how papers are synced to GCP at publish time.