### PR TITLE
[HTML25-165] use arxiv foreground color for black-to-dark-mode map

### DIFF
--- a/browse/static/css/arxiv-html-papers-theme-20250916.css
+++ b/browse/static/css/arxiv-html-papers-theme-20250916.css
@@ -45,6 +45,14 @@
   --error-link-color: #176992; /* darker blue, passes color contrast */
   --error-text-color: #970503; /* dark red */
 }
+/* Special hand-crafted case: \color{black} is the most common use, so hand-curate to match
+   the main foreground color in dark mode.
+   TODO: This color should be a design token name eventually. Without that we have to copy
+   the full selector rule from ar5iv.css: */
+[data-theme="dark"] [style*="--ltx-fg-color:#000000;"] {
+  --text-color: #f9f7f7; /* warm wash */
+  color: var(--text-color);
+}
 
 #modal-submit {
   background-color: #b31b1b;


### PR DESCRIPTION
This PR redoes the black-to-dark-mode fixed map from [ar5iv.0.8.4css here](https://github.com/arXiv/arxiv-browse/blob/318f0aee0ef7052dc943607867323ada35538d8c/browse/static/css/ar5iv.0.8.4.css#L147-L153) using the warm wash arXiv foreground color.

Also a decent example where a "design token" --var name could have avoided the duplication of the selector rule. For now simply adjust the obvious way - this rule is used surprisingly often, as there are millions of black (`#000000`) inline color annotations coming from `\color{black}` in the source files.

For comparison see the text before/after Introduction at https://arxiv.org/html/2402.17214v2#S1