### PR TITLE
ARXIVCE-3884 Enhancements to OptIn feature: Adds new modal

### DIFF
--- a/browse/static/js/optin-modal.js
+++ b/browse/static/js/optin-modal.js
@@ -1,0 +1,54 @@
+// Support for Opt-In modal
+document.addEventListener('DOMContentLoaded', function () {
+  function getCookie(name) {
+    const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+    return match ? match[2] : null;
+  }
+
+  function showModal() {
+    // User opted in
+    const optedIn = getCookie('opt-in-tracking');
+    const modal = document.getElementById('optin-modal');
+    const title = document.getElementById('optin-title');
+    const paragraphs = modal.querySelectorAll('p');
+    const agreeBtn = document.getElementById('optin-agree');
+    const optoutBtn = document.getElementById('optin-optout');
+
+    if (optedIn) {
+      title.textContent = "You're Already Enrolled";
+      paragraphs[0].textContent = "You’ve already opted in to contribute your reading data to research. If you’d like to opt out, click below.";
+      paragraphs[1].style.display = "none"; // hide privacy policy link
+      agreeBtn.style.display = "none";
+      optoutBtn.style.display = "inline-block";
+    } else {
+      title.textContent = "Help Improve arXiv";
+      paragraphs[0].textContent = "arXiv is working with academic researchers to investigate ways to improve the service for our users. This requires a rich dataset to better inform the research. Users who wish to contribute to the future of arXiv may opt in to allow arXiv to use their reading data for research purposes. By clicking ‘I agree’ below, you consent to your reading data being collected, retained, and processed by arXiv and shared with researchers conducting research in the public interest. Reading data will never be shared publicly or otherwise incorporated into public systems in a personally identifiable format. Research use cases include developing privacy-preserving recommendation systems for arXiv.";
+      paragraphs[1].style.display = "block";
+      agreeBtn.style.display = "inline-block";
+      optoutBtn.style.display = "none";
+    }
+
+    modal.classList.remove('hidden');
+  }
+
+  document.getElementById('optin-trigger').addEventListener('click', showModal);
+
+  document.getElementById('optin-close').addEventListener('click', function() {
+    document.cookie = 'opt-out-tracking=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+    document.getElementById('optin-modal').classList.add('hidden');
+  });
+
+  document.getElementById('optin-agree').addEventListener('click', function() {
+    const uuid = crypto.randomUUID();
+    document.cookie = `opt-in-tracking=${uuid}; Path=/; Max-Age=31536000`;
+    document.getElementById('optin-modal').classList.add('hidden');
+  });
+
+  document.getElementById('optin-optout').addEventListener('click', function() {
+    document.cookie = 'opt-in-tracking=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+    alert("You have opted out.");
+    document.getElementById('optin-modal').classList.add('hidden');
+  });
+});
+
+

