### PR TITLE
[RI-396] self-heal an empty/inconsistent listing page

### DIFF
--- a/browse/config.py
+++ b/browse/config.py
@@ -99,6 +99,33 @@ class Settings(arxiv_base.Settings):
     forced to stream the whole (large) object in one response. Fastly's default
     whole-object cache limit is 20 MB.
     """
+
+    LISTING_EMPTY_MAX_AGE: int = 5 * 60
+    """Surrogate-Control max-age (seconds) for an unexpectedly empty listing.
+
+    /list/<ctx>/new and /recent are normally cached for a week. But their item
+    list is rendered from a different query than the counts (items require a
+    Metadata.is_current=1 join the counts do not), so a read-replica lag window
+    during an announcement can produce an empty render while the counts are
+    non-zero. Long-caching that empty page froze a ~2 minute DB blip into a ~10
+    hour outage on 2026-06-25. When a daily-volatile listing comes back empty we
+    cache it only this briefly so it self-heals instead of staying frozen for a
+    week. A count/items contradiction is treated more strongly (see the list_page
+    controller): it returns 503 so Fastly does not cache it at all.
+    """
+
+    LISTING_STALE_IF_ERROR: int = DAY
+    """How long (seconds) Fastly may serve a stale-but-good listing on origin error.
+
+    Emitted as ``stale-if-error`` on the Surrogate-Control of every /list page.
+    It is what makes the 503-on-inconsistency safe: when the origin answers a
+    revalidation with a 5xx (including the deliberate 503 we return for a
+    count/items contradiction), Fastly keeps serving the last good listing from
+    grace for up to this long instead of showing users the error. Listings are
+    refreshed by the announce/publish pipeline's purges, so the cached object
+    rarely approaches even its normal max-age; a day of error-grace is ample to
+    cover an announcement read-replica lag window and its recovery.
+    """
     """"========================= Services ========================="""
     DOCUMENT_LISTING_SERVICE: PyObject = 'browse.services.listing.db_listing'  # type: ignore
     """What implementation to use for the listing service.

--- a/browse/controllers/__init__.py
+++ b/browse/controllers/__init__.py
@@ -13,7 +13,10 @@ from arxiv.identifier import Identifier
 from werkzeug.datastructures import Headers
 
 
-Response = Tuple[Dict[str, Any], int|status, Dict[str, Any]|Headers]
+# The body is usually a template-context dict, but a controller may also return
+# a ready-made body string (e.g. the list_page 503 served on a listing
+# inconsistency, which must not go through normal template rendering).
+Response = Tuple[Dict[str, Any]|str, int|status, Dict[str, Any]|Headers]
 
 
 def check_supplied_identifier(id: Identifier, route: str) -> Optional[Response]:

--- a/browse/controllers/__init__.py
+++ b/browse/controllers/__init__.py
@@ -13,10 +13,7 @@ from arxiv.identifier import Identifier
 from werkzeug.datastructures import Headers
 
 
-# The body is usually a template-context dict, but a controller may also return
-# a ready-made body string (e.g. the list_page 503 served on a listing
-# inconsistency, which must not go through normal template rendering).
-Response = Tuple[Dict[str, Any]|str, int|status, Dict[str, Any]|Headers]
+Response = Tuple[Dict[str, Any], int|status, Dict[str, Any]|Headers]
 
 
 def check_supplied_identifier(id: Identifier, route: str) -> Optional[Response]:

--- a/browse/controllers/list_page/__init__.py
+++ b/browse/controllers/list_page/__init__.py
@@ -308,17 +308,20 @@ def get_listing(subject_or_category: str,
         empty_max_age = current_app.config.get("LISTING_EMPTY_MAX_AGE", 5 * 60)
         if expected_but_missing:
             # Counts promise items but none rendered (replica-lag fingerprint):
-            # 503 so Fastly serves the last good copy via stale-if-error; keep the
-            # surrogate keys so it stays purgeable. The route renders the simple
-            # text body for this status; an empty context dict keeps the response
-            # shape unchanged (no template rendering for an error page).
+            # 503 so Fastly serves the last good copy via stale-if-error, while a
+            # short edge cache (the empty-listing TTL, not the week-long freeze)
+            # keeps a thundering herd off the DB until the listing is ready.
+            # Surrogate keys are preserved so it stays purgeable. The route
+            # renders the simple text body for this status; an empty context dict
+            # keeps the response shape unchanged (no template rendering for an
+            # error page).
             if current_app.config.get("ARXIV_LOG_DATA_INCONSTANCY_ERRORS"):
                 logger.error(
                     "Listing inconsistency for %s/%s: counts promise items but "
                     "none rendered (skip=%d, count=%d, items=%d). Likely "
                     "read-replica lag; returning 503 instead of a wrong page.",
                     list_ctx_id, time_period, skipn, count, len(listings))
-            response_headers["Surrogate-Control"] = "max-age=0"  # never cache
+            response_headers["Surrogate-Control"] = f"max-age={empty_max_age}"
             response_headers["Retry-After"] = str(empty_max_age)
             return ({}, status.SERVICE_UNAVAILABLE, response_headers)
         if announce_page:

--- a/browse/controllers/list_page/__init__.py
+++ b/browse/controllers/list_page/__init__.py
@@ -89,21 +89,6 @@ type_to_template = {
     'year': 'list/year.html'
 }
 
-# Body for the 503 served when a listing is empty but its counts say it should
-# not be (the read-replica inconsistency fingerprint). Deliberately a
-# self-contained static string, not a rendered template: an error page shown
-# when the data layer is misbehaving must not depend on templates or services
-# that could be failing too. Users rarely see it (stale-if-error serves the last
-# good copy at the edge). No request data is interpolated, so nothing to escape.
-_LISTING_UNAVAILABLE_HTML = (
-    "<!DOCTYPE html>\n"
-    "<html lang='en'><head><meta charset='utf-8'>"
-    "<title>Listing temporarily unavailable</title></head>"
-    "<body><h1>This listing is temporarily unavailable</h1>"
-    "<p>This page is being refreshed. Please retry in a few minutes.</p>"
-    "</body></html>"
-)
-
 
 class ListingSection:
     heading:str
@@ -324,7 +309,9 @@ def get_listing(subject_or_category: str,
         if expected_but_missing:
             # Counts promise items but none rendered (replica-lag fingerprint):
             # 503 so Fastly serves the last good copy via stale-if-error; keep the
-            # surrogate keys so it stays purgeable.
+            # surrogate keys so it stays purgeable. The route renders the simple
+            # text body for this status; an empty context dict keeps the response
+            # shape unchanged (no template rendering for an error page).
             if current_app.config.get("ARXIV_LOG_DATA_INCONSTANCY_ERRORS"):
                 logger.error(
                     "Listing inconsistency for %s/%s: counts promise items but "
@@ -333,8 +320,7 @@ def get_listing(subject_or_category: str,
                     list_ctx_id, time_period, skipn, count, len(listings))
             response_headers["Surrogate-Control"] = "max-age=0"  # never cache
             response_headers["Retry-After"] = str(empty_max_age)
-            return (_LISTING_UNAVAILABLE_HTML,
-                    status.SERVICE_UNAVAILABLE, response_headers)
+            return ({}, status.SERVICE_UNAVAILABLE, response_headers)
         if announce_page:
             # Genuinely empty or a total-lag transient (counts empty too): cache
             # briefly so it self-heals; historical months keep their long cache.

--- a/browse/controllers/list_page/__init__.py
+++ b/browse/controllers/list_page/__init__.py
@@ -63,7 +63,7 @@ from browse.services.listing import (Listing, ListingNew, NotModifiedResponse,
 
 from browse.formatting.latexml import get_latexml_url, get_latexml_urls_for_articles
 
-from flask import request, url_for
+from flask import current_app, request, url_for
 from werkzeug.exceptions import BadRequest, NotFound
 
 logger = logging.getLogger(__name__)
@@ -88,6 +88,22 @@ type_to_template = {
     'month': 'list/month.html',
     'year': 'list/year.html'
 }
+
+# Body for the 503 served when a listing is empty but its counts say it should
+# not be (the read-replica inconsistency fingerprint). Deliberately a
+# self-contained static string, not a rendered template: an error page shown
+# when the data layer is misbehaving must not depend on templates or services
+# that could be failing too. Users rarely see it (stale-if-error serves the last
+# good copy at the edge). No request data is interpolated, so nothing to escape.
+_LISTING_UNAVAILABLE_HTML = (
+    "<!DOCTYPE html>\n"
+    "<html lang='en'><head><meta charset='utf-8'>"
+    "<title>Listing temporarily unavailable</title></head>"
+    "<body><h1>This listing is temporarily unavailable</h1>"
+    "<p>This page is being refreshed. Please retry in a few minutes.</p>"
+    "</body></html>"
+)
+
 
 class ListingSection:
     heading:str
@@ -198,9 +214,17 @@ def get_listing(subject_or_category: str,
 
     response_data: Dict[str, Any] = {}
     response_headers: Headers = Headers()
+    # Daily-volatile pages (new/recent and the current month/year) carry the
+    # "announce" surrogate key. Only these can become *transiently* empty from
+    # replica lag, so only these get the short-cache-on-empty treatment below;
+    # immutable historical months keep their normal long cache even when empty.
+    announce_page = False
+    # True when the counts promise items this page should show but none rendered.
+    expected_but_missing = False
 
     if time_period == 'new':
         list_type = 'new'
+        announce_page = True
         response_headers=b_add_surrogate_key(response_headers,["list-new", "announce", f"list-new-{list_ctx_id}"])
         new_resp: Union[ListingNew, NotModifiedResponse] =\
             listing_service.list_new_articles(list_ctx_id, skipn,
@@ -211,6 +235,11 @@ def get_listing(subject_or_category: str,
         listings = new_resp.listings
         count = new_resp.new_count + \
             new_resp.rep_count + new_resp.cross_count
+        # Key /new on the new count, not the replacement-polluted total: a day of
+        # only replacements is legitimate, missing new submissions is not.
+        new_shown = any(item.listingType == 'new' for item in listings)
+        expected_but_missing = (new_resp.new_count > skipn and not new_shown) \
+            or (count > skipn and not listings)
         response_data['announced'] = new_resp.announced
         response_data.update(
             index_for_types(new_resp, list_ctx_id, time_period, skipn, shown))
@@ -219,6 +248,7 @@ def get_listing(subject_or_category: str,
     elif time_period in ['pastweek', 'recent']:
         # A bit different due to returning days not listings
         list_type = 'recent'
+        announce_page = True
         response_headers=b_add_surrogate_key(response_headers,["list-recent", "announce", f"list-recent-{list_ctx_id}"])
         rec_resp = listing_service.list_pastweek_articles(
             list_ctx_id, skipn, shown, if_mod_since)
@@ -227,6 +257,7 @@ def get_listing(subject_or_category: str,
             return {}, status.NOT_MODIFIED, response_headers
         listings = rec_resp.listings
         count = rec_resp.count
+        expected_but_missing = count > skipn and not listings
         response_data['pubdates'] = rec_resp.pubdates
         response_data.update(sub_sections_for_recent(rec_resp, skipn, shown))
 
@@ -260,6 +291,7 @@ def get_listing(subject_or_category: str,
             list_type = 'month'
             response_headers=b_add_surrogate_key(response_headers,[f"list-{list_year:04d}-{list_month:02d}-{list_ctx_id}"])
             if date.today().year==list_year and date.today().month==list_month:
+                announce_page = True
                 response_headers=b_add_surrogate_key(response_headers,["announce"])
             response_data['list_month'] = str(list_month)
             response_data['list_month_name'] = calendar.month_abbr[list_month]
@@ -268,7 +300,8 @@ def get_listing(subject_or_category: str,
         else:
             list_type = 'year'
             response_headers=b_add_surrogate_key(response_headers,[f"list-{list_year:04d}-{list_ctx_id}"])
-            if list_year==date.today().year: 
+            if list_year==date.today().year:
+                announce_page = True
                 response_headers=b_add_surrogate_key(response_headers,["announce"])
             resp = listing_service.list_articles_by_year(
                 list_ctx_id, list_year, skipn, shown, if_mod_since)
@@ -278,10 +311,34 @@ def get_listing(subject_or_category: str,
             return {}, status.NOT_MODIFIED, response_headers
         listings = resp.listings
         count = resp.count
+        expected_but_missing = count > skipn and not listings
         if resp.pubdates and resp.pubdates[0]:
             response_data['pubmonth'] = resp.pubdates[0][0]
         else:
             response_data['pubmonth'] = datetime.now() # just to make the template happy
+
+    # Don't long-cache an empty/inconsistent listing: a replica-lag blip that
+    # left /new empty was frozen for a week (~10h outage on 2026-06-25).
+    if expected_but_missing or not listings:
+        empty_max_age = current_app.config.get("LISTING_EMPTY_MAX_AGE", 5 * 60)
+        if expected_but_missing:
+            # Counts promise items but none rendered (replica-lag fingerprint):
+            # 503 so Fastly serves the last good copy via stale-if-error; keep the
+            # surrogate keys so it stays purgeable.
+            if current_app.config.get("ARXIV_LOG_DATA_INCONSTANCY_ERRORS"):
+                logger.error(
+                    "Listing inconsistency for %s/%s: counts promise items but "
+                    "none rendered (skip=%d, count=%d, items=%d). Likely "
+                    "read-replica lag; returning 503 instead of a wrong page.",
+                    list_ctx_id, time_period, skipn, count, len(listings))
+            response_headers["Surrogate-Control"] = "max-age=0"  # never cache
+            response_headers["Retry-After"] = str(empty_max_age)
+            return (_LISTING_UNAVAILABLE_HTML,
+                    status.SERVICE_UNAVAILABLE, response_headers)
+        if announce_page:
+            # Genuinely empty or a total-lag transient (counts empty too): cache
+            # briefly so it self-heals; historical months keep their long cache.
+            response_headers["Surrogate-Control"] = f"max-age={empty_max_age}"
 
     # TODO if it is a HEAD, and nothing has changed, send not modified
 
@@ -602,6 +659,13 @@ def _expires_headers(listing_resp:
                      Union[Listing, ListingNew, NotModifiedResponse]) \
                      -> Dict[str, str]:
     if listing_resp and listing_resp.expires:
-        return {'Surrogate-Control': f'max-age={listing_resp.expires}'}
+        # stale-if-error lets Fastly keep serving the last good listing from
+        # grace when the origin answers a revalidation with a 5xx -- including
+        # the 503 get_listing deliberately returns for a count/items
+        # inconsistency. Without it, that 503 (or any origin error) would reach
+        # users instead of the cached page.
+        stale = current_app.config.get("LISTING_STALE_IF_ERROR", 24 * 60 * 60)
+        return {'Surrogate-Control':
+                f'max-age={listing_resp.expires}, stale-if-error={stale}'}
     else:
         return {}

--- a/browse/routes/ui.py
+++ b/browse/routes/ui.py
@@ -259,6 +259,13 @@ def list_articles(context: str, subcontext: str) -> Response:
         return redirect(headers["Location"], code=code)  # type: ignore
     elif code == status.NOT_MODIFIED:
         return "", code, headers  # type: ignore
+    elif code == status.SERVICE_UNAVAILABLE:
+        # Empty/inconsistent listing the controller declined to cache as a real
+        # page: a simple text body, not a rendered template (the data layer may
+        # be misbehaving). Users rarely see it -- stale-if-error serves the last
+        # good copy at the edge.
+        return ("This listing is temporarily unavailable; please retry in a few minutes.",
+                code, headers)  # type: ignore
     return response, code, headers  # type: ignore
 
 

--- a/tests/listings/test_list_page.py
+++ b/tests/listings/test_list_page.py
@@ -1,12 +1,15 @@
 import pytest
 import re
+import logging
 from datetime import date
 from unittest.mock import MagicMock
 from unittest import mock
 
 from browse.controllers import list_page
 
-from browse.services.listing import NotModifiedResponse, get_listing_service
+from browse.services.listing import (NotModifiedResponse, get_listing_service,
+                                      ListingNew, Listing, ListingItem, gen_expires)
+from browse.services.listing.fake_listings import FakeListingFilesService
 from bs4 import BeautifulSoup
 
 
@@ -885,3 +888,148 @@ def test_surrogate_keys(client_with_db_listings):
     assert "list-ym" in head
     assert "announce" in head
 
+
+
+# --- Regression tests for the empty/inconsistent listing cache guard ----------
+# Background: /list/<ctx>/new and /recent render their item list from a
+# Metadata.is_current=1 join, but compute the counts from a separate
+# arXiv_updates(+in_category) query. A read-replica lag window during an
+# announcement can leave the counts non-zero while the items come back empty.
+# Long-caching that empty render (Surrogate-Control: max-age=604800) froze a
+# ~2 minute replica blip into a ~10 hour outage on 2026-06-25.
+
+def _empty_new(new_count=0, cross_count=0, rep_count=0):
+    """A ListingNew with NO items but the given (separately-computed) counts --
+    the shape the controller sees during a read-replica lag window."""
+    return ListingNew(listings=[], new_count=new_count, cross_count=cross_count,
+                      rep_count=rep_count, announced=date(2007, 4, 1),
+                      expires=gen_expires())
+
+
+@pytest.mark.parametrize("listing_new, why", [
+    (_empty_new(new_count=7), "whole page empty"),
+    (ListingNew(listings=[ListingItem("0704.0526", "rep", "cs.DB"),
+                          ListingItem("0704.0988", "rep", "cs.DB")],
+                new_count=9, cross_count=0, rep_count=2,
+                announced=date(2007, 4, 1), expires=gen_expires()),
+     "new submissions missing while replacements still render"),
+])
+def test_new_inconsistency_returns_503(client_with_fake_listings, caplog, listing_new, why):
+    """The counts promise new submissions but none rendered -- whether the page is
+    wholly empty, or only replacements remain because the new papers' fresh
+    metadata is still lagging. Either shape is the replica-lag fingerprint: an
+    uncacheable 503 that is logged and stays purgeable, not a wrong page frozen at
+    Fastly for a week. (The reps-present case proves the check keys on the new
+    count, not the replacement-polluted total.)"""
+    with mock.patch.object(FakeListingFilesService, "list_new_articles",
+                           return_value=listing_new), \
+            caplog.at_level(logging.ERROR):
+        rv = client_with_fake_listings.get("/list/hep-ph/new")
+    assert rv.status_code == 503, why
+    sc = rv.headers.get("Surrogate-Control", "")
+    assert "604800" not in sc and "max-age=0" in sc    # uncacheable, not the week freeze
+    assert rv.headers.get("Retry-After")               # tells clients when to retry
+    keys = " " + rv.headers.get("Surrogate-Key", "") + " "
+    assert " list " in keys and " list-new " in keys   # still purgeable
+    assert "inconsistency" in caplog.text.lower()      # alerting hook fired
+
+
+def test_recent_inconsistent_counts_returns_503(client_with_fake_listings):
+    """The same guard protects /recent, which was also empty during the
+    2026-06-25 outage (it uses a different controller branch and response type)."""
+    client = client_with_fake_listings
+    bad = Listing(listings=[], pubdates=[(date(2007, 4, 1), 5)], count=5,
+                  expires=gen_expires())
+    with mock.patch.object(FakeListingFilesService, "list_pastweek_articles",
+                           return_value=bad):
+        rv = client.get("/list/hep-ph/recent")
+    assert rv.status_code == 503
+    assert "max-age=0" in rv.headers.get("Surrogate-Control", "")
+    keys = " " + rv.headers.get("Surrogate-Key", "") + " "
+    assert " list-recent " in keys
+
+
+def test_new_only_replacements_served_normally(client_with_fake_listings):
+    """A day with only replacements and zero new submissions is a legitimate,
+    fully-rendered /new page. It must NOT be mistaken for the inconsistency and
+    503'd: replacements legitimately 'pollute' the total count, which is exactly
+    why the check looks at the new count instead."""
+    client = client_with_fake_listings
+    only_reps = ListingNew(
+        listings=[ListingItem("0704.0526", "rep", "cs.DB"),
+                  ListingItem("0704.0988", "rep", "cs.DB")],
+        new_count=0, cross_count=0, rep_count=2,   # genuinely no new submissions
+        announced=date(2007, 4, 1), expires=gen_expires())
+    with mock.patch.object(FakeListingFilesService, "list_new_articles",
+                           return_value=only_reps):
+        rv = client.get("/list/hep-ph/new")
+    assert rv.status_code == 200                    # legit page, served normally
+    sc = rv.headers.get("Surrogate-Control", "")
+    assert "max-age=0" not in sc                    # not the 503 path
+    assert "max-age=300" not in sc                  # not short-cached; it is a real page
+
+
+def test_new_genuinely_empty_is_short_cached_not_frozen(client_with_fake_listings):
+    """An empty /new with zero counts (genuinely empty, or a total-replica-lag
+    transient we cannot tell apart) is cached only briefly so it self-heals in
+    minutes instead of staying frozen for a week."""
+    client = client_with_fake_listings
+    with mock.patch.object(FakeListingFilesService, "list_new_articles",
+                           return_value=_empty_new()):
+        rv = client.get("/list/hep-ph/new")
+    assert rv.status_code == 200
+    sc = rv.headers.get("Surrogate-Control", "")
+    assert "604800" not in sc          # not the week-long freeze
+    assert "max-age=300" in sc         # the short empty-listing TTL (5 min default)
+
+
+def test_new_overskip_empty_is_not_503(client_with_fake_listings):
+    """An empty page reached only by skipping past the end (skip >= count) is a
+    legitimate empty page, not the inconsistency fingerprint: 200 and
+    short-cached, never a 503."""
+    client = client_with_fake_listings
+    with mock.patch.object(FakeListingFilesService, "list_new_articles",
+                           return_value=_empty_new(new_count=3)):
+        rv = client.get("/list/hep-ph/new?skip=100&show=25")
+    assert rv.status_code == 200
+    assert "604800" not in rv.headers.get("Surrogate-Control", "")
+
+
+def test_populated_new_unchanged_and_advertises_stale_if_error(client_with_fake_listings):
+    """A normal, populated /new is untouched by the guard -- not 503'd, not
+    short-cached -- and carries stale-if-error so Fastly serves the last good copy
+    from grace if the origin later 5xxs (e.g. the inconsistency 503)."""
+    rv = client_with_fake_listings.get("/list/hep-ph/new")
+    assert rv.status_code == 200
+    sc = rv.headers.get("Surrogate-Control", "")
+    assert "max-age=0" not in sc        # the 503 path did not fire
+    assert "max-age=300" not in sc      # the short-cache path did not fire
+    assert "stale-if-error=" in sc      # error-grace advertised on the good response
+
+
+def test_current_month_empty_is_short_cached_not_503(client_with_fake_listings):
+    """An empty *current* month is a daily-volatile announce page, so like /new
+    it is short-cached (200), never 503: its count and items come from one query
+    so a contradiction can't arise, and it may legitimately/transiently be empty."""
+    client = client_with_fake_listings
+    empty = Listing(listings=[], pubdates=[], count=0, expires=gen_expires())
+    with mock.patch.object(FakeListingFilesService, "list_articles_by_month",
+                           return_value=empty):
+        rv = client.get("/list/hep-ph/current")
+    assert rv.status_code == 200
+    sc = rv.headers.get("Surrogate-Control", "")
+    assert "max-age=300" in sc         # short empty-listing TTL
+    assert "604800" not in sc          # not the week-long freeze
+
+
+def test_historical_empty_month_keeps_long_cache(client_with_fake_listings):
+    """An empty *historical* month is immutable, not a transient, so it keeps the
+    normal long cache: the short-cache-on-empty guard is scoped to daily-volatile
+    announce pages (new/recent/current month)."""
+    client = client_with_fake_listings
+    empty = Listing(listings=[], pubdates=[], count=0, expires=gen_expires())
+    with mock.patch.object(FakeListingFilesService, "list_articles_by_month",
+                           return_value=empty):
+        rv = client.get("/list/hep-ph/2009-01")
+    assert rv.status_code == 200
+    assert "max-age=604800" in rv.headers.get("Surrogate-Control", "")

