### PR TITLE
Fix typos in comments and docstrings

### DIFF
--- a/browse/controllers/files/__init__.py
+++ b/browse/controllers/files/__init__.py
@@ -31,7 +31,7 @@ def add_time_headers(resp: Response, file: FileObj, arxiv_id: Identifier) -> Non
 
 
 def last_modified(fileobj: FileObj) -> str:
-    """Returns a value for use with HTTP last-Modified."""
+    """Returns a value for use with HTTP Last-Modified."""
     return format_datetime(fileobj.updated.astimezone(timezone.utc),
                            usegmt=True)
 

--- a/browse/services/dissemination/source_store.py
+++ b/browse/services/dissemination/source_store.py
@@ -17,8 +17,8 @@ logger = logging.getLogger(__file__)
 src_regex = re.compile(r'.*(\.tar\.gz|\.pdf|\.ps\.gz|\.gz|\.div\.gz|\.html\.gz)')
 
 MAX_ITEMS_IN_PATTERN_MATCH = 1000
-"""This uses pattern matching on all the keys in an itmes directory. If
-the number if items is very large the was probably a problem"""
+"""This uses pattern matching on all the keys in an items directory. If
+the number of items is very large there was probably a problem"""
 
 # TODO move this src_path_prefix() to arxiv-base+
 def src_path_prefix(arxiv_id: Identifier, is_current:bool) -> str:
@@ -90,7 +90,7 @@ class SourceStore():
         if is_current:
             # try from the /ftp with no number for current ver of pdf only paper
             # TODO: this should use current_ps_path() from arxiv-base but we
-            # need this fixed and updgrading arxiv-base is going to be a bit of work
+            # need this fixed and upgrading arxiv-base is going to be a bit of work
             archive = arxiv_id.archive if arxiv_id.is_old_id else 'arxiv'
             path = f"ftp/{archive}/papers/{arxiv_id.yymm}/{arxiv_id.filename}.ps.gz"
             ps_file = self.objstore.to_obj(path)
@@ -99,7 +99,7 @@ class SourceStore():
         else:
             # try from the /orig with version number for a pdf only paper
             # TODO: this should use previous_ps_path() from arxiv-base but we
-            # need this fixed and updgrading arxiv-base is going to be a bit of work
+            # need this fixed and upgrading arxiv-base is going to be a bit of work
             archive = arxiv_id.archive if arxiv_id.is_old_id else 'arxiv'
             path = f"orig/{archive}/papers/{arxiv_id.yymm}/{arxiv_id.filename}v{arxiv_id.version}.ps.gz"
             ps_file = self.objstore.to_obj(path)

--- a/browse/services/listing/parse_new_listing_file.py
+++ b/browse/services/listing/parse_new_listing_file.py
@@ -119,7 +119,7 @@ def parse_new_listing_file(listingFilePath: FileObj, listingFilter: str='')\
         if line.startswith('--------'):
             rules_to_pop = rules_to_pop - 1
 
-    # Lines how has the new listings, then a rule, the cross listings, then a
+    # Lines now has the new listings, then a rule, the cross listings, then a
     # rule, the rep listings then a rule and then some unused tail matter.  line
     # should be at // that is part of the first listing item Now cycle through
     # and process update entries in file.
@@ -196,5 +196,5 @@ def _to_item(data: str, ltype: Literal['new', 'cross', 'rep']) -> ListingItem:
 _stripex_re = re.compile(r"\\\\ \( https.*kb.*\)")
 
 def _strip_extra(data: str) -> str:
-    """Srips the extra "(https://arxiv.org/abs/1234.12345,  234332kb)" """
+    """Strips the extra "(https://arxiv.org/abs/1234.12345,  234332kb)" """
     return _stripex_re.sub('', data)


### PR DESCRIPTION
## Summary

Fix 6 typos in comments and docstrings across 3 files:

- **browse/services/listing/parse_new_listing_file.py**: `"""Srips the extra ..."""` -> `"""Strips the extra ..."""`
- **browse/services/listing/parse_new_listing_file.py**: `# Lines how has the new listings` -> `# Lines now has the new listings`
- **browse/services/dissemination/source_store.py**: `keys in an itmes directory` -> `keys in an items directory`
- **browse/services/dissemination/source_store.py**: `the number if items is very large the was probably a problem` -> `the number of items is very large there was probably a problem`
- **browse/services/dissemination/source_store.py**: `updgrading arxiv-base` -> `upgrading arxiv-base` (2 identical occurrences, lines 93 and 102 - fixing only one would have looked arbitrary)
- **browse/controllers/files/__init__.py**: `"""Returns a value for use with HTTP last-Modified."""` -> `HTTP Last-Modified` (matching the header name the function actually sets three lines above, `resp.headers["Last-Modified"]`)

Comments and docstrings only. No functional changes, no identifiers renamed, no behaviour affected. Branched from `develop`, and targets `develop` per the org CONTRIBUTING guide.

## Things deliberately left alone

While checking these I found three nearby items that look like typos but should **not** be changed, in case a linter or another contributor flags them later:

- `browse/formatting/cite.py`: the `STOPWORDS` frozenset contains `"amoungst"` and `"thickv"`. These are the well-known historical corruptions in the Glasgow / scikit-learn English stop-word list (the same list also has `hasnt`, `couldnt`, `cant`, `fify`), and `"amongst"` is already present on the line immediately above `"amoungst"`. `STOPWORDS` feeds the BibTeX citation-key generation at line 63, so editing entries would be a behaviour change, not a typo fix.
- `browse/services/listing/parse_listing_pastweek.py` line 135: `"(*corss-listing*)"` is a string literal matched against real legacy listing-file content, and the inline comment already notes it (`this seems like an old type..? - Erin 2024`). Correcting the spelling would stop cross-listings being detected.
- `browse/controllers/files/__init__.py` line 51: the `add_mimetype` docstring starts lowercase (`"""adds the ..."""`) where the neighbouring `add_time_headers` docstring starts capitalised. Left as a style matter for you to decide.

## Note on process

The org CONTRIBUTING guide asks that work be tracked by an issue. I did not open one for a typo-only change to avoid noise, but I am happy to file one and link it here if you would prefer - just say the word.

---

Your CONTRIBUTING asks for an open issue documenting the change before a PR is merged. I did not open one first, since this is a documentation-only change — happy to file a tracking issue if you would prefer one. Same approach as arxiv-base#464 and arxiv-auth#124.