### PR TITLE
[ARXIVCE-4426] Spinout header/footer feedback (browse)

### DIFF
--- a/browse/static/css/arXiv.css
+++ b/browse/static/css/arXiv.css
@@ -388,6 +388,11 @@ main {
    min-height: 100vh;
    flex-direction: column;
  }
+ /* Spinout footer: span the page width like the abs-page #content (very minimal side
+    margins) instead of the centred 1200px grid. Browse-local override of the shared
+    chrome — the descendant selector beats it regardless of stylesheet order. */
+ .flex-wrap-footer .ds-site-footer { padding-left: 10px; padding-right: 10px; }
+ .flex-wrap-footer .ds-site-footer-grid { max-width: none; }
  footer ul li {
    display: flex;
    align-items: center;

--- a/browse/static/css/arxiv-html-papers-theme-20250131.css
+++ b/browse/static/css/arxiv-html-papers-theme-20250131.css
@@ -235,7 +235,7 @@
   }
 
   .html-header-nav a span:hover {
-    text-shadow: 0 0 0 #000000;
+    text-shadow: 0 0 0 var(--header-hover-color);
     color: transparent;
   }
 

--- a/browse/templates/base.html
+++ b/browse/templates/base.html
@@ -30,16 +30,16 @@
 </head>
 
 <body {% block body_id %}{% endblock %}>
-  {#- Date-windowed promo + announcement banners (incl. the spinout .ds-announcement
-      band) are configured in user_banner.html. -#}
-  {{ user_banner.content(request_datetime) }}
-
   {%- if rd_int >= 202504070100 and rd_int <= 202510282140 -%}
     {% block opt_in_modal %}{% endblock %}
   {%- endif -%}
 
   <div class="flex-wrap-footer">
     <a href="#content" class="ds-skip-link">Skip to main content</a>
+    {#- Promo + announcement banners (configured in user_banner.html). Kept inside
+        .flex-wrap-footer so the sticky-footer 100vh accounts for the banner height,
+        otherwise the footer is pushed ~one banner-height below the viewport. -#}
+    {{ user_banner.content(request_datetime) }}
     {% block header %}{% include "base/header.html" %}{% endblock header %}
 
     <main>

--- a/browse/templates/dissemination/article_scaffold/footer.html
+++ b/browse/templates/dissemination/article_scaffold/footer.html
@@ -49,7 +49,6 @@
     LaTeXML attribution above is retained. -#}
 {% include "base/footer.html" %}
 <div id="fixed-buttons-container">
-  <div id="beta-badge" aria-hidden="true">BETA</div>
   <a id="disable-reading-mode-btn" class="header-button" href="javascript:toggleReadingMode();"
     title="Disable reading mode, show header and footer">
     <svg role="presentation" height="1.25rem"


### PR DESCRIPTION
### Description

Follow-up to #993 . Addresses live-testing feedback on the new spinout header/footer.

### Changes

- **Footer width** for browse: span the page width to match the abstract page margins (full-width, ~10px sides) instead of the centred 1200px grid.
- **Footer position:** move the announcement/promo banners *inside*
  `.flex-wrap-footer` so the sticky-footer `100vh` accounts for the banner height;
   previously the footer was pushed ~one banner-height below the viewport (visible in /abs).
- **HTML papers** — remove the `BETA` corner flag.
- **Accessibility (WAVE)** — fix the HTML reader nav-label hover contrast: 
  the span-wrapped labels (Report Issue / Back to Abstract / Download PDF)
  hovered black (failing contrast on the ink bar); 
  they now use `--header-hover-color` (Open Blue), consistent with "Why HTML?" and the icons.


### Preview

<img width="3847" height="2009" alt="image" src="https://github.com/user-attachments/assets/e24018a5-1c63-4420-a143-dbff8c7db521" />

<img width="3423" height="377" alt="Screenshot from 2026-06-29 14-48-06" src="https://github.com/user-attachments/assets/34412c11-931e-412a-a88a-e1bb7b696442" />