--- a/tests/listings/test_list_page.py
+++ b/tests/listings/test_list_page.py
@@ -917,17 +917,18 @@ def _empty_new(new_count=0, cross_count=0, rep_count=0):
 def test_new_inconsistency_returns_503(client_with_fake_listings, caplog, listing_new, why):
     """The counts promise new submissions but none rendered -- whether the page is
     wholly empty, or only replacements remain because the new papers' fresh
-    metadata is still lagging. Either shape is the replica-lag fingerprint: an
-    uncacheable 503 that is logged and stays purgeable, not a wrong page frozen at
-    Fastly for a week. (The reps-present case proves the check keys on the new
-    count, not the replacement-polluted total.)"""
+    metadata is still lagging. Either shape is the replica-lag fingerprint: a
+    short-cached 503 that is logged and stays purgeable, not a wrong page frozen at
+    Fastly for a week. The short edge cache keeps a thundering herd off the DB
+    while the listing is not yet ready. (The reps-present case proves the check
+    keys on the new count, not the replacement-polluted total.)"""
     with mock.patch.object(FakeListingFilesService, "list_new_articles",
                            return_value=listing_new), \
             caplog.at_level(logging.ERROR):
         rv = client_with_fake_listings.get("/list/hep-ph/new")
     assert rv.status_code == 503, why
     sc = rv.headers.get("Surrogate-Control", "")
-    assert "604800" not in sc and "max-age=0" in sc    # uncacheable, not the week freeze
+    assert "604800" not in sc and "max-age=300" in sc  # short-cached, not the week freeze
     assert rv.headers.get("Retry-After")               # tells clients when to retry
     keys = " " + rv.headers.get("Surrogate-Key", "") + " "
     assert " list " in keys and " list-new " in keys   # still purgeable
@@ -944,7 +945,8 @@ def test_recent_inconsistent_counts_returns_503(client_with_fake_listings):
                            return_value=bad):
         rv = client.get("/list/hep-ph/recent")
     assert rv.status_code == 503
-    assert "max-age=0" in rv.headers.get("Surrogate-Control", "")
+    sc = rv.headers.get("Surrogate-Control", "")
+    assert "604800" not in sc and "max-age=300" in sc  # short-cached, not the week freeze
     keys = " " + rv.headers.get("Surrogate-Key", "") + " "
     assert " list-recent " in keys
 
@@ -965,8 +967,7 @@ def test_new_only_replacements_served_normally(client_with_fake_listings):
         rv = client.get("/list/hep-ph/new")
     assert rv.status_code == 200                    # legit page, served normally
     sc = rv.headers.get("Surrogate-Control", "")
-    assert "max-age=0" not in sc                    # not the 503 path
-    assert "max-age=300" not in sc                  # not short-cached; it is a real page
+    assert "max-age=300" not in sc                  # neither short-cache path fired
 
 
 def test_new_genuinely_empty_is_short_cached_not_frozen(client_with_fake_listings):
@@ -1002,8 +1003,7 @@ def test_populated_new_unchanged_and_advertises_stale_if_error(client_with_fake_
     rv = client_with_fake_listings.get("/list/hep-ph/new")
     assert rv.status_code == 200
     sc = rv.headers.get("Surrogate-Control", "")
-    assert "max-age=0" not in sc        # the 503 path did not fire
-    assert "max-age=300" not in sc      # the short-cache path did not fire
+    assert "max-age=300" not in sc      # neither short-cache path fired
     assert "stale-if-error=" in sc      # error-grace advertised on the good response
 
 


### PR DESCRIPTION
### Motivation

On **2026-06-25**, `/list/hep-th/new` (and `/recent`) served an **empty page** in
production for ~10 hours. A read-replica lag spike during the announcement produced a
single empty render, and because browse ships listings with `Surrogate-Control: max-age=604800` (one week),
Fastly **froze** that empty page until a manual purge. The trigger is hard to eliminate; on the other hand, 
the amplifier (long-caching a bad render) is fully in browse's control, and this fixes it.

### Root cause

`/new` and `/recent` derive their **counts** from `arXiv_updates` (+ `arXiv_in_category`)
but render their **items** from a separate query that also requires `Metadata.is_current = 1`.
During lag the counts can be non-zero while the items come back empty.

### PR approach

`get_listing` guards the empty/inconsistent case before caching:

- **Inconsistency → `503`.** When the counts promise items this page should show but none
  rendered, return an uncacheable `503` (`Surrogate-Control: max-age=0`, `Retry-After`)
  instead of caching a wrong page. For `/new` the check is on the **new** count specifically,
  not the replacement-polluted total: a day of "only replacements" is a legitimate page, 
  while "new submissions promised yet absent" (their fresh metadata still lagging while older replacements render) is the failure.
  Surrogate keys are preserved so it stays purgeable.
- **Empty volatile page → short cache.** An empty daily-volatile announce page (new/recent/current month)
   without the contradiction is cached for only  `LISTING_EMPTY_MAX_AGE` (default 5 min) so a transient empty
   self-heals instead of freezing for a week. Immutable historical months keep their long cache.
- **`stale-if-error` on every `/list` response** (`LISTING_STALE_IF_ERROR`, default 1 day).
  This is makes the `503` somewhat safe for UX: on any origin 5xx, Fastly serves the last good listing rather than showing users the error, for a grace period.

### Config

| setting | default | purpose |
|---|---|---|
| `LISTING_EMPTY_MAX_AGE` | 300 s | short TTL for an empty volatile listing |
| `LISTING_STALE_IF_ERROR` | 86400 s | error-grace for serving the last good listing on origin 5xx |
