### PR TITLE
Hide the opt-in content on the cookies.html page.

### DIFF
--- a/browse/templates/cookies.html
+++ b/browse/templates/cookies.html
@@ -83,7 +83,7 @@ preferences.
 {% endif %}
 
 <hr>
-
+{% if optin %}
 <h2>Opt-in Data Collection for Research (Cornell University)</h2>
 
 <p>arXiv is working with academic researchers to investigate ways to improve
@@ -133,5 +133,6 @@ preferences.
     checkOptInParticipation();
   });
 </script>
+{% endif %}
 
 {% endblock content %}


### PR DESCRIPTION
Hide the opt-in content on the cookies.html page.

The opt-in description and button is currently visible on the cookies.html page at arXiv.org. This PR removes the opt-in description and button, along with the ability to test the opt-in backend implementation at browse.dev.arxiv.org.