### PR TITLE
Accessibility audit remediations for HTML papers, misc

### DIFF
--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -2937,7 +2937,6 @@ body#front.with-cu-identity #header #search {
   text-align: left;
   width: 100%;
   display: flex;
-  justify-content: space-between;
   align-items: center;
 }
 .large-data-list .accordion-toggle:focus {
@@ -2949,7 +2948,7 @@ body#front.with-cu-identity #header #search {
 }
 .large-data-list .accordion-toggle .accordion-caret:before {
   content: "\02C5";
-  padding-left: 1em;
+  padding-right: 0.5em;
   font-size: 1.25em;
   font-weight: 100;
 }

--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -2941,6 +2941,9 @@ body#front.with-cu-identity #header #search {
   align-items: center;
 }
 .large-data-list .accordion-toggle:focus {
+  outline: none;
+}
+.large-data-list .accordion-toggle:focus-visible {
   outline: 2px solid #005ea2;
   outline-offset: 2px;
 }

--- a/browse/static/css/arxiv-html-papers-theme-20250131.css
+++ b/browse/static/css/arxiv-html-papers-theme-20250131.css
@@ -256,6 +256,12 @@
     text-decoration: none;
     color: transparent;
     text-shadow: 0 0 0 var(--header-text-color);
+    /* Button reset for accessibility (changed from anchor to button) */
+    background: none;
+    border: none;
+    cursor: pointer;
+    font: inherit;
+    padding: 0.5rem;
   }
   .automatic-tog {
     display: block;

--- a/browse/static/css/latexml_styles.css
+++ b/browse/static/css/latexml_styles.css
@@ -730,6 +730,11 @@ body:after {
   margin-top: 0.1rem;
   color: transparent;
   text-shadow: 0 0 0 var(--header-text-color);
+  /* Button reset for accessibility (changed from anchor to button) */
+  background: none;
+  border: none;
+  cursor: pointer;
+  font: inherit;
 }
 
 .ar5iv-footer-button {

--- a/browse/static/css/latexml_styles.css
+++ b/browse/static/css/latexml_styles.css
@@ -912,12 +912,12 @@ li.ltx_tocentry.ltx_tocentry_appendix {
 }
 
 .back-to-reference-btn:focus {
-  outline: 2px solid transparent;
-  outline-offset: 2px;
+  outline: none;
 }
 
 .back-to-reference-btn:focus-visible {
-  box-shadow: none;
+  outline: 2px solid var(--link-text-color);
+  outline-offset: 2px;
 }
 .hide{
   display: none;

--- a/browse/static/js/addons.js
+++ b/browse/static/js/addons.js
@@ -41,18 +41,18 @@ let create_header = () => {
         <a class="ar5iv-footer-button hover-effect" target="_blank" href="#myForm" onclick="event.preventDefault(); var modal = document.getElementById('myForm'); modal.style.display = 'block'; bugReportState.setInitiateWay('Header');">Report Issue</a>
         ${id === 'submission' ? '' : `<a class="ar5iv-footer-button hover-effect" href="https://arxiv.org/abs/${locationId}">Back to Abstract</a>`}
         ${id === 'submission' ? '' : `<a class="ar5iv-footer-button hover-effect" href="https://arxiv.org/pdf/${locationId}" target="_blank">Download PDF</a>`}
-        <a class="ar5iv-toggle-color-scheme" href="javascript:toggleColorScheme()"
-        title="Toggle dark/light mode">
-        <label id="automatic-tog" class="toggle-icon" title="Switch to light mode" for="__palette_3">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="m14.3 16-.7-2h-3.2l-.7 2H7.8L11 7h2l3.2 9h-1.9M20 8.69V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69L23.31 12 20 8.69m-9.15 3.96h2.3L12 9l-1.15 3.65Z"></path></svg>
-        </label>
-        <label id="light-tog" class="toggle-icon" title="Switch to dark mode" for="__palette_1" hidden>
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a4 4 0 0 0-4 4 4 4 0 0 0 4 4 4 4 0 0 0 4-4 4 4 0 0 0-4-4m0 10a6 6 0 0 1-6-6 6 6 0 0 1 6-6 6 6 0 0 1 6 6 6 6 0 0 1-6 6m8-9.31V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69L23.31 12 20 8.69Z"></path></svg>
-        </label>
-        <label id="dark-tog" class="toggle-icon" title="Switch to system preference" for="__palette_2" hidden>
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 18c-.89 0-1.74-.2-2.5-.55C11.56 16.5 13 14.42 13 12c0-2.42-1.44-4.5-3.5-5.45C10.26 6.2 11.11 6 12 6a6 6 0 0 1 6 6 6 6 0 0 1-6 6m8-9.31V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69L23.31 12 20 8.69Z"></path></svg>
-        </label>
-      </a>
+        <button type="button" class="ar5iv-toggle-color-scheme" onclick="toggleColorScheme()"
+        title="Toggle dark/light mode" aria-label="Toggle color scheme">
+        <span id="automatic-tog" class="toggle-icon" title="Switch to light mode">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="m14.3 16-.7-2h-3.2l-.7 2H7.8L11 7h2l3.2 9h-1.9M20 8.69V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69L23.31 12 20 8.69m-9.15 3.96h2.3L12 9l-1.15 3.65Z"></path></svg>
+        </span>
+        <span id="light-tog" class="toggle-icon" title="Switch to dark mode" hidden>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 8a4 4 0 0 0-4 4 4 4 0 0 0 4 4 4 4 0 0 0 4-4 4 4 0 0 0-4-4m0 10a6 6 0 0 1-6-6 6 6 0 0 1 6-6 6 6 0 0 1 6 6 6 6 0 0 1-6 6m8-9.31V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69L23.31 12 20 8.69Z"></path></svg>
+        </span>
+        <span id="dark-tog" class="toggle-icon" title="Switch to system preference" hidden>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 18c-.89 0-1.74-.2-2.5-.55C11.56 16.5 13 14.42 13 12c0-2.42-1.44-4.5-3.5-5.45C10.26 6.2 11.11 6 12 6a6 6 0 0 1 6 6 6 6 0 0 1-6 6m8-9.31V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69L23.31 12 20 8.69Z"></path></svg>
+        </span>
+      </button>
       </nav>`;
 
   desktop_header.innerHTML = LogoBanner + Links;
@@ -83,18 +83,18 @@ let create_mobile_header = () => {
           </svg>
           </a>`}
         <!--dark mode-->
-        <a class="ar5iv-toggle-color-scheme" href="javascript:toggleColorScheme()"
-          title="Toggle dark/light mode">
-          <label id="automatic-tog" class="toggle-icon" title="Switch to light mode" for="__palette_3">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="m14.3 16-.7-2h-3.2l-.7 2H7.8L11 7h2l3.2 9h-1.9M20 8.69V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69L23.31 12 20 8.69m-9.15 3.96h2.3L12 9l-1.15 3.65Z"></path></svg>
-          </label>
-          <label id="light-tog" class="toggle-icon" title="Switch to dark mode" for="__palette_1" hidden>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a4 4 0 0 0-4 4 4 4 0 0 0 4 4 4 4 0 0 0 4-4 4 4 0 0 0-4-4m0 10a6 6 0 0 1-6-6 6 6 0 0 1 6-6 6 6 0 0 1 6 6 6 6 0 0 1-6 6m8-9.31V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69L23.31 12 20 8.69Z"></path></svg>
-          </label>
-          <label id="dark-tog" class="toggle-icon" title="Switch to system preference" for="__palette_2" hidden>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 18c-.89 0-1.74-.2-2.5-.55C11.56 16.5 13 14.42 13 12c0-2.42-1.44-4.5-3.5-5.45C10.26 6.2 11.11 6 12 6a6 6 0 0 1 6 6 6 6 0 0 1-6 6m8-9.31V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69L23.31 12 20 8.69Z"></path></svg>
-          </label>
-        </a>
+        <button type="button" class="ar5iv-toggle-color-scheme" onclick="toggleColorScheme()"
+          title="Toggle dark/light mode" aria-label="Toggle color scheme">
+          <span id="automatic-tog" class="toggle-icon" title="Switch to light mode">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="m14.3 16-.7-2h-3.2l-.7 2H7.8L11 7h2l3.2 9h-1.9M20 8.69V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69L23.31 12 20 8.69m-9.15 3.96h2.3L12 9l-1.15 3.65Z"></path></svg>
+          </span>
+          <span id="light-tog" class="toggle-icon" title="Switch to dark mode" hidden>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 8a4 4 0 0 0-4 4 4 4 0 0 0 4 4 4 4 0 0 0 4-4 4 4 0 0 0-4-4m0 10a6 6 0 0 1-6-6 6 6 0 0 1 6-6 6 6 0 0 1 6 6 6 6 0 0 1-6 6m8-9.31V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69L23.31 12 20 8.69Z"></path></svg>
+          </span>
+          <span id="dark-tog" class="toggle-icon" title="Switch to system preference" hidden>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 18c-.89 0-1.74-.2-2.5-.55C11.56 16.5 13 14.42 13 12c0-2.42-1.44-4.5-3.5-5.45C10.26 6.2 11.11 6 12 6a6 6 0 0 1 6 6 6 6 0 0 1-6 6m8-9.31V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69L23.31 12 20 8.69Z"></path></svg>
+          </span>
+        </button>
         <!--nav-->
         <button class="navbar-toggler ar5iv-footer-button" type="button" data-bs-theme="dark" data-bs-toggle="collapse" aria-expanded="false"
           data-bs-target=".ltx_page_main >.ltx_TOC.mobile" aria-controls="navbarSupportedContent" aria-expanded="false"

--- a/browse/static/js/feedbackOverlay.js
+++ b/browse/static/js/feedbackOverlay.js
@@ -27,7 +27,7 @@ var bugReportState = {
 function detectColorScheme() {
     let theme = "light";
     let current_theme = localStorage.getItem("ar5iv_theme");
-    let colorSchemeToggle = document.querySelector('.ar5iv-toggle-color-scheme');
+    let colorSchemeToggles = document.querySelectorAll('.ar5iv-toggle-color-scheme');
     let autoIcon = document.querySelectorAll('#automatic-tog');
     let lightIcon = document.querySelectorAll('#light-tog');
     let darkIcon = document.querySelectorAll('#dark-tog');
@@ -38,18 +38,18 @@ function detectColorScheme() {
         } else {
             theme = "light";
         }
-        colorSchemeToggle.setAttribute('aria-label', 'System preference')
+        colorSchemeToggles.forEach(toggle => toggle.setAttribute('aria-label', 'Color scheme: System preference. Click to switch to light mode.'));
         autoIcon.forEach(x => x.hidden = false);
         lightIcon.forEach(x => x.hidden = true);
         darkIcon.forEach(x => x.hidden = true);
     } else if (current_theme === "light") {
-        colorSchemeToggle.setAttribute('aria-label', 'Light mode')
+        colorSchemeToggles.forEach(toggle => toggle.setAttribute('aria-label', 'Color scheme: Light mode. Click to switch to dark mode.'));
         lightIcon.forEach(x => x.hidden = false);
         autoIcon.forEach(x => x.hidden = true);
         darkIcon.forEach(x => x.hidden = true);
         theme = "light";
     } else {
-        colorSchemeToggle.setAttribute('aria-label', 'Dark mode')
+        colorSchemeToggles.forEach(toggle => toggle.setAttribute('aria-label', 'Color scheme: Dark mode. Click to switch to system preference.'));
         darkIcon.forEach(x => x.hidden = false);
         autoIcon.forEach(x => x.hidden = true);
         lightIcon.forEach(x => x.hidden = true);
@@ -298,22 +298,82 @@ function addSRButton(modal) {
     return buttons;
 }
 
+// Store the element that had focus before modal opened
+var previouslyFocusedElement = null;
+
 function showModal(modal) {
     const theme = document.documentElement.getAttribute("data-theme");
     const modalHeader = document.getElementById("modal-header");
-    if (theme === 'dark') {  
+    if (theme === 'dark') {
         modalHeader.setAttribute('data-bs-theme', "dark");
-    }else{
+    } else {
         modalHeader.setAttribute('data-bs-theme', "light");
     }
-        
+
+    // Store the currently focused element to restore later
+    previouslyFocusedElement = document.activeElement;
+
     modal.style.display = 'block';
-    modal.setAttribute('tabindex', '-1'); // Ensure the modal is focusable
-    modal.focus();
+    modal.setAttribute('tabindex', '-1');
+    modal.setAttribute('aria-modal', 'true');
+
+    // Focus the first focusable element in the modal
+    var focusableElements = modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    if (focusableElements.length > 0) {
+        focusableElements[0].focus();
+    } else {
+        modal.focus();
+    }
+
+    // Add focus trap event listener
+    document.addEventListener('keydown', trapFocus);
 }
 
 function hideModal(modal) {
     modal.style.display = 'none';
+    modal.removeAttribute('aria-modal');
+
+    // Remove focus trap event listener
+    document.removeEventListener('keydown', trapFocus);
+
+    // Restore focus to the previously focused element
+    if (previouslyFocusedElement) {
+        previouslyFocusedElement.focus();
+        previouslyFocusedElement = null;
+    }
+}
+
+// Trap focus within the modal
+function trapFocus(e) {
+    var modal = document.getElementById('myForm');
+    if (!modal || modal.style.display === 'none') return;
+
+    var focusableElements = modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    var firstFocusable = focusableElements[0];
+    var lastFocusable = focusableElements[focusableElements.length - 1];
+
+    // Close on Escape key
+    if (e.key === 'Escape') {
+        hideModal(modal);
+        return;
+    }
+
+    // Only handle Tab key for focus trapping
+    if (e.key !== 'Tab') return;
+
+    if (e.shiftKey) {
+        // Shift + Tab: if on first element, wrap to last
+        if (document.activeElement === firstFocusable) {
+            e.preventDefault();
+            lastFocusable.focus();
+        }
+    } else {
+        // Tab: if on last element, wrap to first
+        if (document.activeElement === lastFocusable) {
+            e.preventDefault();
+            firstFocusable.focus();
+        }
+    }
 }
 
 function showButtons(buttons) {

--- a/browse/static/js/feedbackOverlay.js
+++ b/browse/static/js/feedbackOverlay.js
@@ -115,6 +115,7 @@ function addBugReportForm() {
     // Create the modal title
     const modalTitle = document.createElement("h5");
     modalTitle.setAttribute("class", "modal-title");
+    modalTitle.setAttribute("id", "modal-title");
     modalTitle.appendChild(document.createTextNode("Report GitHub Issue"));
 
     // Create the close button for the modal
@@ -144,10 +145,9 @@ function addBugReportForm() {
     warningLabel.setAttribute('class', 'form-text');
     warningLabel.textContent = "Warning: Issue reports will be publicly available on GitHub, including highlighted text. You may want to omit screenshots if you are reporting on a paper still in submission.";
 
-    // Create the description input field
-    const selectedTextDescriptionLabel = document.createElement("label");
-    selectedTextDescriptionLabel.setAttribute("for", "description");
-    //descriptionLabel.setAttribute("class", "form-label");
+    // Create the description status message (shown when text is selected)
+    const selectedTextDescriptionLabel = document.createElement("p");
+    selectedTextDescriptionLabel.setAttribute("class", "form-text");
     selectedTextDescriptionLabel.setAttribute("id", "selectedTextModalDescription");
     selectedTextDescriptionLabel.appendChild(document.createTextNode("Content selection saved. Describe the issue below:"));
 

--- a/browse/templates/category_taxonomy.html
+++ b/browse/templates/category_taxonomy.html
@@ -36,8 +36,8 @@
   {%- for group_key, group_details in groups.items()|sort if not group_details.is_test  -%}
   <h2 class="accordion-head" id="accordion-head-{{ group_key }}">
     <button type="button" class="accordion-toggle" aria-expanded="false" aria-controls="accordion-panel-{{ group_key }}">
-      {{ group_details.full_name }}
       <span class="accordion-caret" aria-hidden="true"></span>
+      {{ group_details.full_name }}
     </button>
   </h2>
   <div class="accordion-body" id="accordion-panel-{{ group_key }}" role="region" aria-labelledby="accordion-head-{{ group_key }}">

--- a/browse/templates/dissemination/article_scaffold/footer.html
+++ b/browse/templates/dissemination/article_scaffold/footer.html
@@ -46,7 +46,7 @@
   </div>
 </footer>
 <div id="fixed-buttons-container">
-  <div id="beta-badge">BETA</div>
+  <div id="beta-badge" aria-hidden="true">BETA</div>
   <a id="disable-reading-mode-btn" class="header-button" href="javascript:toggleReadingMode();"
     title="Disable reading mode, show header and footer">
     <svg role="presentation" height="1.25rem"

--- a/browse/templates/dissemination/article_scaffold/header.html
+++ b/browse/templates/dissemination/article_scaffold/header.html
@@ -83,28 +83,28 @@
       </svg>
     </a>
     <!--- colored theme toggle -->
-    <a class="header-button color-tog" href="javascript:toggleColorScheme();" title="Toggle dark/light mode">
-      <label class="toggle-icon automatic-tog" title="Switch to light mode">
+    <button type="button" class="header-button color-tog" onclick="toggleColorScheme();" title="Toggle dark/light mode" aria-label="Toggle color scheme">
+      <span class="toggle-icon automatic-tog" aria-hidden="true">
         <svg role="presentation" height="1.25rem" viewBox="0 0 24 24">
           <path
             d="m14.3 16-.7-2h-3.2l-.7 2H7.8L11 7h2l3.2 9h-1.9M20 8.69V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69L23.31 12 20 8.69m-9.15 3.96h2.3L12 9l-1.15 3.65Z">
           </path>
         </svg>
-      </label>
-      <label class="toggle-icon light-tog" title="Switch to dark mode">
+      </span>
+      <span class="toggle-icon light-tog" aria-hidden="true">
         <svg role="presentation" height="1.25rem" viewBox="0 0 24 24">
           <path
             d="M12 8a4 4 0 0 0-4 4 4 4 0 0 0 4 4 4 4 0 0 0 4-4 4 4 0 0 0-4-4m0 10a6 6 0 0 1-6-6 6 6 0 0 1 6-6 6 6 0 0 1 6 6 6 6 0 0 1-6 6m8-9.31V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69L23.31 12 20 8.69Z">
           </path>
         </svg>
-      </label>
-      <label class="toggle-icon dark-tog" title="Switch to system preference">
+      </span>
+      <span class="toggle-icon dark-tog" aria-hidden="true">
         <svg role="presentation" height="1.25rem" viewBox="0 0 24 24">
           <path
             d="M12 18c-.89 0-1.74-.2-2.5-.55C11.56 16.5 13 14.42 13 12c0-2.42-1.44-4.5-3.5-5.45C10.26 6.2 11.11 6 12 6a6 6 0 0 1 6 6 6 6 0 0 1-6 6m8-9.31V4h-4.69L12 .69 8.69 4H4v4.69L.69 12 4 15.31V20h4.69L12 23.31 15.31 20H20v-4.69L23.31 12 20 8.69Z">
           </path>
         </svg>
-      </label>
-    </a>
+      </span>
+    </button>
   </nav>
 </header>


### PR DESCRIPTION
Round 2 of accessibility remediations on arxiv-browse. All code changes done by Claude. Manually tested at https://arxiv-browse-accessibility-demo-874717964009.us-central1.run.app/html/2308.05590v2/

## HTML Paper Pages
1. Dark mode Toggle changed from <a href="javascript:..."> to <button type="button">, inner <label> elements to <span>, added ARIA labels. Edited for both desktop and mobile headers in addons.js.
2. Dark mode toggle button styling fix on the older template: added CSS reset in latexml_styles.css to remove default button appearance.
3. Modal Focus Trap issue: Will now focus on first focusable element when modal opens, tab key cycles within modal, escape key closes. Focus returns to the triggering element on close. 
4. Back-to-Reference button focus Indicator changed transparent to visible outline, and uses :focus-visible so indicator only shows for keyboard navigation.
5. Resolved various ARIA errors.

## Category Taxonomy Accordion Fixes
1. Accordion focus indicator is now using :focus-visible so focus ring only appears for keyboard navigation, not mouse clicks
2. Accordion caret repositioned back to left, as it is on prod.