### PR TITLE
Cache sub-20MB downloads at Fastly by serving HTTP 200 instead of HTTP 206

### DIFF
--- a/browse/config.py
+++ b/browse/config.py
@@ -85,6 +85,20 @@ class Settings(arxiv_base.Settings):
     The cache-control: max-age to set for /pdf /src /e-print /html pages. Max
     for this in the RFC is one year.
     """
+
+    FASTLY_CACHE_MAX_OBJECT_SIZE: int = 20 * 1024 * 1024
+    """Largest object, in bytes, that Fastly will cache as a single whole object.
+
+    Files at or below this size are returned in full (HTTP 200) even when the
+    client/CDN sends a Range header, so Fastly caches the whole object once and
+    serves later range requests from the edge instead of forwarding every range
+    request to the origin (the dominant driver of carrier-peering egress cost).
+
+    Files larger than this are served as HTTP 206 Partial Content so Fastly's
+    segmented caching can fetch them in range-sized pieces, and Cloud Run is not
+    forced to stream the whole (large) object in one response. Fastly's default
+    whole-object cache limit is 20 MB.
+    """
     """"========================= Services ========================="""
     DOCUMENT_LISTING_SERVICE: PyObject = 'browse.services.listing.db_listing'  # type: ignore
     """What implementation to use for the listing service.

--- a/browse/controllers/files/dissemination.py
+++ b/browse/controllers/files/dissemination.py
@@ -54,9 +54,20 @@ def default_resp_fn(file: FileObj,
         Any extra after the normal URL path part. For use in anc files or html files.
     """
     resp: Response = Response()
