### PR TITLE
ARXIVCE-3952: Disable opt-in modal.

### DIFF
--- a/browse/templates/opt_in_modal.html
+++ b/browse/templates/opt_in_modal.html
@@ -1,7 +1,7 @@
 
 <!-- Opt-in Trigger Button -->
  <script type="text/javascript" src="{{ url_for('static', filename='js/optin-modal.js') }}?v=20250819"></script>
-<button id="optin-trigger" class="optin-button" aria-haspopup="dialog">
+<button id="optin-trigger" class="optin-button" aria-haspopup="dialog" disabled style="display: none;">
   Contribute my reading data to research
 </button>
 


### PR DESCRIPTION
Disable to opt-in modal. The modal button appears in the header.

The opt-in modal button is currently appearing in production. This needs to be merged and deployed.

The opt-in modal will actually set the opt-in cookie but the production log endpoint has not been updated so this will have no impact on the logs.