### PR TITLE
permanently redirect /e-print to /src to reduce our traffic

### DIFF
--- a/browse/routes/src.py
+++ b/browse/routes/src.py
@@ -1,15 +1,20 @@
-"""Routes for serving the source of articles. /src /e-prints and ancillary."""
+"""Routes for serving the source of articles.
+
+/src serves the source; the legacy /e-print path permanently redirects to it.
+Also serves ancillary files.
+"""
 import logging
 from typing import Optional
 
 from arxiv.identifier import Identifier, IdentifierException
 from browse import b_add_surrogate_key
 
+from browse.controllers.files import maxage
 from browse.controllers.files.dissemination import get_src_resp
 from browse.controllers.files.ancillary_files import get_extracted_src_file_resp
 from browse.services.dissemination import get_article_store
 from browse.services.documents import get_doc_service
-from flask import Blueprint, Response, make_response, render_template
+from flask import Blueprint, Response, make_response, redirect, render_template, url_for
 from opentelemetry import trace
 
 logger = logging.getLogger(__file__)
@@ -58,17 +63,37 @@ def anc(arxiv_id: str, file_path:str):  # type: ignore
 
 @blueprint.route("/e-print/<string:arxiv_id_str>")
 @blueprint.route("/e-print/<string:archive>/<string:arxiv_id_str>")
+def e_print(arxiv_id_str: str, archive: Optional[str]=None):  # type: ignore
+    """Permanently redirect legacy /e-print URLs to the canonical /src URL.
+
+    /e-print and /src are the same handler and return byte-identical source
+    packages -- before 2024 they differed, but they no longer do. Serving the
+    source under two URLs makes crawlers download the (often large) source twice
+    and makes the CDN cache it under two keys. Collapsing /e-print onto /src with
+    a permanent, edge-cacheable 301 lets Fastly absorb repeat /e-print hits and
+    lets crawlers dedupe to a single canonical URL, cutting origin egress.
+    Mirrors and other redirect-following clients are unaffected: they follow the
+    301 to /src and get the same bytes.
+
+    The redirect itself never depends on the paper's content (it always points at
+    /src/<same id>), so it is cached for a long time and carries a single static
+    surrogate key for bulk purge should the policy ever be reversed.
+    """
+    resp=redirect(url_for(".src", arxiv_id_str=arxiv_id_str, archive=archive), 301)
+    resp.headers["Surrogate-Control"]=maxage()
+    resp.headers=b_add_surrogate_key(resp.headers, ["e-print-redirect"])
+    return resp
+
+
 @blueprint.route("/src/<string:arxiv_id_str>")
 @blueprint.route("/src/<string:archive>/<string:arxiv_id_str>")
 def src(arxiv_id_str: str, archive: Optional[str]=None):  # type: ignore
     """Serves the source of a requested paper.
 
-    This serves it in the original format submitted. Before 2024 it would .tar up
-    single file submissions.
-
-    The e-print path serves the source of a requested paper as original format submitted and
-    form that we store it (.tar.gz, .pdf, etc.). It is used to support the mirrors.
-    Before 2024 /src behavior was different than /e-print.
+    This serves it in the original format submitted and the form that we store it
+    in (.tar.gz, .pdf, etc.). Before 2024 it would .tar up single file
+    submissions. The legacy /e-print path (used to support the mirrors) now
+    permanently redirects here; see `e_print`.
      """
     resp=get_src_resp(arxiv_id_str, archive) #always adds a verion onto the id
     _src_surrogate_keys(resp, arxiv_id_str)

--- a/tests/dissemination/test_encrypted.py
+++ b/tests/dissemination/test_encrypted.py
@@ -22,8 +22,8 @@ def test_no_src_access(client_with_test_fs):
     expected_keys=["paper-unavailable", "unavailable-0704.0945v2", "paper-id-0704.0945", "not-public", "paper-id-0704.0945v2", "src"]
     assert all(" "+item+" " in keys for item in expected_keys)
 