-    if request.method == 'GET' and 'range' in [hk.lower() for hk in request.headers.keys()]:
-        # Fastly requires Range response to cache large objects (>20MB),
-        # Cloud run requires response larger than 20MB to be chunked but Range response will be smaller.
+    range_requested = (request.method == 'GET'
+                       and 'range' in [hk.lower() for hk in request.headers.keys()])
+    # Only answer with HTTP 206 Partial Content for objects too large for Fastly
+    # to cache as a single whole object. For smaller objects a 206 stops Fastly
+    # from caching at all, so every range request (e.g. in-browser PDF viewers
+    # fetching byte ranges) is forwarded to the origin -- the main driver of
+    # carrier-peering egress cost. Returning the full 200 lets Fastly cache the
+    # object once and synthesize later range responses from the edge. (Through
+    # Fastly the end user still sees a 206; only the origin->Fastly fill changes.)
+    fastly_max_object = current_app.config.get(
+        "FASTLY_CACHE_MAX_OBJECT_SIZE", 20 * 1024 * 1024)
+    if range_requested and file.size > fastly_max_object:
+        # Fastly's segmented caching fetches >20MB objects in range-sized pieces,
+        # and Cloud Run is not forced to chunk-stream the whole large object.
         resp = RangeRequest(file.open('rb'),
                             etag=file.etag,
                             last_modified=file.updated,

--- a/tests/dissemination/test_range_caching.py
+++ b/tests/dissemination/test_range_caching.py
@@ -1,0 +1,60 @@
+"""Tests for the Fastly range/caching behaviour of file dissemination.
+
+Background: in-browser PDF viewers (and the CDN itself) issue HTTP Range
+requests. If the origin answers every Range request with a 206 Partial Content,
+Fastly will not cache the object, so each range request is forwarded to the
+origin -- which on arxiv-production was the dominant driver of carrier-peering
+egress cost.
+
+The dissemination controller therefore only emits a 206 for objects larger than
+``FASTLY_CACHE_MAX_OBJECT_SIZE`` (objects Fastly cannot cache whole and must
+fetch via segmented caching). Smaller objects are returned in full (200) so
+Fastly caches them once and synthesizes later range responses from the edge.
+"""
+import pytest
+
+# A small PDF that exists in the test fixture filesystem (see test_response_headers).
+PDF_PATH = "/pdf/cs/0012007"
+
+
+def test_caching_setup_default(client_with_test_fs):
+    """The whole-object cache threshold defaults to Fastly's 20 MB limit."""
+    assert client_with_test_fs.application.config["FASTLY_CACHE_MAX_OBJECT_SIZE"] \
+        == 20 * 1024 * 1024
+
+
+def test_small_object_range_served_whole_and_cacheable(client_with_test_fs):
+    """A Range request for a sub-threshold object is answered in full (200) and
+    carries the headers Fastly needs to cache it."""
+    resp = client_with_test_fs.get(PDF_PATH, headers={"Range": "bytes=0-1"})
+    assert resp.status_code == 200                       # served whole, not 206
+    assert "Content-Range" not in resp.headers           # i.e. not a partial response
+    assert resp.headers["Accept-Ranges"] == "bytes"      # still advertises range support
+    assert "max-age=31536000" in resp.headers.get("Surrogate-Control")  # cacheable at Fastly
+    assert resp.headers.get("ETag")                      # validator for the cached object
+    assert resp.headers.get("Content-Type") == "application/pdf"
+
+
+def test_no_range_is_full_200(client_with_test_fs):
+    """A plain GET (no Range header) is unchanged: a full, chunked 200."""
+    resp = client_with_test_fs.get(PDF_PATH)
+    assert resp.status_code == 200
+    assert resp.headers["Accept-Ranges"] == "bytes"
+    assert "Content-Range" not in resp.headers
+    assert "max-age=31536000" in resp.headers.get("Surrogate-Control")
+
+
+def test_large_object_served_as_206_for_segmented_caching(client_with_test_fs):
+    """An object above the threshold is served as 206 Partial Content so Fastly
+    segmented caching can fetch it in range-sized pieces."""
+    app = client_with_test_fs.application
+    original = app.config.get("FASTLY_CACHE_MAX_OBJECT_SIZE")
+    app.config["FASTLY_CACHE_MAX_OBJECT_SIZE"] = 0  # force every object over the limit
+    try:
+        resp = client_with_test_fs.get(PDF_PATH, headers={"Range": "bytes=0-1"})
+        assert resp.status_code == 206
+        assert resp.headers.get("Content-Range", "").startswith("bytes 0-1/")
+        # cache headers are still present so Fastly's segmented caching can store the pieces
+        assert "max-age=31536000" in resp.headers.get("Surrogate-Control")
+    finally:
+        app.config["FASTLY_CACHE_MAX_OBJECT_SIZE"] = original

--- a/tests/test_ps.py
+++ b/tests/test_ps.py
@@ -53,9 +53,14 @@ def test_ps(dbclient):
     for exp_key in expected_keys:
         assert exp_key in keys
 
-    resp = client.get(path + paperid, headers={"Range": "0-1"})
+    # A Range request for an object small enough for Fastly to cache whole is
+    # answered in full (200) so Fastly caches it once and serves subsequent range
+    # requests from the edge instead of hitting the origin for each one.
+    resp = client.get(path + paperid, headers={"Range": "bytes=0-1"})
     assert resp
-    assert resp.status_code == 206 or resp.status_code == 416
+    assert resp.status_code == 200
+    assert resp.headers["Accept-Ranges"] == "bytes"  # still range-capable, served whole
+    assert "max-age=31536000" in resp.headers.get("Surrogate-Control")  # cacheable at Fastly
 
 
 def test_non_ps(dbclient):

--- a/tests/test_src.py
+++ b/tests/test_src.py
@@ -87,9 +87,14 @@ def test_src(client_with_test_fs, path, paperid, expected_file, desc ):
     assert "Content-Length" in resp.headers
     assert "max-age=31536000" in resp.headers.get("Surrogate-Control")
 
-    resp = client.get(path + paperid, headers={"Range": "0-1"})
+    # A Range request for an object small enough for Fastly to cache whole is
+    # answered in full (200) so Fastly caches it once and serves subsequent range
+    # requests from the edge instead of hitting the origin for each one.
+    resp = client.get(path + paperid, headers={"Range": "bytes=0-1"})
     assert resp
-    assert resp.status_code == 206 or resp.status_code == 416
+    assert resp.status_code == 200
+    assert resp.headers["Accept-Ranges"] == "bytes"  # still range-capable, served whole
+    assert "max-age=31536000" in resp.headers.get("Surrogate-Control")  # cacheable at Fastly
 
 
 def test_src_version_not_found(client_with_test_fs):


### PR DESCRIPTION
### Motivation

This is a follow-up to a discussion we had at the Tuesday dev meeting, Jun 23. Some analysis suggested that we may not be caching small PDF files due to how Fastly deals with HTTP 206 responses.

### Details

`default_resp_fn` answered every `Range` request with `206 Partial Content`. Fastly (apparently) will not cache a 206 without segmented caching, so each range request (in-browser PDF viewers, and the CDN itself) was forwarded to the Cloud Run origin -- the dominant driver of the carrier-peering "Network Data Transfer Out" egress cost.

Production logs showed ~1-2 MB 206 PDF responses are ~69% of /pdf origin egress, with a 3.19x average repeat factor (~68% eliminable by caching).

So we can only emit HTTP 206 for objects larger than  Fastly's whole-object cache limit of 20 MB. Smaller objects are returned in full (HTTP 200) with Accept-Ranges, so Fastly caches the object once and synthesizes later range responses from the edge. Larger objects keep the 206 path for Fastly segmented caching.

### Testing

We need to do some request tracking with Fastly post-deploy to check if the caching behavior is as intended.

