### PR TITLE
[HTML25-208] [HTML25-209] refine navigation UX for narrow viewports

### DIFF
--- a/browse/static/css/arxiv-html-papers-theme-20250131.css
+++ b/browse/static/css/arxiv-html-papers-theme-20250131.css
@@ -338,7 +338,9 @@ Empirically, the xl >1280px breakpoint seems to be the first where a sidebar TOC
       height: 90vh;
       user-select: none;
     }
-    /* the entire sidebar should be toggled off in narrow viewports */
+    /* the entire navbar should be hidden in narrow viewports, not just the inner ToC */
+    /* also: reading mode has no navbar in narrow viewports */
+    [data-reading-mode=enabled] .ltx_page_navbar,
     [data-toc-display=none] .ltx_page_navbar {
       display: none;
     }

--- a/browse/static/js/arxiv-html-papers-20260131.js
+++ b/browse/static/js/arxiv-html-papers-20260131.js
@@ -91,7 +91,16 @@ function toggleNavTOC() {
         localStorage.setItem('arxiv_html_paper_toc_display', tocDisplay);
     }
 }
+function hideNavTOC() {
+    const toc = document.querySelectorAll('.ltx_page_navbar>nav.ltx_TOC');
+    if (toc.length > 0) {
+        document.documentElement.setAttribute("data-toc-display", 'none');
+        localStorage.setItem('arxiv_html_paper_toc_display', 'none');
+    }
+}
 
+// in sync with our CSS @media breakpoints for ToC and header
+const narrowViewport = window.matchMedia("(max-width: 1279px)").matches;
 // Toggles header and footer
 function toggleReadingMode() {
     const header = document.querySelectorAll('.arxiv-html-header');
@@ -99,6 +108,11 @@ function toggleReadingMode() {
     if (header.length > 0 && collapseIcon) {
         const style = window.getComputedStyle(header[0]);
         let readingMode = (style.display === 'none') ? 'disabled' : 'enabled';
+        if (narrowViewport && readingMode === 'enabled') {
+            // In narrow viewports, the header logically owns the ToC UI,
+            // thus a header hide should also hide the ToC.
+            hideNavTOC();
+        }
         document.documentElement.setAttribute("data-reading-mode", readingMode);
         localStorage.setItem('arxiv_html_paper_reading_mode', readingMode);
     }


### PR DESCRIPTION
* [HTML25-208] avoid links being unclickable due to an empty navbar taking over focus
* [HTML25-209] coordinate hiding header with hiding navbar on narrow viewports

[HTML25-208]: https://arxiv-org.atlassian.net/browse/HTML25-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HTML25-209]: https://arxiv-org.atlassian.net/browse/HTML25-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