-    #eprint path also blocks
-    resp = client_with_test_fs.get("/e-print/0704.0945v2")
+    #eprint path 301-redirects to /src, which still blocks not-public source
+    resp = client_with_test_fs.get("/e-print/0704.0945v2", follow_redirects=True)
     assert resp.status_code == 403
     assert 'Source Not Public' in resp.text
     assert headers["Surrogate-Control"]== 'max-age=31536000'

--- a/tests/test_response_headers.py
+++ b/tests/test_response_headers.py
@@ -138,20 +138,22 @@ def test_content_type_header( client_with_test_fs) -> None:
     resp = client.head("/pdf/cs/0012007")
     assert resp.headers.get('Content-Type', '')== "application/pdf"
 
+    # source content types are served from the canonical /src route;
+    # /e-print now 301-redirects to /src (see test_src.test_e_print_redirects_to_src)
     #source in .gz
-    resp = client.head("/e-print/cs/0011004")
+    resp = client.head("/src/cs/0011004")
     assert resp.headers.get('Content-Type', '')== "application/gzip"
 
     #source in tar.gz
-    resp = client.head("/e-print/cs/0012007")
+    resp = client.head("/src/cs/0012007")
     assert resp.headers.get('Content-Type', '')== "application/gzip"
     resp = client.head("/pdf/cs/0012007")
     assert resp.headers.get('Content-Type', '')== "application/pdf"
 
     #source is pdf
-    resp = client.head("/e-print/cs/0212040")
+    resp = client.head("/src/cs/0212040")
     assert resp.headers.get('Content-Type', '')== "application/pdf"
 
     #source file comes in a gz
-    resp = client.head("/e-print/cond-mat/9805021v1")
+    resp = client.head("/src/cond-mat/9805021v1")
     assert resp.headers.get('Content-Type', '')== "application/gzip"

--- a/tests/test_src.py
+++ b/tests/test_src.py
@@ -97,6 +97,28 @@ def test_src(client_with_test_fs, path, paperid, expected_file, desc ):
     assert "max-age=31536000" in resp.headers.get("Surrogate-Control")  # cacheable at Fastly
 
 
+@pytest.mark.parametrize("eprint_path, src_path", [
+    ("/e-print/1601.04345", "/src/1601.04345"),               # current version
+    ("/e-print/1601.04345v2", "/src/1601.04345v2"),           # explicit version
+    ("/e-print/cs/0011004", "/src/cs/0011004"),               # old style id
+    ("/e-print/cond-mat/9805021v1", "/src/cond-mat/9805021v1"),  # old style id + version
+])
+def test_e_print_redirects_to_src(client_with_test_fs, eprint_path, src_path):
+    """Legacy /e-print URLs permanently redirect to the canonical /src URL."""
+    resp = client_with_test_fs.get(eprint_path)  # do not follow the redirect
+    assert resp.status_code == 301
+    assert resp.headers["Location"].endswith(src_path)  # version/archive preserved
+    # The 301 must be cacheable at Fastly so repeat crawler hits to /e-print are
+    # absorbed at the edge instead of reaching the origin, and purgeable in bulk.
+    assert "max-age" in resp.headers.get("Surrogate-Control", "")
+    assert "e-print-redirect" in resp.headers.get("Surrogate-Key", "")
+
+    # Following the redirect yields the same source the /e-print URL used to serve.
+    followed = client_with_test_fs.get(eprint_path, follow_redirects=True)
+    assert followed.status_code == 200
+    assert followed.headers["Content-Disposition"].startswith("attachment")
+
+
 def test_src_version_not_found(client_with_test_fs):
     resp = client_with_test_fs.get("/src/cond-mat/9805021v9")
     assert resp.status_code == 404


### PR DESCRIPTION
### Motivation

This is a follow-up to a discussion we had at the Tuesday dev meeting, Jun 23. One hypothesis is that by having alias names (such as /src and /e-print) for the same download route, we are increasing the overall traffic from non-compliant crawlers, which may not be aware they are fetching duplicate content.

### Details

One low cost approach we can try is to use HTTP 301 permanent redirects for alias routes, which tend to be honored by most crawlers for performance reasons.

This PR attempts that for the legacy `/e-print` route, and we can evaluate if that has impact before considering using the measure elsewhere.

