### PR TITLE
ARXIVCE-4417: filter out unneeded results

### DIFF
--- a/browse/services/database/__init__.py
+++ b/browse/services/database/__init__.py
@@ -354,6 +354,7 @@ def get_sequential_id(paper_id: Identifier,
         if subject_class:
             query = query.filter(t_arXiv_in_category.c.subject_class == subject_class)
 
+    query = query.limit(1)
     result = Session.scalar(query)
     if result:
         return f"{result}"


### PR DESCRIPTION
Just the first row is needed.

With limit, vs original sql:
```
(cost=13583 rows=1) 
(cost=13583 rows=24662) 

(actual time=0.628..0.628 rows=1 loops=1)
(actual time=0.628..48.8 rows=289 loops=1)
```

In query analytics, looks like about 50k calls/hour.
Maybe bots.