### PR TITLE
[HTML25-213] notify /view reverse proxy when article scaffold files change

### DIFF
--- a/.github/workflows/reverse-proxy-cd-on-merge.yml
+++ b/.github/workflows/reverse-proxy-cd-on-merge.yml
@@ -1,0 +1,20 @@
+name: Notify reverse proxy GHA of relevant changes
+
+on:
+  push:
+    branches: [master, develop]
+    paths:
+      - 'browse/templates/dissemination/article_scaffold/**'
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to concrete downstream repo
+        run: |
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.PAT_NOTIFY_ARXIV_VIEW_AS_HTML }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/arXiv/arxiv-view-as-html/dispatches \
+            -d '{"event_type":"arxiv-browse-updated","client_payload":{"branch":"${{ github.ref_name }}"}}'


### PR DESCRIPTION
This is the upstream/initiator of the flow.

- The new workflow tracks changes to the article_scaffold templates and sends an event to the reverse proxy GHA, which will run its trigger and redeploy (following https://github.com/arXiv/arxiv-view-as-html/pull/234 which now tracks master)
- Jake and I have added the mentioned PAT to the secrets of arxiv-browse

Sibling downstream PR coming up shortly.