### PR TITLE
Hide author-contact labels (Affiliation:/Email:) in the arXiv HTML theme

### DIFF
--- a/browse/static/css/arxiv-html-papers-theme-20260807.css
+++ b/browse/static/css/arxiv-html-papers-theme-20260807.css
@@ -637,6 +637,11 @@ Empirically, the xl >1280px breakpoint seems to be the first where a sidebar TOC
     margin: 1rem;
   }
 
+  /* Hide the author-contact labels ("Affiliation:", "Email:"). */
+  .ltx_contact_name {
+    display: none;
+  }
+
   /* Restore a visible text selection. ar5iv 0.9.0 newly tints ::selection with
      var(--note-highlight-color) (a11y.css), which the arXiv theme sets near-white
      (#f9f7f7) for its subtle target/bib highlights -- so selected text becomes

--- a/uv.lock
+++ b/uv.lock
@@ -86,7 +86,7 @@ wheels = [
 [[package]]
 name = "arxiv-base"
 version = "1.0.1"
-source = { git = "https://github.com/arXiv/arxiv-base.git?branch=master#dd15adcdeff6cd06c3ee2555ddf6381582c8966e" }
+source = { git = "https://github.com/arXiv/arxiv-base.git?branch=master#2d29bd72e496ebe2c18ee9879ebeda43c3abd875" }
 dependencies = [
     { name = "bleach" },
     { name = "fastly" },


### PR DESCRIPTION
## What

Hides the `.ltx_contact_name` labels — "Affiliation:" and "Email:" — that render before each author affiliation / email in the HTML paper header.

## Why

The latexml-oxide worker runs with `--nodefaultresources`, so LaTeXML's default `LaTeXML.css` (which italicised `.ltx_contact_name`, and only hid it under the `.ltx_authors_multiline` layout) is no longer emitted. ar5iv 0.9.0 doesn't re-declare the class, so the raw labels leak through on every affiliation/email line — e.g. 5× "Affiliation:" + 1× "Email:" on arXiv:2607.16395v1.

## Change

One rule in the theme's `ar5iv-patches` layer:

```css
.ltx_contact_name { display: none; }
```

This hides both the "Affiliation:" and "Email:" labels (the institution text and the mailto link stand on their own). To keep the "Email:" label, scope it to `.ltx_role_affiliation .ltx_contact_name` instead.

Witness: https://dev.arxiv.org/html/2607.16395v1

Keeping this open for testing over the coming week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
