### PR TITLE
add category agnostic tags to list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,9 @@ venv.bak/
 .mypy_cache/
 mypy_test_errors.txt
 
+# Claude Code
+.claude/
+
 # IDE/editor files
 .idea
 arxiv-browse.iml

--- a/browse/controllers/list_page/__init__.py
+++ b/browse/controllers/list_page/__init__.py
@@ -258,7 +258,7 @@ def get_listing(subject_or_category: str,
             if list_month < 1 or list_month > 12:
                 raise BadRequest(f"Invalid month: {list_month}")
             list_type = 'month'
-            response_headers=b_add_surrogate_key(response_headers,[f"list-{list_year:04d}-{list_month:02d}-{list_ctx_id}"])
+            response_headers=b_add_surrogate_key(response_headers,[f"list-{list_year:04d}-{list_month:02d}-{list_ctx_id}", f"list-{list_year:04d}-{list_month:02d}"])
             if date.today().year==list_year and date.today().month==list_month:
                 response_headers=b_add_surrogate_key(response_headers,["announce"])
             response_data['list_month'] = str(list_month)
@@ -267,7 +267,7 @@ def get_listing(subject_or_category: str,
                 list_ctx_id, list_year, list_month, skipn, shown, if_mod_since)
         else:
             list_type = 'year'
-            response_headers=b_add_surrogate_key(response_headers,[f"list-{list_year:04d}-{list_ctx_id}"])
+            response_headers=b_add_surrogate_key(response_headers,[f"list-{list_year:04d}-{list_ctx_id}", f"list-{list_year:04d}"])
             if list_year==date.today().year: 
                 response_headers=b_add_surrogate_key(response_headers,["announce"])
             resp = listing_service.list_articles_by_year(

--- a/tests/listings/test_list_page.py
+++ b/tests/listings/test_list_page.py
@@ -865,6 +865,7 @@ def test_surrogate_keys(client_with_db_listings):
     assert "list-ym" in head
     assert "announce"  not in head
     assert "list-2005-06-nlin.SI" in head
+    assert "list-2005-06" in head
 
     rv = client.get("/list/astro-ph/2005")
     head=rv.headers["Surrogate-Key"]
@@ -872,6 +873,7 @@ def test_surrogate_keys(client_with_db_listings):
     assert "list-ym" in head
     assert "announce"  not in head
     assert "list-2005-astro-ph" in head
+    assert "list-2005" in head
 
     rv = client.get(f"/list/astro-ph/{date.today().year:04d}")
     head=rv.headers["Surrogate-Key"]

--- a/tests/listings/test_list_page.py
+++ b/tests/listings/test_list_page.py
@@ -865,7 +865,7 @@ def test_surrogate_keys(client_with_db_listings):
     assert "list-ym" in head
     assert "announce"  not in head
     assert "list-2005-06-nlin.SI" in head
-    assert "list-2005-06" in head
+    assert " list-2005-06 " in " "+head+" "
 
     rv = client.get("/list/astro-ph/2005")
     head=rv.headers["Surrogate-Key"]
@@ -873,7 +873,7 @@ def test_surrogate_keys(client_with_db_listings):
     assert "list-ym" in head
     assert "announce"  not in head
     assert "list-2005-astro-ph" in head
-    assert "list-2005" in head
+    assert " list-2005 " in " "+head+" "
 
     rv = client.get(f"/list/astro-ph/{date.today().year:04d}")
     head=rv.headers["Surrogate-Key"]


### PR DESCRIPTION
lets you clear fastly cache of a lists for a specific month or year, rather than just category by category