--- a/browse/static/js/optin.js
+++ b/browse/static/js/optin.js
@@ -78,6 +78,7 @@ document.addEventListener('DOMContentLoaded', function () {
         console.log("Hiding banner due to user choice (Opt In/Out event)");
         // Disable banner on refresh after user has made selection
         banner.style.display = 'none'
+        document.cookie = 'seenBanner_opt-in=; Path=/; Max-Age=2592000';
     }
 
     checkOptInParticipation();
@@ -111,8 +112,9 @@ function updateStatusButton(state) {
   container.style.display = 'block';
 
   if (state === 'optedIn') {
-    button.textContent = 'Opt Out';
-    button.title = 'You are currently opted in. Click to opt out.';
+    //button.textContent = 'Opt Out';
+    button.textContent = 'Thank you for contributing your reading data for research. Click here to pause data collection.';
+    button.title = 'Thank you for contributing your reading data for research. Click here to pause data collection.';
     button.onclick = function () {
       document.cookie = 'opt-in-tracking=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
       document.cookie = 'opt-out-tracking=true; Path=/; Max-Age=2592000';
@@ -120,8 +122,9 @@ function updateStatusButton(state) {
       checkOptInParticipation();
     };
   } else if (state === 'optedOut') {
-    button.textContent = 'Opt In';
-    button.title = 'You are currently opted out. Click to opt in.';
+    //button.textContent = 'Opt In';
+    button.textContent = 'Contribute my reading data to research. Click to agree.';
+    button.title = 'Contribute my reading data to research. Click to agree.';
     button.onclick = function () {
       const uuid = crypto.randomUUID();
       document.cookie = `opt-in-tracking=${uuid}; Path=/; Max-Age=31536000`;

--- a/browse/templates/base.html
+++ b/browse/templates/base.html
@@ -18,7 +18,8 @@
   <link rel="stylesheet" type="text/css" media="screen" href="{{ url_for('static', filename='css/arXiv.css') }}?v=20241206" />
   <link rel="stylesheet" type="text/css" media="print" href="{{ url_for('static', filename='css/arXiv-print.css') }}?v=20200611" />
   <link rel="stylesheet" type="text/css" media="screen" href="{{ url_for('static', filename='css/browse_search.css') }}" />
-  <script language="javascript" src="{{ url_for('static', filename='js/accordion.js') }}" /></script>
+  <script language="javascript" src="{{ url_for('static', filename='js/accordion.js') }}" ></script>
+  <script language="javascript" src="{{ url_for('static', filename='js/optin-modal.js') }}?v=20250819"></script>
   {{ user_banner.script(request_datetime) }}
   {%- endblock head -%}
 </head>
@@ -36,7 +37,7 @@
 
         {%- if rd_int >= 202504070100 and rd_int <= 202510282140 -%}
         <div class="column">
-        {% block opt_in_popup %}{% endblock %}
+        {% block opt_in_modal %}{% endblock %}
         </div>
         {%- endif -%}
 

--- a/browse/templates/base.html
+++ b/browse/templates/base.html
@@ -34,6 +34,11 @@
           <a href="https://www.cornell.edu/"><img src="{{ url_for('static', filename='images/icons/cu/cornell-reduced-white-SMALL.svg') }}" alt="Cornell University" /></a>
         </div>
 
+        {%- if rd_int >= 202504070100 and rd_int <= 202510282140 -%}
+        <div class="column">
+        {% block opt_in_popup %}{% endblock %}
+        </div>
+        {%- endif -%}
 
         <!-- /from April 7 at 1:00 AM to May 29 at 21:40 -->
         {%- if rd_int >= 202504070100 and rd_int <= 202505282140 -%}
@@ -44,7 +49,7 @@
         {%- endif -%}
 
         <!-- /from May 2 at 1:00 AM to May 5 at 9:45 AM -->
-        {%- if rd_int >= 202505020100 and rd_int <= 202505050945 -%}
+        {%- if rd_int >= 202505020100 and rd_int <= 202405050945 -%}
         <div class="column banner-minimal forum">
           <h3 style="color:#b31b1b;"><b>Monday, May 5:</b> arXiv will be READ ONLY at 9:00AM EST for approximately 30 minutes. We apologize for any inconvenience.</h3>
         </div>
@@ -85,10 +90,12 @@
             aria-hidden prevents screenreaders from being caught, and tabindex prevents it from being selectable via the tab key. -#}
         <a aria-hidden="true" tabindex="-1" href="/IgnoreMe"></a>
         {% block header_h1 %}<h1><img src="{{ url_for('static', filename='images/arxiv-logo-one-color-white.svg') }}" alt="arxiv logo" style="height:60px;"/></h1>{% endblock header_h1%}
+
         <div class="columns is-vcentered is-mobile" style="justify-content: flex-end;">
           {% block opt_in_button %}{% endblock %}
           {% block login_link %}{% endblock %}
         </div>
+
         {{ base_macros.compactsearch() }}
        {% endblock header %}
      </div><!-- /end desktop header -->

--- a/browse/templates/home/home.html
+++ b/browse/templates/home/home.html
@@ -3,8 +3,8 @@
 {% block head %}
   {{ super() -}}
 {% endblock head %}
-{% block opt_in_popup %}
- {% include 'opt_in_popup.html' %}
+{% block opt_in_modal %}
+ {% include 'opt_in_modal.html' %}
 {% endblock %}
 {% block opt_in_button %}
  {% include 'opt_in_button.html' %}

--- a/browse/templates/home/home.html
+++ b/browse/templates/home/home.html
@@ -3,7 +3,12 @@
 {% block head %}
   {{ super() -}}
 {% endblock head %}
-{% block opt_in_button %}{% include 'opt_in_button.html' %}{% endblock %}
+{% block opt_in_popup %}
+ {% include 'opt_in_popup.html' %}
+{% endblock %}
+{% block opt_in_button %}
+ {% include 'opt_in_button.html' %}
+{% endblock %}
 {% block login_link %}{% include 'login.html' %}{% endblock %}
 {% block body_id %}id="front"{% endblock %}
 

--- a/browse/templates/opt_in_button.html
+++ b/browse/templates/opt_in_button.html
@@ -1,3 +1,3 @@
 <div class="column is-narrow" id="opt-in-status-button-container" style="display:none;">
-  <button id="opt-in-status-button" class="button is-small is-light"  title="">Status</button>
+  <button id="opt-in-status-button" class="button is-small is-light btn-header-donate"  title="">Status</button>
 </div>

--- a/browse/templates/opt_in_modal.html
+++ b/browse/templates/opt_in_modal.html
@@ -1,0 +1,82 @@
+
+<!-- Opt-in Trigger Button -->
+ <script type="text/javascript" src="{{ url_for('static', filename='js/optin-modal.js') }}?v=20250819"></script>
+<button id="optin-trigger" class="optin-button" aria-haspopup="dialog">
+  Contribute my reading data to research
+</button>
+
+<!-- Modal Dialog -->
+<div id="optin-modal" class="optin-modal hidden" role="dialog" aria-modal="true" aria-labelledby="optin-title">
+  <div class="optin-modal-content">
+    <h2 id="optin-title">Help Improve arXiv</h2>
+    <p>
+      arXiv is working with academic researchers to investigate ways to improve the service for our users.
+      This requires a rich dataset to better inform the research. Users who wish to contribute to the future
+      of arXiv may opt in to allow arXiv to use their reading data for research purposes. By clicking ‘I agree’ below,
+      you consent to your reading data being collected, retained, and processed by arXiv and shared with researchers
+      conducting research in the public interest. Reading data will never be shared publicly or otherwise incorporated
+      into public systems in a personally identifiable format. Research use cases include developing privacy-preserving
+      recommendation systems for arXiv.
+    </p>
+    <p>
+      For more information, see the <a href="https://info.arxiv.org/help/policies/privacy_policy.html" target="_blank">arXiv Privacy Policy</a>.
+    </p>
+    <div class="optin-modal-actions">
+      <button id="optin-agree">I Agree</button>
+      <button id="optin-optout">Opt Out</button>
+      <button id="optin-close">Close</button>
+    </div>
+  </div>
+</div>
+
+<!-- OptIn Styling - Move to CSS file if approved-->
+<style>
+.optin-button {
+  background-color: #0055aa;
+  color: white;
+  border: none;
+  padding: 0.5em 1em;
+  margin: 0.5em;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1em;
+}
+
+.optin-modal.hidden {
+  display: none;
+}
+
+.optin-modal {
+  position: fixed;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  /* align-items: center; */
+  align-items: flex-start;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.optin-modal-content {
+  background: white;
+  color: black;
+  padding: 2em;
+  border-radius: 8px;
+  max-width: 600px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.3);
+}
+
+.optin-modal-actions {
+  margin-top: 1.5em;
+  text-align: right;
+}
+
+.optin-modal-actions button {
+  margin-left: 1em;
+  padding: 0.5em 1em;
+  font-size: 1em;
+}
+</style>
+
+


### PR DESCRIPTION
This PR contains numerous changes to the Opt-In UI implementation. Note that I have not received the final version of the descriptive text that is displayed in the banner and modal text areas. All text and button labels are open for discussion.

The initial opt-in banner implementation uses the existing banner framework. This is much more visible and could be used for an initial roll out. The new modal implementation adds a simple button in the header to support opting in and out of data collection.

There are two (independent) implementation represented in this demo.

    1) The banner option - the large opt-in banner appears when a user has not yet made a data collection selection or dismissed the banner. Once the user makes a selection or the banner is dismissed, a new button appears that indicates whether we are collecting data and allows the user to change the setting. The labels, context text, and positioning/location of this 'status' button is yet to be determine.
    
2) Modal - a button is added to the header. Clicking on the button displays a modal that allows the user to opt in(out) to data collection (per mockups). I added context for opting out of data collection (not specified in mockup).

I expect we may want to use both of these implementations in different situations.

A demo cloud run is currently running this code at: 

    https://arxiv-browse-opt-in-874717964009.us-central1.run.app/

Once this PR is approved, this PR will be deployed to browse.dev.arxiv.org.

FURTHER DISCUSSION IS NEEDED, PER THE MOCK UP DOCUMENT, TO FINALIZE THE UI IMPLEMENTATION.  I will organize a meeting once folks have a chance to experiment.